### PR TITLE
fix: PutEvent returns ErrEventSkipped sentinel instead of nil on skip (#31)

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -25,6 +25,13 @@ var (
 	ErrNotFound         = errors.New("resource not found")
 	ErrInvalidResponse  = errors.New("invalid server response")
 	ErrMalformedContent = errors.New("malformed calendar content")
+	// ErrEventSkipped indicates that PutEvent intentionally did NOT write
+	// the event to the destination (empty data, missing UID, etc.). This
+	// is distinct from a connection/auth/write failure. Callers that
+	// treat all non-nil errors as failures will show these events in
+	// warnings, which is wrong — they are skips, not errors. Use
+	// errors.Is(err, ErrEventSkipped) to distinguish.
+	ErrEventSkipped = errors.New("event skipped")
 )
 
 const (
@@ -599,12 +606,25 @@ func (c *Client) GetEvent(ctx context.Context, eventPath string) (*Event, error)
 	return event, nil
 }
 
-// PutEvent creates or updates an event.
+// PutEvent creates or updates an event on the destination calendar.
+//
+// Return values:
+//   - nil: the event was successfully written.
+//   - wrapped ErrEventSkipped: the event was intentionally NOT written
+//     because it had empty data or no extractable UID. Callers should
+//     count these as "skipped" in the sync result, NOT as "created" or
+//     "updated". Use errors.Is(err, ErrEventSkipped) to detect.
+//   - any other non-nil error: a real failure (parse, connection, auth,
+//     write). Callers should surface these in result.Warnings or
+//     result.Errors as appropriate.
 func (c *Client) PutEvent(ctx context.Context, calendarPath string, event *Event) error {
-	// Skip events with empty data
+	// Skip events with empty data. This is NOT a success — we did not
+	// write anything. Previously this returned nil, which made the
+	// caller's `result.Created++` bookkeeping lie.
 	if event.Data == "" {
 		log.Printf("PutEvent: skipping event with empty data (UID: %s, summary: %s)", event.UID, event.Summary)
-		return nil
+		return fmt.Errorf("%w: empty iCalendar data (UID: %s, summary: %s)",
+			ErrEventSkipped, event.UID, event.Summary)
 	}
 
 	// Parse the iCalendar data
@@ -631,9 +651,12 @@ func (c *Client) PutEvent(ctx context.Context, calendarPath string, event *Event
 		if event.UID != "" {
 			path = strings.TrimSuffix(calendarPath, "/") + "/" + event.UID + ".ics"
 		} else {
-			// Skip events without UID - can't create a valid path
+			// Skip events without UID — can't construct a valid path. Same
+			// honesty contract as the empty-data case above: return a
+			// wrapped sentinel so the caller counts this as a skip.
 			log.Printf("PutEvent: skipping event without UID (summary: %s)", event.Summary)
-			return nil
+			return fmt.Errorf("%w: no UID extractable from event data (summary: %s)",
+				ErrEventSkipped, event.Summary)
 		}
 	}
 

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -195,15 +195,16 @@ func TestEventStruct(t *testing.T) {
 
 func TestErrorConstants(t *testing.T) {
 	t.Run("error constants are not nil", func(t *testing.T) {
-		errors := []error{
+		errs := []error{
 			ErrConnectionFailed,
 			ErrAuthFailed,
 			ErrNotFound,
 			ErrInvalidResponse,
 			ErrMalformedContent,
+			ErrEventSkipped,
 		}
 
-		for _, err := range errors {
+		for _, err := range errs {
 			if err == nil {
 				t.Error("expected error constant to be non-nil")
 			}
@@ -219,6 +220,82 @@ func TestErrorConstants(t *testing.T) {
 		}
 		if ErrNotFound.Error() != "resource not found" {
 			t.Errorf("unexpected error message: %q", ErrNotFound.Error())
+		}
+		if ErrEventSkipped.Error() != "event skipped" {
+			t.Errorf("unexpected error message: %q", ErrEventSkipped.Error())
+		}
+	})
+}
+
+// TestPutEventSkipPaths verifies that PutEvent returns a wrapped
+// ErrEventSkipped sentinel (instead of nil) for events that cannot be
+// written due to bad input. This is the Issue #31 fix — previously the
+// two skip paths returned nil, causing callers to falsely increment
+// result.Created / result.Updated and pollute synced_events tracking
+// with UIDs that were never actually written to the destination.
+func TestPutEventSkipPaths(t *testing.T) {
+	// Any URL works here — the short-circuit paths we're testing fire
+	// before any HTTP request is constructed, so the URL is never dialed.
+	client, err := NewClient("https://example.test/cal", "user", "pass")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	t.Run("empty data returns wrapped ErrEventSkipped", func(t *testing.T) {
+		event := &Event{
+			UID:     "some-uid",
+			Summary: "empty data test",
+			Data:    "",
+		}
+
+		putErr := client.PutEvent(context.Background(), "/cal", event)
+		if putErr == nil {
+			t.Fatal("expected error for empty data, got nil — PutEvent is silently skipping (the Issue #31 bug)")
+		}
+		if !errors.Is(putErr, ErrEventSkipped) {
+			t.Errorf("expected wrapped ErrEventSkipped, got %v", putErr)
+		}
+		// The error message should contain context about why the skip happened.
+		if !strings.Contains(putErr.Error(), "empty") {
+			t.Errorf("expected error message to mention 'empty', got %q", putErr.Error())
+		}
+	})
+
+	t.Run("missing UID returns wrapped ErrEventSkipped", func(t *testing.T) {
+		// Valid iCalendar data but no UID property — triggers the second
+		// skip path where PutEvent tries to extract a UID from the parsed
+		// calendar data, fails, and refuses to construct a destination path.
+		data := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nBEGIN:VEVENT\r\nDTSTAMP:20240115T120000Z\r\nDTSTART:20240115T140000Z\r\nSUMMARY:No UID\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+		event := &Event{
+			Summary: "no UID test",
+			Data:    data,
+			// UID and Path deliberately unset
+		}
+
+		putErr := client.PutEvent(context.Background(), "/cal", event)
+		if putErr == nil {
+			t.Fatal("expected error for missing UID, got nil — PutEvent is silently skipping (the Issue #31 bug)")
+		}
+		if !errors.Is(putErr, ErrEventSkipped) {
+			t.Errorf("expected wrapped ErrEventSkipped, got %v", putErr)
+		}
+		if !strings.Contains(putErr.Error(), "UID") {
+			t.Errorf("expected error message to mention 'UID', got %q", putErr.Error())
+		}
+	})
+
+	t.Run("errors.Is distinguishes ErrEventSkipped from other errors", func(t *testing.T) {
+		// Sanity check the errors.Is semantics callers rely on.
+		skipErr := &Event{Data: ""}
+		err := client.PutEvent(context.Background(), "/cal", skipErr)
+		if !errors.Is(err, ErrEventSkipped) {
+			t.Error("errors.Is(err, ErrEventSkipped) should be true for skip errors")
+		}
+		if errors.Is(err, ErrConnectionFailed) {
+			t.Error("errors.Is(err, ErrConnectionFailed) must be false for skip errors — they are not connection failures")
+		}
+		if errors.Is(err, ErrMalformedContent) {
+			t.Error("errors.Is(err, ErrMalformedContent) must be false for skip errors — empty data is not malformed, just absent")
 		}
 	})
 }

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -377,7 +377,14 @@ func (se *SyncEngine) syncCalendar(ctx context.Context, source *db.Source, sourc
 						Data: item.Data,
 					}
 					if err := destClient.PutEvent(ctx, destCalendarPath, event); err != nil {
-						result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to sync event: %v", err))
+						if errors.Is(err, ErrEventSkipped) {
+							// PutEvent refused to write this event (empty data,
+							// missing UID). Count it as skipped rather than
+							// falsely incrementing Updated.
+							result.Skipped++
+						} else {
+							result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to sync event: %v", err))
+						}
 					} else {
 						result.Updated++
 					}
@@ -722,7 +729,15 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 
 			// Create new event on destination
 			if err := destClient.PutEvent(ctx, destCalendarPath, &sourceEvent); err != nil {
-				result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to create event on dest: %v", err))
+				if errors.Is(err, ErrEventSkipped) {
+					// PutEvent refused (empty data, missing UID). Count
+					// it as skipped. Do NOT mark the event as "ours" in
+					// destDedupeMap or currentUIDs since nothing was
+					// actually written to the destination.
+					result.Skipped++
+				} else {
+					result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to create event on dest: %v", err))
+				}
 			} else {
 				result.Created++
 				if dedupeKey != "|" {
@@ -736,7 +751,15 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 			// Update existing event
 			sourceEvent.Path = destEvent.Path
 			if err := destClient.PutEvent(ctx, destCalendarPath, &sourceEvent); err != nil {
-				result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to update event on dest: %v", err))
+				if errors.Is(err, ErrEventSkipped) {
+					// PutEvent refused. Don't add to currentUIDs —
+					// the destination still has the OLD version of
+					// this event, not an updated one, so we should
+					// not track it as freshly synced.
+					result.Skipped++
+				} else {
+					result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to update event on dest: %v", err))
+				}
 			} else {
 				result.Updated++
 				currentUIDs[sourceEvent.UID] = true
@@ -775,11 +798,15 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 				if source.ConflictStrategy == db.ConflictDestWins {
 					destEvent.Path = sourceEvent.Path
 					if err := sourceClient.PutEvent(ctx, calendar.Path, &destEvent); err != nil {
-						if isAlreadyExistsError(err) {
+						switch {
+						case errors.Is(err, ErrEventSkipped):
+							// Source PutEvent refused. Count as skipped.
+							result.Skipped++
+						case isAlreadyExistsError(err):
 							skippedAlreadyExists++
-						} else if isForbiddenError(err) {
+						case isForbiddenError(err):
 							skippedForbidden++
-						} else {
+						default:
 							result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to update event on source: %v", err))
 						}
 					} else {


### PR DESCRIPTION
## Summary

Closes #31. **Stacks on PR #30** (Issue #29). Eliminates a silent-success class of bug where `PutEvent` returned `nil` when it refused to write an event, tricking callers into incrementing `result.Created` / `result.Updated` and polluting `synced_events` tracking with ghost UIDs.

## The bug

`PutEvent` had two skip paths that returned `nil`:

```go
// Skip 1: empty data (client.go:605-608)
if event.Data == "" {
    log.Printf("PutEvent: skipping event with empty data ...")
    return nil
}

// Skip 2: no UID (client.go:633-637)
if event.UID != "" {
    path = strings.TrimSuffix(calendarPath, "/") + "/" + event.UID + ".ics"
} else {
    log.Printf("PutEvent: skipping event without UID ...")
    return nil
}
```

All four call sites in `sync.go` treated `err == nil` as "event was written":

```go
if err := destClient.PutEvent(ctx, destCalendarPath, event); err != nil {
    result.Warnings = append(...)
} else {
    result.Created++              // ← LIE if PutEvent skipped
    destDedupeMap[dedupeKey] = true  // ← destination doesn't actually have this
    currentUIDs[sourceEvent.UID] = true  // ← ghost UID
}
```

Consequences:
- Dashboard shows inflated `Created` / `Updated` counts
- `synced_events` table accumulates UIDs for events that were never actually written
- PR #22's ownership filter (for one-way orphan deletion) uses `previouslySyncedMap` built from `synced_events` — so it would later try to "orphan-delete" events that don't exist on the destination, generating confusing warnings
- Users have no way to know which events actually made it

## The fix

### `internal/caldav/client.go`

1. **New sentinel error** in the var block:
   ```go
   ErrEventSkipped = errors.New("event skipped")
   ```

2. **Empty-data path** now returns a wrapped sentinel with context:
   ```go
   return fmt.Errorf("%w: empty iCalendar data (UID: %s, summary: %s)",
       ErrEventSkipped, event.UID, event.Summary)
   ```

3. **Missing-UID path** same treatment:
   ```go
   return fmt.Errorf("%w: no UID extractable from event data (summary: %s)",
       ErrEventSkipped, event.Summary)
   ```

4. **Doc comment** on `PutEvent` now documents the three-way return contract: `nil` = written, `ErrEventSkipped` = refused, anything else = real failure.

### `internal/caldav/sync.go` — 4 call sites, same pattern

```go
if err := destClient.PutEvent(...); err != nil {
    if errors.Is(err, ErrEventSkipped) {
        result.Skipped++
    } else {
        result.Warnings = append(result.Warnings, ...)
    }
} else {
    result.Created++  // or Updated++
    // ... bookkeeping (destDedupeMap, currentUIDs) ...
}
```

**Critical**: the skip branch does NOT add to `currentUIDs` or `destDedupeMap`. Previously the `nil` return meant these bookkeeping structures got polluted with UIDs for events that were never written.

The 4 call sites:

1. **`sync.go:379`** (WebDAV-Sync Changed loop) — skips count as `Skipped++` instead of `Updated++`
2. **`sync.go:731`** (fullSync: create new event on destination) — skips count as `Skipped++` instead of `Created++`, and the `destDedupeMap`/`currentUIDs` bookkeeping is skipped too
3. **`sync.go:745`** (fullSync: update existing event on destination) — skips count as `Skipped++` instead of `Updated++`; `currentUIDs` bookkeeping skipped because the destination still has the OLD version, not an updated one
4. **`sync.go:784`** (fullSync: two-way put to source) — `ErrEventSkipped` is now a first-class case in the error switch alongside `isAlreadyExistsError` and `isForbiddenError`

## Tests

### `TestErrorConstants` — updated
Added `ErrEventSkipped` to the nil-check loop and the error-message assertions.

### `TestPutEventSkipPaths` — new, 3 subtests
- `empty data returns wrapped ErrEventSkipped` — verifies the first skip path returns a wrapped sentinel mentioning "empty"
- `missing UID returns wrapped ErrEventSkipped` — verifies the second skip path with valid iCal data but no `UID` property returns a wrapped sentinel mentioning "UID"
- `errors.Is distinguishes ErrEventSkipped from other errors` — sanity-checks the `errors.Is` semantics callers rely on: `ErrEventSkipped` matches, `ErrConnectionFailed` and `ErrMalformedContent` do not

Tests use `https://example.test/cal` as the client URL because both skip paths short-circuit before any HTTP request is constructed, so the URL is never dialed.

## Behavior change (for the 3 production users)

- `Created` / `Updated` counts on the dashboard will drop slightly if you had invisible skips before
- A new `Skipped` count will rise correspondingly
- Totals will match the truth instead of an over-count
- Sync log details will now include skip reasons for events that `PutEvent` couldn't write
- `synced_events` table entries will no longer accumulate ghost UIDs, which means PR #22's ownership filter gets cleaner inputs

If a user was previously seeing "42 created today", that might become "38 created, 4 skipped today". The underlying reality is unchanged.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/caldav/...` — all new + existing tests pass
- [x] `go test ./...` — full suite green
- [ ] After deploy: check the dashboard for any new `Skipped` counts that correlate with previously-invisible `Created` / `Updated` totals
- [ ] After deploy: check sync log details for skip reasons (events with missing UIDs, events with empty data)

## Rollback

Three files touched (2 production, 1 test). `git revert` removes cleanly. No schema change. No config change.

## Base branch

This PR's base is `fix/29-encode-calendar-error-propagation` (PR #30), **not** `main`, because both PRs modify `client.go` in the same region and PR #30 introduces `ErrMalformedContent`-wrapping patterns that PR #31 mirrors for `ErrEventSkipped`. Merge order must be PR #30 first, then PR #31. GitHub will auto-retarget PR #31 to `main` when PR #30 merges.

## Protected regions (not touched)

- PR #22 `planOrphanDeletion` (this PR improves its inputs by fixing `currentUIDs` pollution, doesn't modify the helper itself)
- PR #26 `rewriteDeletePathForDestination`
- PR #28 `extractUIDFromEventPath`
- PR #30 `encodeCalendar` signature change
- Recurring events dedup, cross-calendar two-way fix, RRULE filter, ICS UID grouping, ETag comparison, 403/412 handling

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)