### PR TITLE
fix: WebDAV-Sync path populates synced_events table (#27)

### DIFF
--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -50,6 +50,45 @@ func getSyncDirectionForCalendar(source *db.Source, calendarPath string) db.Sync
 // or filter misconfiguration rather than a legitimate bulk cleanup.
 const defaultOrphanDeleteRatioThreshold = 0.5
 
+// extractUIDFromEventPath returns the event UID embedded in a CalDAV object
+// path. By PutEvent convention (client.go:602), events are written as
+// "{calendarPath}/{UID}.ics" so the UID is the basename of the path with
+// the ".ics" extension stripped.
+//
+// This is used by the WebDAV-Sync path in syncCalendar to keep the
+// synced_events table in sync with destination writes and deletes:
+// SyncCollection.Deleted only tells us the source-side path, not the UID,
+// so we have to recover the UID from the last URL segment.
+//
+// Returns an empty string for inputs that cannot yield a UID (empty path,
+// path with no trailing filename, filename without the ".ics" extension).
+// Callers MUST check for the empty return before passing the result to
+// DeleteSyncedEvent — a DELETE with an empty UID would match no rows but
+// still wastes a DB round-trip and pollutes logs.
+func extractUIDFromEventPath(eventPath string) string {
+	trimmed := strings.TrimSuffix(eventPath, "/")
+	if trimmed == "" {
+		return ""
+	}
+	filename := trimmed
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 {
+		filename = trimmed[idx+1:]
+	}
+	if filename == "" {
+		return ""
+	}
+	// Strip the .ics extension if present. Filenames without .ics are
+	// likely not event objects — return empty so callers skip them.
+	if !strings.HasSuffix(filename, ".ics") {
+		return ""
+	}
+	uid := strings.TrimSuffix(filename, ".ics")
+	if uid == "" {
+		return ""
+	}
+	return uid
+}
+
 // rewriteDeletePathForDestination translates a CalDAV object path from the
 // source server's URL namespace into the destination server's URL namespace.
 //
@@ -430,6 +469,22 @@ func (se *SyncEngine) syncCalendar(ctx context.Context, source *db.Source, sourc
 						result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to sync event: %v", err))
 					} else {
 						result.Updated++
+						// Track in synced_events so PR #22's ownership filter
+						// and two-way deletion logic can see these writes.
+						// PutEvent populates event.UID in-place when it
+						// successfully parses the calendar data; if the
+						// event had no UID it cannot reach this branch
+						// (PutEvent returns nil early without writing).
+						if event.UID != "" {
+							syncedEvent := &db.SyncedEvent{
+								SourceID:     source.ID,
+								CalendarHref: calendar.Path,
+								EventUID:     event.UID,
+							}
+							if err := se.db.UpsertSyncedEvent(syncedEvent); err != nil {
+								log.Printf("Failed to upsert synced event record for %s: %v", event.UID, err)
+							}
+						}
 					}
 				}
 			}
@@ -450,6 +505,16 @@ func (se *SyncEngine) syncCalendar(ctx context.Context, source *db.Source, sourc
 					log.Printf("Failed to delete event (source: %s, dest: %s): %v", sourcePath, destEventPath, err)
 				} else {
 					result.Deleted++
+					// Remove the synced_events record too so the next sync's
+					// previouslySyncedMap doesn't still think we own it.
+					// The UID is encoded in the filename of the destination
+					// path (and equivalently in the source path) per the
+					// PutEvent convention.
+					if uid := extractUIDFromEventPath(destEventPath); uid != "" {
+						if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, uid); err != nil {
+							log.Printf("Failed to delete synced event record for %s: %v", uid, err)
+						}
+					}
 				}
 			}
 

--- a/internal/caldav/sync_test.go
+++ b/internal/caldav/sync_test.go
@@ -377,3 +377,105 @@ func TestRewriteDeletePathForDestination_FilenameMatchesPutEventConvention(t *te
 			deletePath, putPath)
 	}
 }
+
+// TestExtractUIDFromEventPath verifies the UID extraction helper used by
+// the WebDAV-Sync path to keep synced_events in sync with destination
+// writes and deletes. PutEvent writes events as "{path}/{UID}.ics", so
+// extractUIDFromEventPath must be able to recover the UID from any path
+// in that shape.
+func TestExtractUIDFromEventPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "normal destination path",
+			path: "/SOGo/dav/user@host/Calendar/personal/abc123.ics",
+			want: "abc123",
+		},
+		{
+			name: "normal source path",
+			path: "/calendar/work-acct/event-uid-1234.ics",
+			want: "event-uid-1234",
+		},
+		{
+			name: "trailing slash tolerated",
+			path: "/cal/abc.ics/",
+			want: "abc",
+		},
+		{
+			name: "UID with dots and hyphens",
+			path: "/cal/user/20260101T120000Z-event-uid-1234.ics",
+			want: "20260101T120000Z-event-uid-1234",
+		},
+		{
+			name: "URL-encoded characters preserved in UID",
+			path: "/cal/event%20with%20spaces.ics",
+			want: "event%20with%20spaces",
+		},
+		{
+			name: "filename only, no leading slash",
+			path: "abc.ics",
+			want: "abc",
+		},
+		{
+			name: "root-level filename",
+			path: "/abc.ics",
+			want: "abc",
+		},
+		{
+			name: "empty string returns empty",
+			path: "",
+			want: "",
+		},
+		{
+			name: "slash only returns empty",
+			path: "/",
+			want: "",
+		},
+		{
+			name: "path without .ics extension returns empty",
+			path: "/cal/some-directory",
+			want: "",
+		},
+		{
+			name: "filename is just .ics returns empty",
+			path: "/cal/.ics",
+			want: "",
+		},
+		{
+			name: "deep nested path extracts only the last segment",
+			path: "/very/deeply/nested/path/final-uid.ics",
+			want: "final-uid",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractUIDFromEventPath(tt.path)
+			if got != tt.want {
+				t.Errorf("extractUIDFromEventPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractUIDFromEventPath_RoundTripWithRewrite verifies that a UID
+// survives the full round-trip: a source path rewritten by
+// rewriteDeletePathForDestination and then passed to extractUIDFromEventPath
+// must yield the original UID back. This is the contract the
+// WebDAV-Sync delete loop relies on: after successfully deleting an
+// event from the destination, the loop needs to be able to recover
+// the UID from the rewritten path so it can call DeleteSyncedEvent.
+func TestExtractUIDFromEventPath_RoundTripWithRewrite(t *testing.T) {
+	uid := "round-trip-uid-1234"
+	sourcePath := "/source/server/layout/" + uid + ".ics"
+	destCalendarPath := "/destination/server/layout"
+
+	rewritten := rewriteDeletePathForDestination(sourcePath, destCalendarPath)
+	got := extractUIDFromEventPath(rewritten)
+	if got != uid {
+		t.Errorf("round-trip lost the UID: source=%q → rewritten=%q → extracted=%q, want %q",
+			sourcePath, rewritten, got, uid)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #27. **Stacks on PR #26** (issue #25). This is the third and final known correctness gap in the WebDAV-Sync happy path in `internal/caldav/sync.go:syncCalendar`.

## The gap

The WebDAV-Sync path writes events to the destination via `PutEvent` / `DeleteEvent` but **never touches the `synced_events` table**. Three downstream features depend on that table being accurate:

1. **PR #22 one-way orphan-deletion ownership filter (issue #21)** — uses `previouslySyncedMap` (built from `GetSyncedEvents`) to decide which destination events this source is allowed to delete. If `synced_events` is empty for a WebDAV-Sync-using source, nothing is "ours" → the ownership filter rejects all candidates → orphan cleanup never runs, even when it should.
2. **Two-way sync deletion detection at `sync.go:568-621`** — walks `previouslySyncedMap` to detect "event on source but no longer on destination" and vice versa. Empty map = no deletion propagation at all, in either direction.
3. **Two-way destination-empty safety guard at `sync.go:560-566`** (commit `b772c56`) — checks `len(previouslySyncedMap) > 0` to decide whether to skip mass deletion when the destination returns zero events. Empty map defeats the guard.

## Why this was latent

Before PR #22, this was a latent bug — two-way sync was silently broken for any source that advertised sync-collection. Nobody noticed on SOGo-only setups because SOGo doesn't advertise it, so the code fell through to `fullSync` which tracks `synced_events` correctly via its own `currentUIDs` map at `sync.go:742-751`.

After PR #22, the one-way ownership filter depends on `synced_events` being populated correctly. Adding a sync-collection source (iCloud, Google, Fastmail) to a setup that relies on one-way + source_wins means the orphan filter refuses to delete anything — the sync goes "silent in a different way".

## The fix

### `internal/caldav/sync.go`

1. **New helper `extractUIDFromEventPath(path) string`** — takes a CalDAV object path in the `{anything}/{UID}.ics` shape (PutEvent convention at `client.go:602`) and returns the UID. Strips trailing slashes, extracts the last URL segment, requires `.ics` suffix, returns empty for unparseable inputs.
2. **WebDAV-Sync Changed loop** — after successful `PutEvent`, call `UpsertSyncedEvent` with `event.UID` (which PutEvent populates in-place from the parsed iCal data).
3. **WebDAV-Sync Deleted loop** — after successful `DeleteEvent`, extract the UID from the rewritten destination path and call `DeleteSyncedEvent`.

## Tests

### `TestExtractUIDFromEventPath` — table-driven, 12 cases
Normal destination path, normal source path, trailing slash tolerated, UIDs with dots/hyphens, URL-encoded characters preserved, filename-only input, root-level filename, empty/slash-only input, missing `.ics` extension, filename that is exactly `.ics`, deep nested path.

### `TestExtractUIDFromEventPath_RoundTripWithRewrite`
Documents and locks in the contract between `extractUIDFromEventPath` and `rewriteDeletePathForDestination` (from PR #26): a UID must survive the full round-trip `sourcePath → rewrite → destPath → extract → UID`. If either helper ever changes its path shape, this test fails immediately.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/caldav/...` — all new + existing tests pass
- [x] `go test ./...` — full suite green, zero regressions
- [ ] After deploy with a sync-collection source: verify `synced_events` table gets populated (e.g. `sqlite3 calbridgesync.db "SELECT count(*) FROM synced_events WHERE source_id = '<sync-coll-source-id>';"` should return > 0 after a sync)
- [ ] After deploy: verify PR #22's ownership filter activates for sync-collection sources (a subsequent source-side delete propagates to destination)

## Rollback

Single file touched (plus test file). `git revert` removes cleanly. No schema change. No config change.

## Base branch

This PR's base is `fix/25-webdav-sync-path-correctness` (PR #26), **not** `main`, because the changes here depend on PR #26's `rewriteDeletePathForDestination` helper. When PR #26 merges to main, GitHub will auto-retarget this PR to `main`. Merge order must be PR #26 first, then PR #27.

## Protected regions (not touched)

- PR #22 one-way orphan deletion + `planOrphanDeletion` helper
- PR #26 `rewriteDeletePathForDestination` helper (this PR uses it, doesn't modify it)
- Recurring-events dedup, cross-calendar two-way fix, RRULE filter, ICS client UID grouping, ETag comparison, 403/412 graceful handling
- `fullSync`'s own `currentUIDs` tracking path — orthogonal code path, no changes

## Explicitly NOT in scope

- Refactoring `fullSync` to use the same helper pattern (its current bookkeeping is correct, just different)
- Adding `synced_events` tracking to the ICS sync path — separate issue if needed

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)