### PR TITLE
CRITICAL fix: one-way orphan deletion safety guards (#21)

### DIFF
--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -44,6 +44,75 @@ func getSyncDirectionForCalendar(source *db.Source, calendarPath string) db.Sync
 	return source.SyncDirection
 }
 
+// defaultOrphanDeleteRatioThreshold is the maximum fraction of previously-synced
+// events that can be deleted in a single one-way sync cycle before safety aborts.
+// Exceeding this threshold usually indicates an auth failure, broken source URL,
+// or filter misconfiguration rather than a legitimate bulk cleanup.
+const defaultOrphanDeleteRatioThreshold = 0.5
+
+// planOrphanDeletion determines which destination events should be deleted as
+// "orphans" during a one-way + source_wins sync.
+//
+// Three safety rules are enforced to prevent data loss:
+//
+//  1. Ownership: only events that this source previously synced are candidates
+//     for deletion. This prevents a multi-source setup (multiple source
+//     calendars writing to a single destination) from having sources wipe each
+//     other's events on every sync. It also preserves events created manually
+//     on the destination.
+//
+//  2. Empty-source guard: if the source returned zero events but we have prior
+//     sync records, the sync is assumed to be unhealthy (auth failure, broken
+//     URL, filter wipeout) and the entire orphan-delete pass is skipped.
+//     This mirrors the two-way guard introduced in commit b772c56.
+//
+//  3. Mass-delete threshold: if the planned deletion would remove more than
+//     maxDeleteRatio of previously-synced events in a single cycle, the entire
+//     orphan-delete pass is aborted. Normal day-to-day operation deletes a
+//     handful of events per sync; wiping more than half is almost always a bug.
+//
+// Returns the events to delete and a non-empty warning string if any safety
+// rule was triggered. When a warning is returned, toDelete is nil — the caller
+// must not perform any deletions in that case.
+func planOrphanDeletion(
+	destEventMap map[string]Event,
+	sourceEventCount int,
+	previouslySyncedMap map[string]*db.SyncedEvent,
+	maxDeleteRatio float64,
+) (toDelete []Event, warning string) {
+	// Rule 2: empty source with prior records → refuse to delete anything.
+	if sourceEventCount == 0 && len(previouslySyncedMap) > 0 {
+		return nil, fmt.Sprintf(
+			"source returned 0 events but %d previously-synced records exist - "+
+				"skipping one-way orphan deletion for safety (possible auth failure or broken source)",
+			len(previouslySyncedMap),
+		)
+	}
+
+	// Rule 1: ownership filter. Only consider events THIS source synced.
+	candidates := make([]Event, 0)
+	for uid, event := range destEventMap {
+		if _, ours := previouslySyncedMap[uid]; ours {
+			candidates = append(candidates, event)
+		}
+	}
+
+	// Rule 3: mass-delete threshold. Only applied when there is prior state
+	// to measure against and a threshold is configured.
+	if len(previouslySyncedMap) > 0 && maxDeleteRatio > 0 {
+		ratio := float64(len(candidates)) / float64(len(previouslySyncedMap))
+		if ratio > maxDeleteRatio {
+			return nil, fmt.Sprintf(
+				"one-way orphan deletion would remove %d of %d previously-synced events (%.0f%%), "+
+					"exceeds safety threshold %.0f%% - skipping deletion",
+				len(candidates), len(previouslySyncedMap), ratio*100, maxDeleteRatio*100,
+			)
+		}
+	}
+
+	return candidates, ""
+}
+
 // SyncResult represents the result of a sync operation.
 type SyncResult struct {
 	Success           bool          `json:"success"`
@@ -719,9 +788,24 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 		}
 	}
 
-	// One-way sync: delete orphan events on destination
+	// One-way sync: delete orphan events on destination (with safety checks).
+	// See planOrphanDeletion for the full rationale. The bug this fixes:
+	// without these guards, a one-way source_wins sync would delete EVERY
+	// destination event whenever the source returned 0 events (auth failure,
+	// broken URL, filter wipeout) or whenever multiple sources shared a
+	// destination (each source would delete the others' events on every cycle).
 	if syncDirection == db.SyncDirectionOneWay && source.ConflictStrategy == db.ConflictSourceWins {
-		for _, event := range destEventMap {
+		toDelete, warning := planOrphanDeletion(
+			destEventMap,
+			len(sourceEvents),
+			previouslySyncedMap,
+			defaultOrphanDeleteRatioThreshold,
+		)
+		if warning != "" {
+			log.Printf("WARNING: %s", warning)
+			result.Warnings = append(result.Warnings, warning)
+		}
+		for _, event := range toDelete {
 			if err := destClient.DeleteEvent(ctx, event.Path); err != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to delete orphan event: %v", err))
 			} else {

--- a/internal/caldav/sync_test.go
+++ b/internal/caldav/sync_test.go
@@ -1,0 +1,262 @@
+package caldav
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/macjediwizard/calbridgesync/internal/db"
+)
+
+// TestPlanOrphanDeletion_EmptySourceWithPriorRecords verifies that a source
+// returning zero events combined with a populated previouslySyncedMap
+// produces zero deletions and a warning. This is the primary data-loss
+// scenario: an auth failure or broken source URL must not wipe the
+// destination.
+func TestPlanOrphanDeletion_EmptySourceWithPriorRecords(t *testing.T) {
+	destEventMap := map[string]Event{
+		"uid-1": {UID: "uid-1", Path: "/cal/uid-1.ics"},
+		"uid-2": {UID: "uid-2", Path: "/cal/uid-2.ics"},
+		"uid-3": {UID: "uid-3", Path: "/cal/uid-3.ics"},
+	}
+	previouslySyncedMap := map[string]*db.SyncedEvent{
+		"uid-1": {EventUID: "uid-1"},
+		"uid-2": {EventUID: "uid-2"},
+		"uid-3": {EventUID: "uid-3"},
+	}
+
+	toDelete, warning := planOrphanDeletion(destEventMap, 0, previouslySyncedMap, 0.5)
+
+	if len(toDelete) != 0 {
+		t.Fatalf("expected zero deletions when source is empty but previouslySyncedMap is populated; got %d", len(toDelete))
+	}
+	if warning == "" {
+		t.Fatal("expected a safety warning when source returned 0 events but previouslySyncedMap is populated")
+	}
+	if !strings.Contains(warning, "0 events") {
+		t.Errorf("warning should mention the zero-events condition; got: %q", warning)
+	}
+}
+
+// TestPlanOrphanDeletion_EmptySourceNoPriorRecords verifies that the
+// empty-source guard does NOT block a legitimate first sync of a
+// new, empty source. Before any sync has happened, previouslySyncedMap
+// is empty and there is nothing to protect.
+func TestPlanOrphanDeletion_EmptySourceNoPriorRecords(t *testing.T) {
+	destEventMap := map[string]Event{}
+	previouslySyncedMap := map[string]*db.SyncedEvent{}
+
+	toDelete, warning := planOrphanDeletion(destEventMap, 0, previouslySyncedMap, 0.5)
+
+	if len(toDelete) != 0 {
+		t.Fatalf("expected zero deletions from an empty destination; got %d", len(toDelete))
+	}
+	if warning != "" {
+		t.Errorf("expected no warning on first-sync empty case; got: %q", warning)
+	}
+}
+
+// TestPlanOrphanDeletion_OwnershipFilter verifies the multi-source →
+// one-destination protection. destEventMap contains events from multiple
+// sources, but only events in previouslySyncedMap (owned by THIS source)
+// are eligible for deletion. This is the second data-loss scenario: the
+// user has Work, Home, and Family source calendars all syncing to a single
+// SOGo destination. Without this filter, each source wipes the others'
+// events on every sync cycle.
+func TestPlanOrphanDeletion_OwnershipFilter(t *testing.T) {
+	destEventMap := map[string]Event{
+		// Owned by this source (in previouslySyncedMap)
+		"our-uid-1": {UID: "our-uid-1", Path: "/cal/our-uid-1.ics"},
+		"our-uid-2": {UID: "our-uid-2", Path: "/cal/our-uid-2.ics"},
+		// Owned by a different source (NOT in previouslySyncedMap)
+		"other-uid-1": {UID: "other-uid-1", Path: "/cal/other-uid-1.ics"},
+		"other-uid-2": {UID: "other-uid-2", Path: "/cal/other-uid-2.ics"},
+		"other-uid-3": {UID: "other-uid-3", Path: "/cal/other-uid-3.ics"},
+	}
+	previouslySyncedMap := map[string]*db.SyncedEvent{
+		"our-uid-1": {EventUID: "our-uid-1"},
+		"our-uid-2": {EventUID: "our-uid-2"},
+	}
+	// Source is present but returned zero events — i.e., both our-uid-1 and
+	// our-uid-2 were intentionally deleted from source. Pass a non-zero
+	// sourceEventCount so the empty-source guard does not trigger; we want
+	// to isolate the ownership-filter behavior in this test.
+	// (sourceEventCount=1 simulates a source that still has unrelated events.)
+	toDelete, warning := planOrphanDeletion(destEventMap, 1, previouslySyncedMap, 0.0)
+
+	if warning != "" {
+		t.Fatalf("expected no warning; got: %q", warning)
+	}
+	if len(toDelete) != 2 {
+		t.Fatalf("expected to delete 2 events owned by this source; got %d", len(toDelete))
+	}
+
+	// Verify only our-owned UIDs are in toDelete.
+	gotUIDs := make(map[string]bool)
+	for _, e := range toDelete {
+		gotUIDs[e.UID] = true
+	}
+	for uid := range previouslySyncedMap {
+		if !gotUIDs[uid] {
+			t.Errorf("expected toDelete to include %q (owned by this source)", uid)
+		}
+	}
+	for uid := range destEventMap {
+		if _, owned := previouslySyncedMap[uid]; !owned && gotUIDs[uid] {
+			t.Errorf("toDelete must NOT include %q (owned by a different source)", uid)
+		}
+	}
+}
+
+// TestPlanOrphanDeletion_MassDeleteThresholdExceeded verifies the
+// defense-in-depth against a scenario where, despite the ownership filter,
+// a source would legitimately delete more than half of its own previously
+// synced events in a single cycle. This is almost always the result of a
+// partial auth failure or source-side corruption rather than an intentional
+// bulk cleanup by the user.
+func TestPlanOrphanDeletion_MassDeleteThresholdExceeded(t *testing.T) {
+	previouslySyncedMap := make(map[string]*db.SyncedEvent)
+	destEventMap := make(map[string]Event)
+	// Ten previously-synced events, eight still on destination (would be deleted).
+	for i := 0; i < 10; i++ {
+		uid := "uid-" + string(rune('a'+i))
+		previouslySyncedMap[uid] = &db.SyncedEvent{EventUID: uid}
+	}
+	for i := 0; i < 8; i++ {
+		uid := "uid-" + string(rune('a'+i))
+		destEventMap[uid] = Event{UID: uid, Path: "/cal/" + uid + ".ics"}
+	}
+
+	// Source claims it has only 2 events (the remaining uid-i and uid-j).
+	// Ratio of would-be-deletes to previouslySyncedMap = 8/10 = 80%,
+	// exceeds the 50% threshold.
+	toDelete, warning := planOrphanDeletion(destEventMap, 2, previouslySyncedMap, 0.5)
+
+	if len(toDelete) != 0 {
+		t.Fatalf("expected zero deletions when threshold exceeded; got %d", len(toDelete))
+	}
+	if warning == "" {
+		t.Fatal("expected a safety warning when mass-delete threshold exceeded")
+	}
+	if !strings.Contains(warning, "80%") {
+		t.Errorf("warning should report the actual ratio; got: %q", warning)
+	}
+	if !strings.Contains(warning, "50%") {
+		t.Errorf("warning should report the configured threshold; got: %q", warning)
+	}
+}
+
+// TestPlanOrphanDeletion_NormalOperation verifies that a routine,
+// small-delta sync still works correctly. A user deletes a handful of
+// events from source; the same events are removed from destination.
+// Nothing else is touched.
+func TestPlanOrphanDeletion_NormalOperation(t *testing.T) {
+	previouslySyncedMap := make(map[string]*db.SyncedEvent)
+	destEventMap := make(map[string]Event)
+	// 20 previously-synced events.
+	for i := 0; i < 20; i++ {
+		uid := "uid-" + string(rune('a'+i))
+		previouslySyncedMap[uid] = &db.SyncedEvent{EventUID: uid}
+	}
+	// 2 of them (uid-a, uid-b) remain on destination but are absent from
+	// source — i.e., user intentionally deleted them. The other 18 are
+	// still present on both source and destination, so the sync loop at
+	// sync.go:625 would have already removed them from destEventMap
+	// before planOrphanDeletion was called.
+	destEventMap["uid-a"] = Event{UID: "uid-a", Path: "/cal/uid-a.ics"}
+	destEventMap["uid-b"] = Event{UID: "uid-b", Path: "/cal/uid-b.ics"}
+
+	// Source returned 18 events, so the empty-source guard does not trigger.
+	toDelete, warning := planOrphanDeletion(destEventMap, 18, previouslySyncedMap, 0.5)
+
+	if warning != "" {
+		t.Errorf("expected no warning on normal 2-of-20 delete; got: %q", warning)
+	}
+	if len(toDelete) != 2 {
+		t.Fatalf("expected 2 events to be deleted; got %d", len(toDelete))
+	}
+
+	gotUIDs := make(map[string]bool)
+	for _, e := range toDelete {
+		gotUIDs[e.UID] = true
+	}
+	if !gotUIDs["uid-a"] || !gotUIDs["uid-b"] {
+		t.Errorf("expected toDelete to contain uid-a and uid-b; got %+v", gotUIDs)
+	}
+}
+
+// TestPlanOrphanDeletion_ThresholdBoundary verifies that the ratio check
+// uses strict greater-than, so a ratio exactly at the threshold is allowed
+// through. This prevents a single-event-off edge case where legitimate
+// operations at the boundary get blocked unnecessarily.
+func TestPlanOrphanDeletion_ThresholdBoundary(t *testing.T) {
+	previouslySyncedMap := make(map[string]*db.SyncedEvent)
+	destEventMap := make(map[string]Event)
+	for i := 0; i < 10; i++ {
+		uid := "uid-" + string(rune('a'+i))
+		previouslySyncedMap[uid] = &db.SyncedEvent{EventUID: uid}
+	}
+	// Exactly 5 of 10 remain on destination (50%).
+	for i := 0; i < 5; i++ {
+		uid := "uid-" + string(rune('a'+i))
+		destEventMap[uid] = Event{UID: uid, Path: "/cal/" + uid + ".ics"}
+	}
+
+	// 50% ratio == threshold. Should NOT trigger the safety check.
+	toDelete, warning := planOrphanDeletion(destEventMap, 5, previouslySyncedMap, 0.5)
+
+	if warning != "" {
+		t.Errorf("ratio at the threshold should not trigger safety; got warning: %q", warning)
+	}
+	if len(toDelete) != 5 {
+		t.Errorf("expected 5 events at the 50%% boundary; got %d", len(toDelete))
+	}
+}
+
+// TestPlanOrphanDeletion_ManualDestEventsPreserved verifies that events
+// the user created manually on the destination (events which are therefore
+// NOT in previouslySyncedMap) are never touched by one-way orphan deletion.
+// This is a pleasant side-effect of the ownership filter: users who add
+// events directly to their destination calendar won't see them disappear
+// on the next sync.
+func TestPlanOrphanDeletion_ManualDestEventsPreserved(t *testing.T) {
+	// Populate previouslySyncedMap with 10 synced events so the mass-delete
+	// ratio guard does not trigger — we only want to isolate the
+	// ownership-filter assertion in this test.
+	previouslySyncedMap := make(map[string]*db.SyncedEvent)
+	for i := 0; i < 10; i++ {
+		uid := "synced-uid-" + string(rune('a'+i))
+		previouslySyncedMap[uid] = &db.SyncedEvent{EventUID: uid}
+	}
+
+	// destEventMap contains exactly one previously-synced event that is
+	// absent from source (legitimate orphan), plus two events the user
+	// created manually on the destination (never tracked by this source).
+	destEventMap := map[string]Event{
+		"synced-uid-a": {UID: "synced-uid-a", Path: "/cal/synced-uid-a.ics"},
+		"manual-uid-1": {UID: "manual-uid-1", Path: "/cal/manual-uid-1.ics"},
+		"manual-uid-2": {UID: "manual-uid-2", Path: "/cal/manual-uid-2.ics"},
+	}
+
+	// Source returned 9 events (all the other synced-uid-b..j still exist
+	// on source, only synced-uid-a was intentionally deleted by the user).
+	// Ratio of candidates to previouslySyncedMap = 1/10 = 10%, well below
+	// the 50% safety threshold.
+	toDelete, warning := planOrphanDeletion(destEventMap, 9, previouslySyncedMap, 0.5)
+
+	if warning != "" {
+		t.Fatalf("expected no warning on routine 1-of-10 delete; got: %q", warning)
+	}
+	if len(toDelete) != 1 {
+		t.Fatalf("expected exactly 1 event to be deleted (synced-uid-a); got %d", len(toDelete))
+	}
+	if toDelete[0].UID != "synced-uid-a" {
+		t.Errorf("expected toDelete[0].UID = synced-uid-a; got %q", toDelete[0].UID)
+	}
+
+	// Double-check no manual events sneaked in.
+	for _, e := range toDelete {
+		if e.UID == "manual-uid-1" || e.UID == "manual-uid-2" {
+			t.Errorf("manual destination event %q must not be deleted by one-way sync", e.UID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes active data-loss bug in `sync.go:722-732`. See issue #21 for the full root-cause analysis. Short version: the one-way + source_wins orphan-deletion loop had **zero safety checks** and was wiping production calendars in two distinct failure modes.

## Failure modes fixed

1. **Empty-source wipeout** — source returns 0 events (auth expired, broken URL, sync_days_past filter wipeout), every destination event gets deleted in one cycle.
2. **Multi-source → one-destination collision** — multiple source calendars writing to the same destination (Work + Home + Family → one SOGo calendar) have each sync cycle delete the other sources' events.

The analogous bugs in the two-way path were fixed in `0abe8c4` (cross-calendar) and `b772c56` (dest-empty guard) but both scoped themselves to two-way only. One-way is the default for ICS feeds, which have the highest auth-failure rate, so the gap bit production the hardest.

## The fix

Extracted `planOrphanDeletion()` as a pure function with three layered safety rules:

1. **Ownership filter** — only delete events this source previously synced (uses existing `previouslySyncedMap`). Eliminates multi-source collision; bonus: preserves user-created destination events.
2. **Empty-source guard** — if `sourceEventCount == 0 && len(previouslySyncedMap) > 0`, skip all deletions + warn. Parity with two-way guard at `:560-566`.
3. **Mass-delete threshold** — abort + warn if planned deletion would remove > 50% of `previouslySyncedMap` in one cycle. Catches partial auth failures.

## Tests

New file `internal/caldav/sync_test.go` with 7 pure-function tests:
- `TestPlanOrphanDeletion_EmptySourceWithPriorRecords` — empty source + prior records → zero deletes + warning
- `TestPlanOrphanDeletion_EmptySourceNoPriorRecords` — legitimate first-sync of empty source is not blocked
- `TestPlanOrphanDeletion_OwnershipFilter` — multi-source: only our-owned events deletable
- `TestPlanOrphanDeletion_MassDeleteThresholdExceeded` — 80% delete ratio blocked + warning
- `TestPlanOrphanDeletion_NormalOperation` — routine 2-of-20 delete still works
- `TestPlanOrphanDeletion_ThresholdBoundary` — exactly-50% ratio allowed (strict gt)
- `TestPlanOrphanDeletion_ManualDestEventsPreserved` — user-created dest events never touched

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/caldav/...` — all 7 new tests pass
- [x] `go test ./...` — full suite green, zero regressions
- [ ] Manual smoke test: trigger one sync against a known-good source, verify normal deletes still work
- [ ] Manual smoke test: simulate broken source (bad ICS URL), verify safety guard fires + logs warning
- [ ] Monitor `result.Warnings` in sync logs after deploy

## Behavior change (note for the 3 production users)

A new source pointing at a destination that already contains unrelated events will no longer wipe those events on first sync. Users who want a clean destination should empty it manually. This is strictly safer than the previous behavior and should not affect routine operation — normal day-to-day syncs delete a handful of events per cycle, well below the 50% threshold.

## Rollback

Single-file change to `sync.go` + one new test file. `git revert` removes the fix cleanly. No schema change, no config change. Safe to roll back the binary without data migration.

## Protected regions (not touched)

Verified the fix does not modify or interfere with any of the following intentional regions documented in `tasks/lessons.md`:
- Recurring-events dedup (`normalizeStartTime`, `DedupeKey`, `cleanupDuplicates`)
- Cross-calendar two-way fix at `:681-695` (commit 0abe8c4)
- Two-way destination-empty safety at `:560-566` (commit b772c56)
- Two-way source-delete safety threshold at `:556-558, :592-597` (commit 23e88c1)
- 403/412 graceful handling
- ETag comparison logic at `:657`

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)