### PR TITLE
fix: encodeCalendar returns error instead of empty string on failure (#29)

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -20,11 +20,11 @@ import (
 )
 
 var (
-	ErrConnectionFailed  = errors.New("connection failed")
-	ErrAuthFailed        = errors.New("authentication failed")
-	ErrNotFound          = errors.New("resource not found")
-	ErrInvalidResponse   = errors.New("invalid server response")
-	ErrMalformedContent  = errors.New("malformed calendar content")
+	ErrConnectionFailed = errors.New("connection failed")
+	ErrAuthFailed       = errors.New("authentication failed")
+	ErrNotFound         = errors.New("resource not found")
+	ErrInvalidResponse  = errors.New("invalid server response")
+	ErrMalformedContent = errors.New("malformed calendar content")
 )
 
 const (
@@ -333,28 +333,38 @@ func (c *Client) getEventsBatch(ctx context.Context, calendarPath string, paths 
 			ETag: obj.ETag,
 		}
 
-		if obj.Data != nil {
-			event.Data = encodeCalendar(obj.Data)
-
-			for _, evt := range obj.Data.Events() {
-				if uid, err := evt.Props.Text(ical.PropUID); err == nil {
-					event.UID = uid
-				}
-				if summary, err := evt.Props.Text(ical.PropSummary); err == nil {
-					event.Summary = summary
-				}
-				if dtstart := evt.Props.Get(ical.PropDateTimeStart); dtstart != nil {
-					event.StartTime = normalizeStartTime(dtstart)
-				}
-			}
-		}
-
-		if event.Data == "" {
+		if obj.Data == nil {
 			if collector != nil {
-				collector.Add(obj.Path, "empty iCalendar data - event may be corrupted or deleted")
+				collector.Add(obj.Path, "nil iCalendar data - event may be corrupted or deleted")
 			}
 			skippedEmpty++
 			continue
+		}
+
+		data, encErr := encodeCalendar(obj.Data)
+		if encErr != nil {
+			// Encode failure is a form of malformed content — the go-ical
+			// encoder rejected calendar data that the library itself had
+			// just parsed. Track it distinctly from the "empty data" case
+			// so the dashboard can surface the real cause.
+			if collector != nil {
+				collector.Add(obj.Path, fmt.Sprintf("failed to encode event: %v", encErr))
+			}
+			skippedMalformed++
+			continue
+		}
+		event.Data = data
+
+		for _, evt := range obj.Data.Events() {
+			if uid, err := evt.Props.Text(ical.PropUID); err == nil {
+				event.UID = uid
+			}
+			if summary, err := evt.Props.Text(ical.PropSummary); err == nil {
+				event.Summary = summary
+			}
+			if dtstart := evt.Props.Get(ical.PropDateTimeStart); dtstart != nil {
+				event.StartTime = normalizeStartTime(dtstart)
+			}
 		}
 
 		events = append(events, event)
@@ -395,31 +405,42 @@ func (c *Client) getEventsIndividually(ctx context.Context, paths []string, coll
 	return events, skippedMalformed, skippedEmpty
 }
 
-// objectsToEvents converts CalDAV objects to Events.
+// objectsToEvents converts CalDAV objects to Events. Events that fail to
+// encode (or have nil data) are skipped and logged — the returned slice
+// may have fewer entries than the input. This is safer than the prior
+// behavior, which silently stored Event{Data: ""} values that then flowed
+// into the sync engine as if they were valid events.
 func (c *Client) objectsToEvents(objects []caldav.CalendarObject) []Event {
 	events := make([]Event, 0, len(objects))
 	for _, obj := range objects {
+		if obj.Data == nil {
+			log.Printf("objectsToEvents: skipping %s with nil data", obj.Path)
+			continue
+		}
+
+		data, encErr := encodeCalendar(obj.Data)
+		if encErr != nil {
+			log.Printf("objectsToEvents: skipping %s, encode failed: %v", obj.Path, encErr)
+			continue
+		}
+
 		event := Event{
 			Path: obj.Path,
 			ETag: obj.ETag,
+			Data: data,
 		}
 
-		if obj.Data != nil {
-			// Encode the calendar to string
-			event.Data = encodeCalendar(obj.Data)
-
-			// Extract UID, Summary, and StartTime from events
-			for _, evt := range obj.Data.Events() {
-				if uid, err := evt.Props.Text(ical.PropUID); err == nil {
-					event.UID = uid
-				}
-				if summary, err := evt.Props.Text(ical.PropSummary); err == nil {
-					event.Summary = summary
-				}
-				// Extract start time for deduplication (normalized to UTC)
-				if dtstart := evt.Props.Get(ical.PropDateTimeStart); dtstart != nil {
-					event.StartTime = normalizeStartTime(dtstart)
-				}
+		// Extract UID, Summary, and StartTime from events
+		for _, evt := range obj.Data.Events() {
+			if uid, err := evt.Props.Text(ical.PropUID); err == nil {
+				event.UID = uid
+			}
+			if summary, err := evt.Props.Text(ical.PropSummary); err == nil {
+				event.Summary = summary
+			}
+			// Extract start time for deduplication (normalized to UTC)
+			if dtstart := evt.Props.Get(ical.PropDateTimeStart); dtstart != nil {
+				event.StartTime = normalizeStartTime(dtstart)
 			}
 		}
 
@@ -550,7 +571,16 @@ func (c *Client) GetEvent(ctx context.Context, eventPath string) (*Event, error)
 	}
 
 	if obj.Data != nil {
-		event.Data = encodeCalendar(obj.Data)
+		data, encErr := encodeCalendar(obj.Data)
+		if encErr != nil {
+			// Encode failure is a form of malformed content. Return an
+			// error so getEventsIndividually's existing malformed-error
+			// detection classifies this correctly and records it in the
+			// MalformedEventCollector, rather than silently returning an
+			// Event{Data: ""} that downstream code would treat as valid.
+			return nil, encErr
+		}
+		event.Data = data
 
 		for _, evt := range obj.Data.Events() {
 			if uid, err := evt.Props.Text(ical.PropUID); err == nil {
@@ -635,14 +665,30 @@ func parseICalendar(data string) (*ical.Calendar, error) {
 	return cal, nil
 }
 
-// encodeCalendar encodes a calendar object to iCalendar string.
-func encodeCalendar(cal *ical.Calendar) string {
+// encodeCalendar encodes a calendar object to iCalendar string form.
+//
+// Returns an error wrapping ErrMalformedContent if the go-ical encoder
+// fails. Previously this function silently returned an empty string on
+// encode failure, which led to three distinct forms of data corruption:
+//
+//  1. getEventsBatch misclassified encode failures as "empty iCalendar
+//     data" in the MalformedEventCollector, hiding the real cause.
+//  2. objectsToEvents silently stored Event{Data: ""} in its returned
+//     slice and never checked, letting corrupt events flow into the
+//     sync engine as if they were normal.
+//  3. GetEvent returned a zero-Data Event with err == nil, so callers
+//     believed the fetch had succeeded.
+//
+// All callers now MUST handle the error explicitly. Encode failures
+// should be treated as malformed events — recorded in a collector where
+// one is available, logged where one is not, and the event skipped.
+func encodeCalendar(cal *ical.Calendar) (string, error) {
 	var buf bytes.Buffer
 	enc := ical.NewEncoder(&buf)
 	if err := enc.Encode(cal); err != nil {
-		return ""
+		return "", fmt.Errorf("%w: %w", ErrMalformedContent, err)
 	}
-	return buf.String()
+	return buf.String(), nil
 }
 
 // normalizeStartTime converts a DTSTART property to a normalized UTC string for comparison.

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -16,9 +16,9 @@ import (
 
 func TestEventDedupeKey(t *testing.T) {
 	testCases := []struct {
-		name      string
-		event     Event
-		expected  string
+		name     string
+		event    Event
+		expected string
 	}{
 		{
 			name: "combines summary and start time",
@@ -962,7 +962,10 @@ func TestEncodeCalendar(t *testing.T) {
 			t.Fatalf("failed to parse: %v", err)
 		}
 
-		result := encodeCalendar(cal)
+		result, err := encodeCalendar(cal)
+		if err != nil {
+			t.Fatalf("unexpected encode error: %v", err)
+		}
 		if result == "" {
 			t.Error("expected non-empty result")
 		}
@@ -979,18 +982,27 @@ func TestEncodeCalendar(t *testing.T) {
 		}
 	})
 
-	t.Run("returns empty string when encoding fails", func(t *testing.T) {
-		// Create a calendar missing required DTSTAMP - encoding should fail
+	t.Run("returns ErrMalformedContent when encoding fails", func(t *testing.T) {
+		// Create a calendar missing required DTSTAMP - encoding should fail.
+		// Previously the function silently returned an empty string; now
+		// it must return a wrapped ErrMalformedContent so callers can
+		// classify this as a malformed event.
 		data := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\nBEGIN:VEVENT\r\nUID:test-uid@example.com\r\nDTSTART:20240115T140000Z\r\nSUMMARY:Test Event\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
 
-		cal, err := parseICalendar(data)
-		if err != nil {
-			t.Fatalf("failed to parse: %v", err)
+		cal, parseErr := parseICalendar(data)
+		if parseErr != nil {
+			t.Fatalf("failed to parse: %v", parseErr)
 		}
 
-		result := encodeCalendar(cal)
+		result, err := encodeCalendar(cal)
+		if err == nil {
+			t.Fatal("expected an error when encoding a calendar missing required DTSTAMP, got nil")
+		}
+		if !errors.Is(err, ErrMalformedContent) {
+			t.Errorf("expected wrapped ErrMalformedContent, got %v", err)
+		}
 		if result != "" {
-			t.Error("expected empty string when encoding fails due to missing DTSTAMP")
+			t.Errorf("expected empty string on error, got %q", result)
 		}
 	})
 }
@@ -1558,7 +1570,14 @@ func TestObjectsToEvents(t *testing.T) {
 		}
 	})
 
-	t.Run("converts object without data", func(t *testing.T) {
+	t.Run("skips object with nil data", func(t *testing.T) {
+		// Issue #29 fix: objects with nil Data are silent-corruption
+		// sources and must NOT be returned to the sync engine as
+		// Event{Data: ""}. The previous behavior returned them with
+		// empty Data, which then flowed into PutEvent at call sites
+		// that didn't bother to check event.Data first. Now they
+		// are logged and skipped so the returned slice only contains
+		// events with valid content.
 		objects := []caldav.CalendarObject{
 			{
 				Path: "/calendars/user/default/event1.ics",
@@ -1567,18 +1586,8 @@ func TestObjectsToEvents(t *testing.T) {
 		}
 
 		events := client.objectsToEvents(objects)
-		if len(events) != 1 {
-			t.Fatalf("expected 1 event, got %d", len(events))
-		}
-
-		if events[0].Path != "/calendars/user/default/event1.ics" {
-			t.Errorf("expected path, got %q", events[0].Path)
-		}
-		if events[0].ETag != "etag123" {
-			t.Errorf("expected etag, got %q", events[0].ETag)
-		}
-		if events[0].Data != "" {
-			t.Errorf("expected empty data, got %q", events[0].Data)
+		if len(events) != 0 {
+			t.Fatalf("expected nil-data object to be skipped, got %d events", len(events))
 		}
 	})
 

--- a/internal/caldav/ics_client.go
+++ b/internal/caldav/ics_client.go
@@ -183,10 +183,10 @@ func (c *ICSClient) FetchEvents(ctx context.Context, collector *MalformedEventCo
 			singleCal.Children = append(singleCal.Children, vevent)
 		}
 
-		data := encodeCalendar(singleCal)
-		if data == "" {
+		data, encErr := encodeCalendar(singleCal)
+		if encErr != nil {
 			if collector != nil {
-				collector.Add(uid, "failed to encode event")
+				collector.Add(uid, fmt.Sprintf("failed to encode event: %v", encErr))
 			}
 			continue
 		}


### PR DESCRIPTION
## Summary

Closes #29. Eliminates a silent-data-corruption class of bug in `internal/caldav/client.go:encodeCalendar` and its four call sites.

## The bug

`encodeCalendar` previously returned `string` and silently returned `""` on encoder failure. Four call sites handled this inconsistently — three of them wrong, one only kinda-right:

| Call site | Previous behavior |
|---|---|
| `getEventsBatch` (`client.go:337`) | Misclassified encode failure as "empty data" in the `MalformedEventCollector`, hiding the real cause |
| `objectsToEvents` (`client.go:409`) | **Silently stored `Event{Data: ""}` in the returned slice with no check** — downstream code processed these as valid events |
| `GetEvent` (`client.go:553`) | **Returned `&Event{Data: ""}` with `err == nil`** — callers believed the fetch succeeded |
| `ics_client.go:186` | Had an `if data == ""` check (only safe site), but the empty-string-as-signal pattern is fragile |

The silent-corruption path through `objectsToEvents` was the worst: corrupt events flowed from `getEventsViaQuery` → `GetEvents` → `sync.go`, where they'd hit `PutEvent` and get dropped by the early-return at `client.go:576` (itself a lie — see Issue #I, next PR).

## The fix

### `encodeCalendar` signature change
```go
func encodeCalendar(cal *ical.Calendar) (string, error) {
    var buf bytes.Buffer
    enc := ical.NewEncoder(&buf)
    if err := enc.Encode(cal); err != nil {
        return "", fmt.Errorf("%w: %w", ErrMalformedContent, err)
    }
    return buf.String(), nil
}
```

### Call site updates
1. **`getEventsBatch`** — on nil data: collector entry + `skippedEmpty++`. On encode error: collector entry with real error message + **`skippedMalformed++`** (also fixes one of the two reasons `skippedMalformed` was dead code; the other reason remains Issue #L).
2. **`objectsToEvents`** — logs and skips nil-data OR encode-error entries. Documentation now warns callers that the slice may be shorter than the input. **Removes the silent-corruption path entirely.**
3. **`GetEvent`** — returns `(nil, encErr)` on encode failure so `getEventsIndividually`'s existing malformed detection classifies correctly.
4. **`ics_client.go`** — changed `if data == ""` to `if encErr != nil`, includes error message in collector entry.

## Tests

### `TestEncodeCalendar/round trip encodes parsed calendar`
Updated to unpack `(result, err)` and assert no unexpected error.

### `TestEncodeCalendar/returns ErrMalformedContent when encoding fails`
Renamed from `returns empty string when encoding fails`. Now asserts `errors.Is(err, ErrMalformedContent)` in addition to the empty string return, locking in the error-wrapping contract.

### `TestObjectsToEvents/skips object with nil data`
Renamed from `converts object without data`. The old test was locking in the buggy behavior (returning `Event{Data: ""}` for nil input). The new test asserts the nil-data object is skipped entirely, which is the correct post-fix behavior.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/caldav/...` — all tests pass
- [x] `go test ./...` — full suite green, zero regressions
- [ ] After deploy: monitor the Corrupted Events dashboard card for any "failed to encode event: <reason>" entries — these would previously have been silently lost or misclassified as "empty data"

## Rollback

Three files touched: `client.go`, `client_test.go`, `ics_client.go`. No schema change. No config change. `git revert` removes cleanly.

## Side effect

This PR also fixes one of the two reasons `getEventsBatch`'s `skippedMalformed` counter was dead code (the encode-error path now increments it). The other reason — MULTIGET silently dropping events the library can't parse at all — remains Issue #L and will be a separate PR.

## No conflicts with open PRs

- PR #24 touches `notify.go` and `scheduler.go` — different package
- PR #26 / PR #28 touch `sync.go` — different file
- This PR touches `client.go` and `ics_client.go` — no overlap

Can merge in any order relative to the other open PRs.

## Protected regions (not touched)

- Recurring-events dedup, `normalizeStartTime`, `parseGMTOffset`, `DedupeKey`
- PR #22 `planOrphanDeletion` and call site
- PR #26 `rewriteDeletePathForDestination`
- PR #28 `extractUIDFromEventPath`
- Cross-calendar two-way fix, RRULE filter, ICS UID grouping, ETag comparison, 403/412 handling

## Related follow-ups

- **Issue #I** — `PutEvent` returns `nil` on skip (same file, same silent-failure pattern)
- **Issue #L** — MULTIGET malformed-event detection blind spot

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)