### PR TITLE
fix: WebDAV-Sync path correctness — destination discovery + delete path rewrite (#25)

### DIFF
--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -50,6 +50,42 @@ func getSyncDirectionForCalendar(source *db.Source, calendarPath string) db.Sync
 // or filter misconfiguration rather than a legitimate bulk cleanup.
 const defaultOrphanDeleteRatioThreshold = 0.5
 
+// rewriteDeletePathForDestination translates a CalDAV object path from the
+// source server's URL namespace into the destination server's URL namespace.
+//
+// This is needed for the WebDAV-Sync (RFC 6578) incremental sync path.
+// When a source supports sync-collection, `SyncCollection` returns a list
+// of deleted paths in the SOURCE server's URL space — e.g.
+// "/calendar/work-acct/abc123.ics". Passing those paths directly to
+// `destClient.DeleteEvent` results in a 404 on the destination, because
+// the destination has no concept of the source's URL layout.
+//
+// The destination path is reconstructed from the last URL segment of the
+// source path (the event filename, which by convention in PutEvent is
+// "{UID}.ics") prepended with the destination calendar path. This mirrors
+// how PutEvent writes events in the first place, so delete paths match
+// write paths.
+//
+// Returns an empty string if the source path has no extractable filename
+// (empty input, trailing-slash-only, etc). Callers MUST check for the
+// empty return and skip the delete rather than issuing a request with
+// a malformed URL.
+func rewriteDeletePathForDestination(sourcePath, destCalendarPath string) string {
+	trimmed := strings.TrimSuffix(sourcePath, "/")
+	if trimmed == "" {
+		return ""
+	}
+	// Extract the last path segment (the event filename).
+	filename := trimmed
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 {
+		filename = trimmed[idx+1:]
+	}
+	if filename == "" {
+		return ""
+	}
+	return strings.TrimSuffix(destCalendarPath, "/") + "/" + filename
+}
+
 // planOrphanDeletion determines which destination events should be deleted as
 // "orphans" during a one-way + source_wins sync.
 //
@@ -361,8 +397,22 @@ func (se *SyncEngine) syncCalendar(ctx context.Context, source *db.Source, sourc
 		syncToken = syncState.SyncToken
 	}
 
-	// Get the destination calendar path from the destination client's base URL
-	destCalendarPath := destClient.GetCalendarPath()
+	// Discover destination calendar path using the same logic as fullSync
+	// to ensure both code paths target the same calendar.
+	destCalendarPath := ""
+	destCalendars, discoverErr := destClient.FindCalendars(ctx)
+	if discoverErr != nil {
+		log.Printf("Failed to discover destination calendars, falling back to URL path: %v", discoverErr)
+		destCalendarPath = destClient.GetCalendarPath()
+	} else if len(destCalendars) == 0 {
+		log.Printf("No calendars found on destination, using URL path as fallback")
+		destCalendarPath = destClient.GetCalendarPath()
+	} else {
+		destCalendarPath = destCalendars[0].Path
+		if len(destCalendars) > 1 {
+			log.Printf("WARNING: Multiple destination calendars found, using first one: %s", destCalendarPath)
+		}
+	}
 
 	// Try WebDAV-Sync if supported
 	if sourceClient.SupportsWebDAVSync(ctx, calendar.Path) {
@@ -384,10 +434,20 @@ func (se *SyncEngine) syncCalendar(ctx context.Context, source *db.Source, sourc
 				}
 			}
 
-			for _, path := range syncResult.Deleted {
-				if err := destClient.DeleteEvent(ctx, path); err != nil {
+			// Delete events from destination. Source paths are in the source
+			// server's URL namespace and cannot be used directly against the
+			// destination, so we rewrite each path through
+			// rewriteDeletePathForDestination. See that helper's doc comment
+			// for the full rationale.
+			for _, sourcePath := range syncResult.Deleted {
+				destEventPath := rewriteDeletePathForDestination(sourcePath, destCalendarPath)
+				if destEventPath == "" {
+					log.Printf("Skipping delete for unrewriteable source path: %q", sourcePath)
+					continue
+				}
+				if err := destClient.DeleteEvent(ctx, destEventPath); err != nil {
 					// Don't count as error if event doesn't exist on destination
-					log.Printf("Failed to delete event %s: %v", path, err)
+					log.Printf("Failed to delete event (source: %s, dest: %s): %v", sourcePath, destEventPath, err)
 				} else {
 					result.Deleted++
 				}

--- a/internal/caldav/sync_test.go
+++ b/internal/caldav/sync_test.go
@@ -260,3 +260,120 @@ func TestPlanOrphanDeletion_ManualDestEventsPreserved(t *testing.T) {
 		}
 	}
 }
+
+// TestRewriteDeletePathForDestination verifies the WebDAV-Sync delete-path
+// rewrite logic. When a source supports sync-collection (RFC 6578), the
+// deleted-paths list returned by SyncCollection is in the SOURCE server's
+// URL namespace and cannot be used directly against the destination. This
+// helper extracts the event filename (UID.ics by PutEvent convention) and
+// reattaches it to the destination calendar path.
+//
+// Before this helper existed, every WebDAV-Sync delete silently 404'd on
+// the destination and stale events accumulated forever.
+func TestRewriteDeletePathForDestination(t *testing.T) {
+	tests := []struct {
+		name             string
+		sourcePath       string
+		destCalendarPath string
+		want             string
+	}{
+		{
+			name:             "normal case — deep source path, clean destination",
+			sourcePath:       "/calendar/work-acct/abc123.ics",
+			destCalendarPath: "/SOGo/dav/user@host/Calendar/personal",
+			want:             "/SOGo/dav/user@host/Calendar/personal/abc123.ics",
+		},
+		{
+			name:             "destination has trailing slash — no double slash",
+			sourcePath:       "/calendar/work-acct/abc123.ics",
+			destCalendarPath: "/SOGo/dav/user@host/Calendar/personal/",
+			want:             "/SOGo/dav/user@host/Calendar/personal/abc123.ics",
+		},
+		{
+			name:             "source has trailing slash — still extracts filename",
+			sourcePath:       "/calendar/work-acct/abc123.ics/",
+			destCalendarPath: "/dest/cal",
+			want:             "/dest/cal/abc123.ics",
+		},
+		{
+			name:             "URL-encoded filename preserved as-is",
+			sourcePath:       "/cal/event%20with%20spaces.ics",
+			destCalendarPath: "/dest/cal",
+			want:             "/dest/cal/event%20with%20spaces.ics",
+		},
+		{
+			name:             "root-level source path",
+			sourcePath:       "/abc.ics",
+			destCalendarPath: "/dest/cal",
+			want:             "/dest/cal/abc.ics",
+		},
+		{
+			name:             "filename only, no leading slash",
+			sourcePath:       "abc.ics",
+			destCalendarPath: "/dest/cal",
+			want:             "/dest/cal/abc.ics",
+		},
+		{
+			name:             "empty source path returns empty (skip-signal)",
+			sourcePath:       "",
+			destCalendarPath: "/dest/cal",
+			want:             "",
+		},
+		{
+			name:             "source path is a single slash returns empty (skip-signal)",
+			sourcePath:       "/",
+			destCalendarPath: "/dest/cal",
+			want:             "",
+		},
+		{
+			name:             "UID with dots and hyphens",
+			sourcePath:       "/cal/user/20260101T120000Z-event-uid-1234.ics",
+			destCalendarPath: "/dest/cal",
+			want:             "/dest/cal/20260101T120000Z-event-uid-1234.ics",
+		},
+		{
+			name:             "destination is root /",
+			sourcePath:       "/cal/abc.ics",
+			destCalendarPath: "/",
+			want:             "/abc.ics",
+		},
+		{
+			name:             "destination is empty string",
+			sourcePath:       "/cal/abc.ics",
+			destCalendarPath: "",
+			want:             "/abc.ics",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rewriteDeletePathForDestination(tt.sourcePath, tt.destCalendarPath)
+			if got != tt.want {
+				t.Errorf("rewriteDeletePathForDestination(%q, %q) = %q, want %q",
+					tt.sourcePath, tt.destCalendarPath, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRewriteDeletePathForDestination_FilenameMatchesPutEventConvention
+// documents the contract between this helper and client.go:PutEvent.
+// PutEvent writes events as "{calendarPath}/{UID}.ics" (see client.go:602).
+// rewriteDeletePathForDestination must produce a path in the same shape
+// so that a delete issued after a put finds the same file.
+func TestRewriteDeletePathForDestination_FilenameMatchesPutEventConvention(t *testing.T) {
+	// Simulate what PutEvent would have written.
+	destCalendarPath := "/SOGo/dav/user@host/Calendar/personal"
+	uid := "event-uid-12345"
+	putPath := strings.TrimSuffix(destCalendarPath, "/") + "/" + uid + ".ics"
+
+	// Simulate what WebDAV-Sync returns from the source for the same UID.
+	// Source server uses a different URL layout.
+	sourcePath := "/caldav/different-layout/" + uid + ".ics"
+
+	// The rewritten delete path must match the put path.
+	deletePath := rewriteDeletePathForDestination(sourcePath, destCalendarPath)
+	if deletePath != putPath {
+		t.Errorf("rewrite produced %q, but PutEvent would have written %q — delete will 404",
+			deletePath, putPath)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #25. Fixes two correctness bugs in the WebDAV-Sync (RFC 6578) incremental sync path in `internal/caldav/sync.go:syncCalendar`. These bugs are silent on SOGo-only setups (SOGo doesn't advertise sync-collection so the code falls through to `fullSync`), but they fire immediately for any source that does support sync-collection — iCloud, Google Calendar, Fastmail, some Nextcloud configurations.

## Bug 1 — WebDAV-Sync deletes silently fail

`sourceClient.SyncCollection` returns deleted event paths in the **source** server's URL namespace (e.g. `/calendar/work-acct/abc123.ics`). The previous code passed those paths directly to `destClient.DeleteEvent`, which 404'd every time because the destination has no concept of the source's URL layout. Errors were `log.Printf`'d and swallowed, so the sync reported "success" while stale events accumulated on the destination forever.

**Fix**: new pure helper `rewriteDeletePathForDestination(sourcePath, destCalendarPath)` that extracts the filename (`{UID}.ics` by `PutEvent` convention at `client.go:602`) and joins it to the destination calendar path. Returns empty string for unrewriteable inputs so callers can skip gracefully.

## Bug 2 — WebDAV-Sync path uses different destination discovery than fullSync

- **WebDAV-Sync (old code)**: `destClient.GetCalendarPath()` — naive URL string parsing
- **fullSync**: `destClient.FindCalendars(ctx)` — proper CalDAV principal + calendar-home-set discovery with fallback (commit `235446f`)

These can resolve differently depending on how the user configured the destination URL. Events would get PUT to a different location than fullSync would have used, and because `PutEvent`'s HasPrefix fallback reconstructs paths from UID, events might end up written **somewhere** — just not where the user's destination calendar actually is.

**Fix**: use the same `FindCalendars`-with-fallback discovery logic in both paths. Copy-paste parity with `fullSync:468-484` so any future fixes there apply to both paths symmetrically.

## Tests

New in `internal/caldav/sync_test.go`:

### `TestRewriteDeletePathForDestination` — table-driven, 12 cases
- Normal deep source path + clean destination
- Destination with trailing slash (no double-slash)
- Source with trailing slash (still extracts filename)
- URL-encoded filename preserved as-is (no decode/encode layering)
- Root-level source path `/abc.ics`
- Filename-only source path (no leading slash)
- Empty source path returns empty (skip signal)
- Source path `/` returns empty
- UID with dots and hyphens
- Destination `/`
- Destination empty string

### `TestRewriteDeletePathForDestination_FilenameMatchesPutEventConvention`
Documents and locks in the invariant: the rewriter's output must match what `PutEvent` would have written for the same UID. If `PutEvent`'s `{path}/{UID}.ics` convention ever changes, this test fails immediately, preventing a silent divergence.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/caldav/...` — all new + existing tests pass
- [x] `go test ./...` — full suite green, zero regressions
- [ ] After deploy: for a source that supports WebDAV-Sync, verify deletes actually propagate to destination (source-side: delete an event, wait for sync, confirm destination reflects the delete)
- [ ] After deploy: verify events written to destination end up in the same calendar that `fullSync` targets

## Rollback

Single file touched: `internal/caldav/sync.go` (plus test file). No schema change. No config change. `git revert` removes cleanly. Safe to roll back the binary without data migration.

## Protected regions (not touched)

- `planOrphanDeletion` and orphan-delete call site (PR #22 / issue #21)
- Recurring-events dedup (`normalizeStartTime`, `DedupeKey`, `cleanupDuplicates`)
- Cross-calendar two-way fix at `:681-695` (commit `0abe8c4`)
- Two-way destination-empty safety at `:560-566` (commit `b772c56`)
- `filterEventsByDate` RRULE short-circuit (commit `58d890f`)
- ICS client UID grouping (commit `92e1458`)
- ETag comparison logic, 403/412 graceful handling

## Explicitly NOT in scope — follow-up issue

**Issue #G — WebDAV-Sync path does not populate `synced_events` table.** The WebDAV-Sync happy path writes events directly without calling `UpsertSyncedEvent`, so the two-way safety checks that depend on `previouslySyncedMap` (including PR #22's one-way orphan-deletion ownership filter) starve on any source that uses sync-collection. That is a separate concern — fixing it in this PR would entangle two unrelated changes and complicate rollback.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)