### PR TITLE
feat: Wire sync failures and data-loss warnings into alert pipeline (#23)

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -48,14 +48,14 @@ type Config struct {
 	WebhookURL     string
 
 	// Email settings
-	EmailEnabled   bool
-	SMTPHost       string
-	SMTPPort       int
-	SMTPUsername   string
-	SMTPPassword   string
-	SMTPFrom       string
-	SMTPTo         []string // Recipients
-	SMTPTLS        bool
+	EmailEnabled bool
+	SMTPHost     string
+	SMTPPort     int
+	SMTPUsername string
+	SMTPPassword string
+	SMTPFrom     string
+	SMTPTo       []string // Recipients
+	SMTPTLS      bool
 
 	// Alert settings
 	CooldownPeriod time.Duration // How long to wait before re-alerting for same source
@@ -79,6 +79,11 @@ type Notifier struct {
 	mu             sync.RWMutex
 	lastAlertTimes map[string]time.Time
 	staleState     map[string]bool // Track if source is currently in stale state
+
+	// Failure alert cooldown is tracked separately from stale alerts so a
+	// source that is both stale and failing doesn't lose one signal because
+	// the other already consumed the cooldown window.
+	lastFailureAlertTimes map[string]time.Time
 }
 
 // New creates a new Notifier.
@@ -88,8 +93,9 @@ func New(cfg *Config) *Notifier {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		lastAlertTimes: make(map[string]time.Time),
-		staleState:     make(map[string]bool),
+		lastAlertTimes:        make(map[string]time.Time),
+		staleState:            make(map[string]bool),
+		lastFailureAlertTimes: make(map[string]time.Time),
 	}
 }
 
@@ -547,6 +553,81 @@ func (n *Notifier) getCooldownPeriod(userPrefs *UserPreferences) time.Duration {
 		return time.Duration(*userPrefs.CooldownMinutes) * time.Minute
 	}
 	return n.cfg.CooldownPeriod
+}
+
+// SendSyncFailureAlertWithPrefs sends an alert when a sync fails or when a
+// data-loss protection guard is triggered, using per-user preferences.
+// userPrefs can be nil to use global defaults only.
+//
+// This method has its own cooldown window independent from stale alerts:
+// a source that is both stale AND failing will not lose one signal because
+// the other already consumed the cooldown.
+//
+// errorMessage is a short human-readable summary shown in the alert subject.
+// details is the full error/warning text shown in the alert body.
+//
+// Returns true if the alert was queued for send, false if still in cooldown.
+func (n *Notifier) SendSyncFailureAlertWithPrefs(
+	ctx context.Context,
+	sourceID, sourceName, userEmail, errorMessage, details string,
+	userPrefs *UserPreferences,
+) bool {
+	cooldown := n.getCooldownPeriod(userPrefs)
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	// Cooldown check — failure alerts use their own map, independent of
+	// the stale-alert cooldown.
+	if lastAlert, exists := n.lastFailureAlertTimes[sourceID]; exists {
+		if time.Since(lastAlert) < cooldown {
+			return false
+		}
+	}
+	n.lastFailureAlertTimes[sourceID] = time.Now()
+
+	alert := Alert{
+		Type:       AlertTypeError,
+		SourceID:   sourceID,
+		SourceName: sourceName,
+		UserEmail:  userEmail,
+		Message:    errorMessage,
+		Details:    details,
+		Timestamp:  time.Now(),
+	}
+
+	// Send in background to not block the scheduler.
+	go n.sendWithPrefs(ctx, alert, userPrefs)
+	return true
+}
+
+// ClearFailureAlertState clears the failure-alert cooldown for a source
+// (used on source deletion). Safe to call for sources that have never
+// triggered a failure alert.
+func (n *Notifier) ClearFailureAlertState(sourceID string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	delete(n.lastFailureAlertTimes, sourceID)
+}
+
+// IsDangerousWarning returns true if a sync warning indicates a data-loss
+// protection guard was triggered and the user should be alerted, even if
+// the overall sync result reports success.
+//
+// These patterns are produced by planOrphanDeletion in internal/caldav/sync.go
+// (added in PR #22, issue #21). They represent cases where the sync engine
+// refused to delete destination events because the inputs looked unsafe
+// (source returned zero events, or the planned deletion ratio exceeded the
+// configured safety threshold).
+//
+// Harmless warnings (individual event put/delete failures, 403/412 skip
+// counts, etc.) do NOT match and do not trigger alerts.
+func IsDangerousWarning(w string) bool {
+	if w == "" {
+		return false
+	}
+	return strings.Contains(w, "previously-synced records exist") ||
+		strings.Contains(w, "exceeds safety threshold")
 }
 
 // sendWithPrefs sends the alert via configured channels, respecting per-user preferences.

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -341,6 +341,198 @@ func TestClearStaleState(t *testing.T) {
 	}
 }
 
+// TestSendSyncFailureAlertCooldown verifies that a second failure alert for
+// the same source inside the cooldown window is rejected, preventing alert
+// storms on a persistently broken source.
+func TestSendSyncFailureAlertCooldown(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "connection refused", nil,
+	)
+	if !sent {
+		t.Error("first failure alert should be sent")
+	}
+
+	// Second alert within cooldown should be suppressed.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "connection refused", nil,
+	)
+	if sent {
+		t.Error("second failure alert within cooldown should be suppressed")
+	}
+
+	// Different source should still work.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source2", "Test Source 2", "user@example.com",
+		"Sync failed", "auth expired", nil,
+	)
+	if !sent {
+		t.Error("failure alert for a different source should be sent")
+	}
+}
+
+// TestSendSyncFailureAlertIndependentFromStale verifies that the failure
+// cooldown and the stale cooldown are tracked separately. A source that is
+// both stale AND failing should be able to fire BOTH alert types without
+// one consuming the other's cooldown.
+func TestSendSyncFailureAlertIndependentFromStale(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Fire a stale alert first.
+	sent := n.SendStaleAlert(nil, "source1", "Test Source", "user@example.com", 2*time.Hour, time.Hour)
+	if !sent {
+		t.Fatal("stale alert should fire")
+	}
+
+	// A failure alert for the same source should NOT be blocked by the
+	// stale cooldown — they use independent maps.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "some error", nil,
+	)
+	if !sent {
+		t.Error("failure alert should not be blocked by stale cooldown")
+	}
+}
+
+// TestClearFailureAlertState verifies that clearing the failure-alert state
+// lets the next failure fire immediately instead of waiting for cooldown.
+func TestClearFailureAlertState(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "connection refused", nil,
+	)
+	if !sent {
+		t.Fatal("first failure alert should fire")
+	}
+
+	// Before clear, second alert is blocked.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "connection refused", nil,
+	)
+	if sent {
+		t.Fatal("second failure alert should be blocked before clear")
+	}
+
+	n.ClearFailureAlertState("source1")
+
+	// After clear, next alert fires.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "connection refused", nil,
+	)
+	if !sent {
+		t.Error("failure alert should fire after ClearFailureAlertState")
+	}
+
+	// ClearFailureAlertState must be safe for unknown source IDs.
+	n.ClearFailureAlertState("never-alerted-source")
+}
+
+// TestSendSyncFailureAlertUserCooldownOverride verifies that user preferences
+// can shorten or lengthen the failure cooldown independently of the global
+// cooldown setting.
+func TestSendSyncFailureAlertUserCooldownOverride(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Zero-minute cooldown via user pref — second alert should fire immediately.
+	zero := 0
+	prefs := &UserPreferences{CooldownMinutes: &zero}
+
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "first", prefs,
+	)
+	if !sent {
+		t.Fatal("first failure alert should fire")
+	}
+
+	// With zero cooldown the second alert fires immediately.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "second", prefs,
+	)
+	if !sent {
+		t.Error("second alert should fire with zero-minute user cooldown")
+	}
+}
+
+// TestIsDangerousWarning verifies the pattern match for data-loss protection
+// warnings. The scheduler uses this to decide whether a "successful" sync
+// with warnings should still fire an alert.
+func TestIsDangerousWarning(t *testing.T) {
+	tests := []struct {
+		name    string
+		warning string
+		want    bool
+	}{
+		{
+			name:    "empty-source guard warning from planOrphanDeletion",
+			warning: "source returned 0 events but 42 previously-synced records exist - skipping one-way orphan deletion for safety (possible auth failure or broken source)",
+			want:    true,
+		},
+		{
+			name:    "mass-delete threshold warning from planOrphanDeletion",
+			warning: "one-way orphan deletion would remove 80 of 100 previously-synced events (80%), exceeds safety threshold 50% - skipping deletion",
+			want:    true,
+		},
+		{
+			name:    "harmless individual delete failure",
+			warning: "Failed to delete orphan event: 404 not found",
+			want:    false,
+		},
+		{
+			name:    "harmless 403 skip",
+			warning: "Two-way sync: 3 events skipped (source calendar read-only)",
+			want:    false,
+		},
+		{
+			name:    "empty string",
+			warning: "",
+			want:    false,
+		},
+		{
+			name:    "unrelated warning containing none of the patterns",
+			warning: "Failed to update sync log",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsDangerousWarning(tt.warning)
+			if got != tt.want {
+				t.Errorf("IsDangerousWarning(%q) = %v, want %v", tt.warning, got, tt.want)
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
 		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,7 +2,9 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,12 +14,12 @@ import (
 )
 
 const (
-	cleanupInterval     = 24 * time.Hour
-	logRetentionDays    = 30
-	syncTimeout         = 120 * time.Minute // Maximum time for a single sync operation (2 hours for slow iCloud with multiple calendars)
-	healthLogInterval   = 5 * time.Minute   // Interval for scheduler health logging
-	staleMultiplier     = 2                 // Source is stale if last sync > staleMultiplier * interval
-	startupStagger      = 30 * time.Second  // Delay between starting each source's first sync
+	cleanupInterval   = 24 * time.Hour
+	logRetentionDays  = 30
+	syncTimeout       = 120 * time.Minute // Maximum time for a single sync operation (2 hours for slow iCloud with multiple calendars)
+	healthLogInterval = 5 * time.Minute   // Interval for scheduler health logging
+	staleMultiplier   = 2                 // Source is stale if last sync > staleMultiplier * interval
+	startupStagger    = 30 * time.Second  // Delay between starting each source's first sync
 )
 
 // Job represents a scheduled sync job.
@@ -204,9 +206,12 @@ func (s *Scheduler) RemoveJob(sourceID string) {
 		log.Printf("Removed sync job for source %s", sourceID)
 	}
 
-	// Clear stale state in notifier if configured
+	// Clear alert state in notifier if configured. Both stale and failure
+	// cooldowns must be cleared so a newly-added source with a reused ID
+	// (unlikely but possible) starts with a clean slate.
 	if s.notifier != nil {
 		s.notifier.ClearStaleState(sourceID)
+		s.notifier.ClearFailureAlertState(sourceID)
 	}
 }
 
@@ -410,6 +415,79 @@ func (s *Scheduler) executeSync(sourceID string) {
 	} else {
 		log.Printf("Sync failed for source %s: %s", source.Name, result.Message)
 	}
+
+	// Fire a failure alert when appropriate. This covers two cases:
+	//   1. The sync itself returned Success=false (hard failure).
+	//   2. The sync succeeded but a data-loss protection guard was
+	//      triggered, producing a "dangerous" warning in result.Warnings.
+	//      These warnings come from planOrphanDeletion in caldav/sync.go
+	//      (PR #22 / issue #21) and indicate that the sync refused to
+	//      delete events because the inputs looked unsafe. The user MUST
+	//      know about these — before PR #22 they would have silently
+	//      deleted data; after PR #22 they silently preserve data, but
+	//      the underlying problem (broken source, auth expired, etc.)
+	//      still needs user attention.
+	s.maybeSendFailureAlert(sourceID, source, result)
+}
+
+// maybeSendFailureAlert inspects a sync result and fires a failure alert if
+// the sync failed or if any data-loss protection guard was triggered.
+// It respects the notifier's cooldown window — called on every sync, the
+// per-source cooldown map prevents alert storms on a persistently broken
+// source.
+func (s *Scheduler) maybeSendFailureAlert(sourceID string, source *db.Source, result *caldav.SyncResult) {
+	if s.notifier == nil || !s.notifier.IsEnabled() {
+		return
+	}
+
+	var (
+		shouldAlert  bool
+		alertMessage string
+		alertDetails string
+	)
+
+	if !result.Success {
+		shouldAlert = true
+		alertMessage = fmt.Sprintf("Sync failed for source '%s'", source.Name)
+		if len(result.Errors) > 0 {
+			alertDetails = strings.Join(result.Errors, "\n")
+		} else {
+			alertDetails = result.Message
+		}
+	} else {
+		// Successful sync — check warnings for data-loss protection signals.
+		var dangerous []string
+		for _, w := range result.Warnings {
+			if notify.IsDangerousWarning(w) {
+				dangerous = append(dangerous, w)
+			}
+		}
+		if len(dangerous) > 0 {
+			shouldAlert = true
+			alertMessage = fmt.Sprintf("Data-loss protection triggered for source '%s'", source.Name)
+			alertDetails = strings.Join(dangerous, "\n")
+		}
+	}
+
+	if !shouldAlert {
+		return
+	}
+
+	// Look up user email for per-user notifications. nil-safe so tests
+	// can exercise this path with a no-DB scheduler; production always
+	// has a real db.
+	userEmail := ""
+	if s.db != nil {
+		if user, err := s.db.GetUserByID(source.UserID); err == nil {
+			userEmail = user.Email
+		}
+	}
+	userPrefs := s.getUserAlertPrefs(source.UserID)
+
+	s.notifier.SendSyncFailureAlertWithPrefs(
+		s.ctx, sourceID, source.Name, userEmail,
+		alertMessage, alertDetails, userPrefs,
+	)
 }
 
 // cleanupRoutine runs periodic cleanup of old sync logs.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -4,6 +4,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/macjediwizard/calbridgesync/internal/caldav"
+	"github.com/macjediwizard/calbridgesync/internal/db"
+	"github.com/macjediwizard/calbridgesync/internal/notify"
 )
 
 func TestNew(t *testing.T) {
@@ -563,4 +567,153 @@ func TestContextCancellation(t *testing.T) {
 		// Cancel should not panic
 		sched.cancel()
 	})
+}
+
+// newTestSchedulerWithNotifier returns a Scheduler wired to a real Notifier
+// with webhook/email disabled (no network I/O) and a nil DB. This exercises
+// the full scheduler → notifier pipeline without standing up mock
+// infrastructure. The disabled channels mean the background send goroutine
+// exits immediately, leaving only the cooldown-map side effects — which is
+// exactly what the tests need to observe.
+func newTestSchedulerWithNotifier(t *testing.T) (*Scheduler, *notify.Notifier) {
+	t.Helper()
+	n := notify.New(&notify.Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	})
+	// Notifier must be "enabled" for the scheduler to call it. With both
+	// channels disabled, IsEnabled() returns false — so to exercise the
+	// path we enable webhook but do not set a URL. sendWithPrefs then
+	// no-ops on the empty URL branch.
+	n = notify.New(&notify.Config{
+		WebhookEnabled: true,
+		WebhookURL:     "", // empty URL — send is a no-op
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	})
+	sched := New(nil, nil, n)
+	return sched, n
+}
+
+// TestMaybeSendFailureAlert_HardFailureFiresAlert verifies that a sync
+// result with Success=false triggers a failure alert via the notifier.
+func TestMaybeSendFailureAlert_HardFailureFiresAlert(t *testing.T) {
+	sched, n := newTestSchedulerWithNotifier(t)
+	defer sched.cancel()
+
+	source := &db.Source{ID: "src-1", Name: "Test Source", UserID: "u1"}
+	result := &caldav.SyncResult{
+		Success: false,
+		Message: "sync failed",
+		Errors:  []string{"connection refused"},
+	}
+
+	sched.maybeSendFailureAlert(source.ID, source, result)
+
+	// Verify by probing the notifier's cooldown: a direct call with the
+	// same source should now be blocked, proving the scheduler populated
+	// the failure-alert cooldown map.
+	fired := n.SendSyncFailureAlertWithPrefs(
+		nil, source.ID, source.Name, "",
+		"probe", "probe", nil,
+	)
+	if fired {
+		t.Error("expected scheduler to have populated the failure cooldown (probe should return false)")
+	}
+}
+
+// TestMaybeSendFailureAlert_DangerousWarningFiresAlert verifies that a
+// successful sync with a data-loss-protection warning still triggers a
+// failure alert. This is the scenario that explains why the user's
+// calendar data disappeared without any alert reaching them: after PR #22,
+// the safety guards will emit these warnings, and the scheduler must
+// surface them as alerts.
+func TestMaybeSendFailureAlert_DangerousWarningFiresAlert(t *testing.T) {
+	sched, n := newTestSchedulerWithNotifier(t)
+	defer sched.cancel()
+
+	source := &db.Source{ID: "src-2", Name: "Test Source 2", UserID: "u1"}
+	result := &caldav.SyncResult{
+		Success: true,
+		Warnings: []string{
+			"source returned 0 events but 42 previously-synced records exist - skipping one-way orphan deletion for safety (possible auth failure or broken source)",
+		},
+	}
+
+	sched.maybeSendFailureAlert(source.ID, source, result)
+
+	fired := n.SendSyncFailureAlertWithPrefs(
+		nil, source.ID, source.Name, "",
+		"probe", "probe", nil,
+	)
+	if fired {
+		t.Error("expected scheduler to alert on dangerous warning even on success (probe should return false)")
+	}
+}
+
+// TestMaybeSendFailureAlert_HarmlessWarningDoesNotFire verifies that a
+// successful sync with only routine warnings (e.g. individual event delete
+// failures, 403 skips) does NOT trigger a failure alert. This prevents
+// alert noise from day-to-day sync operations.
+func TestMaybeSendFailureAlert_HarmlessWarningDoesNotFire(t *testing.T) {
+	sched, n := newTestSchedulerWithNotifier(t)
+	defer sched.cancel()
+
+	source := &db.Source{ID: "src-3", Name: "Test Source 3", UserID: "u1"}
+	result := &caldav.SyncResult{
+		Success: true,
+		Warnings: []string{
+			"Failed to delete orphan event: 404 not found",
+			"Two-way sync: 2 events skipped (source calendar read-only)",
+		},
+	}
+
+	sched.maybeSendFailureAlert(source.ID, source, result)
+
+	// Direct call should still fire — cooldown was never populated.
+	fired := n.SendSyncFailureAlertWithPrefs(
+		nil, source.ID, source.Name, "",
+		"probe", "probe", nil,
+	)
+	if !fired {
+		t.Error("expected direct call to fire (scheduler must not have populated cooldown on harmless warnings)")
+	}
+}
+
+// TestMaybeSendFailureAlert_SuccessWithNoWarningsDoesNotFire verifies the
+// happy path: a clean successful sync with no warnings triggers zero alerts.
+func TestMaybeSendFailureAlert_SuccessWithNoWarningsDoesNotFire(t *testing.T) {
+	sched, n := newTestSchedulerWithNotifier(t)
+	defer sched.cancel()
+
+	source := &db.Source{ID: "src-4", Name: "Test Source 4", UserID: "u1"}
+	result := &caldav.SyncResult{
+		Success:  true,
+		Warnings: nil,
+	}
+
+	sched.maybeSendFailureAlert(source.ID, source, result)
+
+	fired := n.SendSyncFailureAlertWithPrefs(
+		nil, source.ID, source.Name, "",
+		"probe", "probe", nil,
+	)
+	if !fired {
+		t.Error("expected direct call to fire (scheduler must not have populated cooldown on clean success)")
+	}
+}
+
+// TestMaybeSendFailureAlert_NilNotifierSafe verifies the nil-notifier
+// guard. A scheduler without a notifier (tests, stripped-down deploys)
+// must not panic.
+func TestMaybeSendFailureAlert_NilNotifierSafe(t *testing.T) {
+	sched := New(nil, nil, nil)
+	defer sched.cancel()
+
+	source := &db.Source{ID: "src-5", Name: "Test Source 5", UserID: "u1"}
+	result := &caldav.SyncResult{Success: false, Message: "sync failed"}
+
+	// Must not panic.
+	sched.maybeSendFailureAlert(source.ID, source, result)
 }


### PR DESCRIPTION
## Summary

Closes #23. Turns the alert pipeline from "only fires on staleness" into "fires on sync failures and on PR #22's data-loss protection warnings". This is the direct fix for the user's complaint that alerts never reached them while their calendar was being wiped.

## What changed

### `internal/notify/notify.go`
- **New cooldown map `lastFailureAlertTimes`** — tracked independently from stale alerts so a source that is both stale AND failing doesn't lose one signal to the other's cooldown
- **New method `SendSyncFailureAlertWithPrefs`** — uses the existing `AlertTypeError` enum (previously dead code) and reuses the existing `sendWithPrefs` pipeline (global webhook + per-user webhook + email)
- **New method `ClearFailureAlertState`** — symmetric with `ClearStaleState`, called from source deletion
- **New helper `IsDangerousWarning(string) bool`** — matches the two safety-abort patterns produced by `planOrphanDeletion` in PR #22:
  - `"previously-synced records exist"` (empty-source guard)
  - `"exceeds safety threshold"` (mass-delete threshold)
  - Harmless warnings (individual delete failures, 403/412 skips) do NOT match

### `internal/scheduler/scheduler.go`
- **New method `Scheduler.maybeSendFailureAlert`** — fires an alert after every sync when either:
  - `result.Success == false` (hard failure) → alert body joins `result.Errors` by newlines
  - `result.Success == true` but `result.Warnings` contains an `IsDangerousWarning` match → alert body contains the matching warnings
- Wired into `runSync` after the existing success/recovery logging. Existing stale and recovery paths are **untouched**.
- Extended source-deletion cleanup to call `ClearFailureAlertState` alongside `ClearStaleState`
- Made nil-safe on `s.db` so the method can be exercised from tests without mock infrastructure

## Why this matters

PR #22 added safety guards that **prevent** data loss by aborting orphan-delete loops. But without this PR, those guards emit warnings that go nowhere — a user whose sync has silently gone into "safety mode" would never know. The sync would report success, the dashboard would show green, and the underlying problem (broken source, expired auth) would persist until the user manually investigated.

This PR closes that observability gap. The safety guard now reaches the user.

## Tests

### `internal/notify/notify_test.go` (+5 new tests, 192 lines)
- `TestSendSyncFailureAlertCooldown` — cooldown suppresses repeat alerts; different source still fires
- `TestSendSyncFailureAlertIndependentFromStale` — a source that's both stale AND failing can fire both alert types
- `TestClearFailureAlertState` — clearing lets the next alert fire immediately; safe for unknown source IDs
- `TestSendSyncFailureAlertUserCooldownOverride` — zero-minute per-user cooldown overrides the global
- `TestIsDangerousWarning` — table-driven, 6 cases covering both safety patterns, harmless warnings, empty string

### `internal/scheduler/scheduler_test.go` (+5 new tests, 153 lines)
- `newTestSchedulerWithNotifier` helper — real Notifier with empty webhook URL (no network I/O, cooldown map observable)
- `TestMaybeSendFailureAlert_HardFailureFiresAlert` — `Success=false` populates cooldown
- `TestMaybeSendFailureAlert_DangerousWarningFiresAlert` — the PR-#22-induced warning fires an alert even on successful sync
- `TestMaybeSendFailureAlert_HarmlessWarningDoesNotFire` — routine 404/403 warnings do not populate cooldown
- `TestMaybeSendFailureAlert_SuccessWithNoWarningsDoesNotFire` — happy path, no alerts
- `TestMaybeSendFailureAlert_NilNotifierSafe` — defensive nil-notifier test

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/notify/...` — all new + existing tests pass
- [x] `go test ./internal/scheduler/...` — all new + existing tests pass
- [x] `go test ./...` — full suite green, zero regressions
- [ ] After deploy: trigger a sync against a broken source (bad URL, expired auth) and verify an alert fires
- [ ] After deploy: verify cooldown suppresses repeat alerts within the configured window
- [ ] After deploy: verify normal successful syncs do NOT spam alerts

## Behavior change / user impact

For the 3 production users: if they have alerts configured (webhook or email), they will now receive alerts on:
- Any sync that fails with `Success == false`
- Any sync that triggers the PR-#22 data-loss safety guards

Users who have NOT configured alerts see no behavior change (`notifier.IsEnabled()` returns false → the entire path is a no-op). Per-user alert preferences (`user_alert_preferences` table) are honored via the existing `sendWithPrefs` pipeline. No schema change, no config change.

## Rollback

Two files touched (plus two test files). `git revert` removes cleanly. Additive path: existing stale/recovery alerts are not modified, so reverting leaves the system in its prior (silent-on-failure) state — not worse than before.

## Explicitly NOT in scope (future issues)

- **Cooldown-set-before-send timing bug** — Issue #D. When that lands it'll fix all three cooldowns (stale, recovery, failure) together.
- **Retry with bounded backoff** — Issue #E
- **Dead-code removal of legacy `SendStaleAlert` / `SendRecoveryAlert` / `AlertTypeError` enum** — Issue #M, after all live replacements are shipped

## Protected regions (not touched)

Verified the fix does not modify or interfere with any of the following documented in `tasks/lessons.md`:
- PR #22's `planOrphanDeletion` + call site (we only react to its warning output)
- Recurring-events dedup (`normalizeStartTime`, `DedupeKey`, `cleanupDuplicates`)
- Cross-calendar two-way fix at `sync.go:681-695`
- Two-way destination-empty safety
- 403/412 graceful handling
- ETag comparison logic
- `filterEventsByDate` RRULE short-circuit (William's 58d890f fix)
- ICS client UID grouping (William's 92e1458 fix)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)