### PR TITLE
fix: add panic recovery to scheduler + health background goroutines (#37)

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log"
 	"net/http"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -87,36 +89,44 @@ func (c *Checker) Check(ctx context.Context) *Report {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 
-	// Database check
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		check := c.checkDatabase(ctx)
-		mu.Lock()
-		report.Checks["database"] = check
-		mu.Unlock()
-	}()
-
-	// OIDC check
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		check := c.checkOIDC(ctx)
-		mu.Lock()
-		report.Checks["oidc"] = check
-		mu.Unlock()
-	}()
-
-	// CalDAV check (optional)
-	if c.caldavURL != "" {
+	// runCheck launches a health check in a panic-safe goroutine. If the
+	// check function panics, the panic is recovered, logged with a stack
+	// trace, AND the report entry is populated with a synthetic
+	// "Unhealthy" check so the HTTP caller sees a degraded status for
+	// that component instead of a missing key (which downstream code
+	// might misinterpret as "not checked"). Without this recovery, a
+	// panic in one check would bypass wg.Done(), leaving wg.Wait()
+	// hung forever and eventually exhausting the HTTP server's
+	// goroutine pool — a single malformed /health request would
+	// become a DoS vector.
+	runCheck := func(name string, fn func(context.Context) Check) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			check := c.checkCalDAV(ctx)
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[PANIC] health.check.%s: %v\n%s", name, r, debug.Stack())
+					mu.Lock()
+					report.Checks[name] = Check{
+						Name:    name,
+						Status:  StatusUnhealthy,
+						Message: fmt.Sprintf("check panicked: %v", r),
+					}
+					mu.Unlock()
+				}
+			}()
+
+			check := fn(ctx)
 			mu.Lock()
-			report.Checks["caldav"] = check
+			report.Checks[name] = check
 			mu.Unlock()
 		}()
+	}
+
+	runCheck("database", c.checkDatabase)
+	runCheck("oidc", c.checkOIDC)
+	if c.caldavURL != "" {
+		runCheck("caldav", c.checkCalDAV)
 	}
 
 	wg.Wait()

--- a/internal/health/health_panic_test.go
+++ b/internal/health/health_panic_test.go
@@ -1,0 +1,67 @@
+package health
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCheck_RecoversFromPanicInCheckFunction verifies Issue #37's core
+// contract for health: if a check function panics (e.g. nil pointer
+// dereference on an uninitialized db handle), the Check method must
+// recover, populate the report with a synthetic "Unhealthy" entry for
+// that check, AND allow the other checks to complete normally.
+//
+// Setup: construct a Checker with db=nil. checkDatabase's first line
+// calls c.db.Ping() which triggers a nil pointer panic immediately.
+// If recovery is broken, either the whole test binary crashes OR
+// wg.Wait() hangs forever and the test times out.
+func TestCheck_RecoversFromPanicInCheckFunction(t *testing.T) {
+	// Checker with nil db — database check will panic. OIDC issuer is
+	// empty so the OIDC check returns a "degraded" status quickly and
+	// safely. CalDAV URL is empty so that check is skipped entirely.
+	c := &Checker{
+		db:         nil,
+		oidcIssuer: "",
+		caldavURL:  "",
+	}
+
+	// Bound the test so it can't hang even if the recovery is broken.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan *Report, 1)
+	go func() {
+		done <- c.Check(ctx)
+	}()
+
+	select {
+	case report := <-done:
+		// Database check must have a synthetic unhealthy entry from
+		// the recover path.
+		dbCheck, ok := report.Checks["database"]
+		if !ok {
+			t.Fatal("expected database entry in report.Checks even on panic")
+		}
+		if dbCheck.Status != StatusUnhealthy {
+			t.Errorf("expected database Status=%q on panic, got %q", StatusUnhealthy, dbCheck.Status)
+		}
+		if !strings.Contains(dbCheck.Message, "panic") {
+			t.Errorf("expected database Message to mention panic, got %q", dbCheck.Message)
+		}
+
+		// The OIDC check should still have completed normally.
+		oidcCheck, ok := report.Checks["oidc"]
+		if !ok {
+			t.Fatal("expected oidc entry in report.Checks; a panic in one check must not prevent others from completing")
+		}
+		// Empty issuer → degraded
+		if oidcCheck.Status != StatusDegraded {
+			t.Errorf("expected oidc Status=%q for empty issuer, got %q", StatusDegraded, oidcCheck.Status)
+		}
+
+	case <-time.After(3 * time.Second):
+		t.Fatal("Check() did not return within 3s; panic recovery must be broken and wg.Wait() is hanging")
+	}
+}

--- a/internal/scheduler/safe.go
+++ b/internal/scheduler/safe.go
@@ -1,0 +1,33 @@
+package scheduler
+
+import (
+	"log"
+	"runtime/debug"
+)
+
+// recoverPanic logs a panic with its stack trace. Call it as a deferred
+// function at the top of any goroutine — before any other deferred work
+// that must still run — to prevent a runtime panic from crashing the
+// daemon or silently killing a long-running background service.
+//
+// Usage:
+//
+//	func (s *Scheduler) runJob(job *Job) {
+//	    defer s.wg.Done()
+//	    defer recoverPanic("scheduler.runJob")
+//	    // ... body ...
+//	}
+//
+// Go runs deferred functions in LIFO order, so the recoverPanic defer
+// should be placed AFTER the wg.Done defer — that way recoverPanic runs
+// first (catching the panic) and then wg.Done runs (advancing the
+// WaitGroup), so the caller's wg.Wait() isn't left hanging forever.
+//
+// The name parameter identifies the goroutine in the log output so
+// operators can find the source of a crash quickly. Use a dotted
+// "package.function" convention to match the runtime stack format.
+func recoverPanic(name string) {
+	if r := recover(); r != nil {
+		log.Printf("[PANIC] %s: %v\n%s", name, r, debug.Stack())
+	}
+}

--- a/internal/scheduler/safe_test.go
+++ b/internal/scheduler/safe_test.go
@@ -1,0 +1,100 @@
+package scheduler
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestRecoverPanic_RecoversAndDoesNotPropagate verifies the core
+// contract of the recoverPanic helper: a deferred call recovers any
+// panic that escapes the goroutine body, preventing it from crashing
+// the process.
+func TestRecoverPanic_RecoversAndDoesNotPropagate(t *testing.T) {
+	// This test would fail (crash the test binary) if recoverPanic
+	// did not actually recover. The absence of a crash is the pass
+	// condition.
+	done := false
+	func() {
+		defer func() {
+			// If recoverPanic failed to catch the panic, our own
+			// recover here would see it. The test would still
+			// technically pass but the assertion below would never
+			// run, so we guard with a secondary check.
+			if r := recover(); r != nil {
+				t.Errorf("panic escaped recoverPanic: %v", r)
+			}
+		}()
+		defer recoverPanic("test.doesNotPropagate")
+		panic("expected test panic")
+	}()
+	done = true
+	if !done {
+		t.Error("recoverPanic did not allow the deferred-wrapped call to complete")
+	}
+}
+
+// TestRecoverPanic_WaitGroupAdvances verifies that when recoverPanic is
+// paired with a deferred wg.Done(), the WaitGroup advances even if the
+// body panics. This is the critical contract for scheduler goroutines —
+// without wg.Done() advancing, the graceful-shutdown wg.Wait() would
+// hang forever.
+func TestRecoverPanic_WaitGroupAdvances(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer recoverPanic("test.wgAdvances")
+		panic("expected test panic in wg scenario")
+	}()
+
+	// wg.Wait() should return quickly. If recoverPanic were broken,
+	// this would block forever and the test would time out.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success — wg.Wait returned, meaning wg.Done() executed
+		// despite the panic in the body.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("wg.Wait did not return; recoverPanic did not let wg.Done advance after panic")
+	}
+}
+
+// TestRecoverPanic_NoopOnNormalReturn verifies the no-panic happy path:
+// recoverPanic should do nothing visible when the body returns normally.
+func TestRecoverPanic_NoopOnNormalReturn(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ranToCompletion := false
+	go func() {
+		defer wg.Done()
+		defer recoverPanic("test.noopNormal")
+		ranToCompletion = true
+	}()
+	wg.Wait()
+	if !ranToCompletion {
+		t.Error("goroutine body did not execute to completion in the no-panic path")
+	}
+}
+
+// TestRecoverPanic_NilPointerDereference verifies recovery from a real
+// runtime panic (nil map access), not just an explicit panic() call.
+// This is the more realistic crash mode in production code.
+func TestRecoverPanic_NilPointerDereference(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer recoverPanic("test.nilDeref")
+		var m map[string]int
+		m["key"] = 1 // panic: assignment to entry in nil map
+	}()
+	wg.Wait()
+	// Passing this test means the runtime panic was caught. No further
+	// assertion needed — the absence of a crash is the pass condition.
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -12,12 +12,12 @@ import (
 )
 
 const (
-	cleanupInterval     = 24 * time.Hour
-	logRetentionDays    = 30
-	syncTimeout         = 120 * time.Minute // Maximum time for a single sync operation (2 hours for slow iCloud with multiple calendars)
-	healthLogInterval   = 5 * time.Minute   // Interval for scheduler health logging
-	staleMultiplier     = 2                 // Source is stale if last sync > staleMultiplier * interval
-	startupStagger      = 30 * time.Second  // Delay between starting each source's first sync
+	cleanupInterval   = 24 * time.Hour
+	logRetentionDays  = 30
+	syncTimeout       = 120 * time.Minute // Maximum time for a single sync operation (2 hours for slow iCloud with multiple calendars)
+	healthLogInterval = 5 * time.Minute   // Interval for scheduler health logging
+	staleMultiplier   = 2                 // Source is stale if last sync > staleMultiplier * interval
+	startupStagger    = 30 * time.Second  // Delay between starting each source's first sync
 )
 
 // Job represents a scheduled sync job.
@@ -250,6 +250,7 @@ func (s *Scheduler) TriggerSync(sourceID string) {
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
+		defer recoverPanic("scheduler.TriggerSync")
 		s.executeSync(sourceID)
 	}()
 }
@@ -264,6 +265,7 @@ func (s *Scheduler) GetJobCount() int {
 // runJob runs the sync job loop.
 func (s *Scheduler) runJob(job *Job) {
 	defer s.wg.Done()
+	defer recoverPanic("scheduler.runJob")
 
 	// Run immediately on start
 	s.executeSync(job.sourceID)
@@ -286,6 +288,7 @@ func (s *Scheduler) runJob(job *Job) {
 // Used when updating interval - does NOT run immediately.
 func (s *Scheduler) runJobFromTicker(job *Job) {
 	defer s.wg.Done()
+	defer recoverPanic("scheduler.runJobFromTicker")
 
 	for {
 		select {
@@ -303,6 +306,7 @@ func (s *Scheduler) runJobFromTicker(job *Job) {
 // runJobWithDelay runs the sync job loop with an initial delay.
 func (s *Scheduler) runJobWithDelay(job *Job, initialDelay time.Duration) {
 	defer s.wg.Done()
+	defer recoverPanic("scheduler.runJobWithDelay")
 
 	// Wait for initial delay before first sync
 	if initialDelay > 0 {
@@ -415,6 +419,7 @@ func (s *Scheduler) executeSync(sourceID string) {
 // cleanupRoutine runs periodic cleanup of old sync logs.
 func (s *Scheduler) cleanupRoutine() {
 	defer s.wg.Done()
+	defer recoverPanic("scheduler.cleanupRoutine")
 
 	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
@@ -445,6 +450,7 @@ func (s *Scheduler) cleanupOldLogs() {
 // healthLogRoutine periodically logs scheduler health information.
 func (s *Scheduler) healthLogRoutine() {
 	defer s.wg.Done()
+	defer recoverPanic("scheduler.healthLogRoutine")
 
 	ticker := time.NewTicker(healthLogInterval)
 	defer ticker.Stop()
@@ -471,6 +477,7 @@ func (s *Scheduler) logHealth() {
 // staleDetectionRoutine periodically checks for stale sources and logs warnings.
 func (s *Scheduler) staleDetectionRoutine() {
 	defer s.wg.Done()
+	defer recoverPanic("scheduler.staleDetectionRoutine")
 
 	// Check every minute for stale sources
 	ticker := time.NewTicker(1 * time.Minute)


### PR DESCRIPTION
## Summary

Closes #37. `rg 'recover()' internal/` returned **zero results**. Every background goroutine in the service was unprotected. A panic in any long-running scheduler routine would silently kill sync (daemon appears healthy, does nothing). A panic in a health check would hang the HTTP handler's `wg.Wait()` forever — turning `/health` into a DoS vector.

This PR adds panic recovery to all known goroutines in `scheduler` and `health` packages. `notify.go` is out of scope because it conflicts with open PR #24 / PR #34 — follow-up issue.

## Scheduler changes

**New file `internal/scheduler/safe.go`** — 10-line helper:

```go
func recoverPanic(name string) {
    if r := recover(); r != nil {
        log.Printf("[PANIC] %s: %v\n%s", name, r, debug.Stack())
    }
}
```

Applied as a top-level defer in each goroutine entry function:

```go
func (s *Scheduler) runJob(job *Job) {
    defer s.wg.Done()                          // runs LAST (advances WaitGroup)
    defer recoverPanic("scheduler.runJob")     // runs FIRST (catches panic)
    // ... existing body ...
}
```

Go's LIFO defer order matters here: `recoverPanic` must defer AFTER `wg.Done()` so it runs FIRST. That way the WaitGroup advances even when the body panics — otherwise `Stop()`'s graceful-shutdown `wg.Wait()` would hang forever.

**7 goroutine entry points wired**:
- `runJob`
- `runJobFromTicker`
- `runJobWithDelay`
- `cleanupRoutine`
- `healthLogRoutine`
- `staleDetectionRoutine`
- `TriggerSync` (inline anonymous goroutine)

## Health changes

The 3 check goroutines in `Check()` used a shared `sync.WaitGroup` but did not recover. Refactored into a local `runCheck` closure that handles wg + mu + recover + degraded-entry recording in one place:

```go
runCheck := func(name string, fn func(context.Context) Check) {
    wg.Add(1)
    go func() {
        defer wg.Done()
        defer func() {
            if r := recover(); r != nil {
                log.Printf("[PANIC] health.check.%s: %v\n%s", name, r, debug.Stack())
                mu.Lock()
                report.Checks[name] = Check{
                    Name:    name,
                    Status:  StatusUnhealthy,
                    Message: fmt.Sprintf("check panicked: %v", r),
                }
                mu.Unlock()
            }
        }()
        check := fn(ctx)
        mu.Lock()
        report.Checks[name] = check
        mu.Unlock()
    }()
}

runCheck("database", c.checkDatabase)
runCheck("oidc", c.checkOIDC)
if c.caldavURL != "" {
    runCheck("caldav", c.checkCalDAV)
}
```

The recovery is an inline closure (not the scheduler's top-level helper) because it shares `wg`, `mu`, and `report` with the caller and must record a degraded-check entry, not just log. On panic, the HTTP caller sees `Status: Unhealthy` + `Message: "check panicked: <r>"` for that component instead of a missing key.

## Tests (all pass, race detector clean)

### `internal/scheduler/safe_test.go` — 4 tests
- **`TestRecoverPanic_RecoversAndDoesNotPropagate`** — explicit panic caught
- **`TestRecoverPanic_WaitGroupAdvances`** — wg.Done still runs after panic; bounded by `time.After` select so a broken recovery times out fast instead of hanging
- **`TestRecoverPanic_NoopOnNormalReturn`** — happy path still works
- **`TestRecoverPanic_NilPointerDereference`** — **real runtime panic** (nil map assignment), not just an explicit `panic()` call. More realistic crash mode.

### `internal/health/health_panic_test.go` — 1 test
- **`TestCheck_RecoversFromPanicInCheckFunction`** — constructs `Checker{db: nil}`, which makes `checkDatabase` panic on its first line (`c.db.Ping()` dereferences nil). Verifies:
  - `Check()` returns (no hang)
  - `report.Checks["database"].Status == StatusUnhealthy`
  - Message mentions "panic"
  - `report.Checks["oidc"]` still populated (other checks completed normally)
  - Bounded by `time.After` so a broken recovery can't hang the test suite

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/scheduler/...` — all new + existing pass
- [x] `go test ./internal/health/...` — all new + existing pass
- [x] `go test ./...` — full suite green
- [x] `go test -race ./internal/scheduler/... ./internal/health/...` — **race detector clean**
- [ ] After deploy: verify `[PANIC]` log lines appear if any goroutine crashes (should be none in normal operation)
- [ ] After deploy: deliberately crash a sync by feeding it malformed data, verify scheduler keeps running

## Behavior change

Under normal operation: zero behavior change. Recovery only engages when there's a real panic.

In a crash scenario: previously, a scheduler panic would silently kill the background service (scheduler stops ticking, daemon keeps running) OR crash the daemon entirely. Now, panics are logged with `[PANIC] scheduler.<routine>: <reason>` + full stack trace, and the goroutine exits cleanly. **The next scheduler tick still won't run** (because the goroutine is dead), but at least the user gets a clear signal in the logs and the rest of the daemon stays healthy. A follow-up issue will wire a "goroutine panicked" counter into the failure alert path so this becomes fire-an-alert-worthy.

For the health endpoint: a panic in one check no longer hangs the other checks or the HTTP handler. The caller sees `{"checks": {"database": {"status": "unhealthy", "message": "check panicked: ..."}, "oidc": {"status": "healthy", ...}}}` instead of a hung request.

## Rollback

5 files touched (2 production edits, 1 new helper file, 2 new test files). `git revert` removes cleanly. No schema change. No config change. Branched from `main` — no conflicts with any open PR.

## Explicitly NOT in scope

- **`internal/notify/notify.go` goroutines** — there are 4 of them (`SendStaleAlert` and `SendStaleAlertWithPrefs` plus their recovery variants, and PR #24's new failure alert goroutine). They need panic recovery too, but touching notify.go now conflicts with PR #24 and PR #34. Will be a follow-up issue after those merge.
- **Test-only goroutines** in `scheduler_test.go` — left bare intentionally. Test panics should surface as test failures, not be recovered silently.
- **Metric/alert on "goroutine panicked"** — useful future work but needs a metrics infrastructure that doesn't exist yet.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)