### PR TITLE
feat: retry webhook + email sends on transient failures with exponential backoff (#39)

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -313,7 +313,7 @@ func (n *Notifier) send(ctx context.Context, alert Alert) {
 		}
 
 		if len(recipients) > 0 {
-			if err := n.sendEmail(alert, recipients); err != nil {
+			if err := n.sendEmail(ctx, alert, recipients); err != nil {
 				log.Printf("[Notify] Email error: %v", err)
 			}
 		}
@@ -333,7 +333,9 @@ type WebhookPayload struct {
 }
 
 func (n *Notifier) sendWebhook(ctx context.Context, alert Alert) error {
-	// Build Slack-compatible message
+	// Build Slack-compatible message.
+	// Idempotent setup lives outside the retry: re-marshaling the same
+	// payload every attempt is wasted work.
 	emoji := ""
 	switch alert.Type {
 	case AlertTypeStale:
@@ -359,28 +361,34 @@ func (n *Notifier) sendWebhook(ctx context.Context, alert Alert) error {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", n.cfg.WebhookURL, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
+	// Retry the HTTP call itself on transient failures (DNS, TCP, TLS,
+	// 5xx). Permanent errors (4xx, request construction) fall through
+	// immediately — see isTransientHTTPError for the full taxonomy.
+	return retryTransient(ctx, defaultMaxSendAttempts, func(ctx context.Context) error {
+		req, err := http.NewRequestWithContext(ctx, "POST", n.cfg.WebhookURL, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
 
-	resp, err := n.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("send request: %w", err)
-	}
-	defer resp.Body.Close()
+		resp, err := n.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("send request: %w", err)
+		}
+		defer resp.Body.Close()
 
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
-	}
+		if resp.StatusCode >= 400 {
+			return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+		}
 
-	log.Printf("[Notify] Webhook sent: %s", alert.Message)
-	return nil
+		log.Printf("[Notify] Webhook sent: %s", alert.Message)
+		return nil
+	}, isTransientHTTPError)
 }
 
-func (n *Notifier) sendEmail(alert Alert, recipients []string) error {
-	// Sanitize user-controlled inputs to prevent email header injection
+func (n *Notifier) sendEmail(ctx context.Context, alert Alert, recipients []string) error {
+	// Sanitize user-controlled inputs to prevent email header injection.
+	// This is idempotent setup and stays outside the retry.
 	sanitizedSourceName := sanitizeForEmail(alert.SourceName)
 	sanitizedMessage := sanitizeForEmail(alert.Message)
 	sanitizedDetails := sanitizeForEmail(alert.Details)
@@ -408,19 +416,30 @@ func (n *Notifier) sendEmail(alert Alert, recipients []string) error {
 		auth = smtp.PlainAuth("", n.cfg.SMTPUsername, n.cfg.SMTPPassword, n.cfg.SMTPHost)
 	}
 
-	var err error
-	if n.cfg.SMTPTLS {
-		err = n.sendEmailTLS(addr, auth, n.cfg.SMTPFrom, recipients, []byte(msg))
-	} else {
-		err = smtp.SendMail(addr, auth, n.cfg.SMTPFrom, recipients, []byte(msg))
-	}
-
-	if err != nil {
-		return fmt.Errorf("send email: %w", err)
-	}
-
-	log.Printf("[Notify] Email sent to %d recipients: %s", len(recipients), sanitizedMessage)
-	return nil
+	// Retry transient SMTP failures. SMTP errors are mostly transient
+	// (connection drops, TLS hiccups, temporary server rejection) and
+	// the isTransientSMTPError classifier is intentionally permissive —
+	// the outer cooldown loop (PR #34) will eventually give up on
+	// persistently broken destinations by not retrying for another
+	// full cooldown window.
+	//
+	// Context is honored during backoff sleeps via retryTransient.
+	// Note: the stdlib smtp.SendMail itself does not take a context,
+	// so a mid-attempt cancellation only affects the sleep between
+	// attempts, not the send in progress.
+	return retryTransient(ctx, defaultMaxSendAttempts, func(ctx context.Context) error {
+		var err error
+		if n.cfg.SMTPTLS {
+			err = n.sendEmailTLS(addr, auth, n.cfg.SMTPFrom, recipients, []byte(msg))
+		} else {
+			err = smtp.SendMail(addr, auth, n.cfg.SMTPFrom, recipients, []byte(msg))
+		}
+		if err != nil {
+			return fmt.Errorf("send email: %w", err)
+		}
+		log.Printf("[Notify] Email sent to %d recipients: %s", len(recipients), sanitizedMessage)
+		return nil
+	}, isTransientSMTPError)
 }
 
 // sendEmailTLS sends email over TLS (for port 465).
@@ -779,7 +798,7 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 
 		if len(recipients) > 0 {
 			anyAttempted = true
-			if err := n.sendEmail(alert, recipients); err != nil {
+			if err := n.sendEmail(ctx, alert, recipients); err != nil {
 				log.Printf("[Notify] Email error: %v", err)
 			} else {
 				anyDelivered = true
@@ -799,12 +818,14 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 
 // sendWebhookToURL sends a webhook to a specific URL (for user webhooks).
 func (n *Notifier) sendWebhookToURL(ctx context.Context, alert Alert, webhookURL string) error {
-	// Validate URL before sending (security check)
+	// Validate URL before sending (security check). Validation failures
+	// are permanent — no point retrying a URL that will never pass.
 	if err := validateWebhookURL(webhookURL); err != nil {
 		return fmt.Errorf("invalid webhook URL: %w", err)
 	}
 
-	// Build Slack-compatible message
+	// Build Slack-compatible message. Idempotent setup stays outside
+	// the retry.
 	emoji := ""
 	switch alert.Type {
 	case AlertTypeStale:
@@ -830,24 +851,26 @@ func (n *Notifier) sendWebhookToURL(ctx context.Context, alert Alert, webhookURL
 		return fmt.Errorf("marshal payload: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", webhookURL, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
+	return retryTransient(ctx, defaultMaxSendAttempts, func(ctx context.Context) error {
+		req, err := http.NewRequestWithContext(ctx, "POST", webhookURL, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
 
-	resp, err := n.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("send request: %w", err)
-	}
-	defer resp.Body.Close()
+		resp, err := n.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("send request: %w", err)
+		}
+		defer resp.Body.Close()
 
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
-	}
+		if resp.StatusCode >= 400 {
+			return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+		}
 
-	log.Printf("[Notify] User webhook sent: %s", alert.Message)
-	return nil
+		log.Printf("[Notify] User webhook sent: %s", alert.Message)
+		return nil
+	}, isTransientHTTPError)
 }
 
 // SendTestWebhook sends a test message to a webhook URL.

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -75,7 +75,11 @@ type Notifier struct {
 	cfg        *Config
 	httpClient *http.Client
 
-	// Track last alert time per source to implement cooldown
+	// Track last SUCCESSFUL alert time per source to implement cooldown.
+	// Previously this was set BEFORE the background send fired, so a
+	// failed send still consumed the cooldown window. Since Issue #33,
+	// the timestamp is recorded only after sendWithPrefs confirms at
+	// least one channel delivered.
 	mu             sync.RWMutex
 	lastAlertTimes map[string]time.Time
 	staleState     map[string]bool // Track if source is currently in stale state
@@ -84,6 +88,14 @@ type Notifier struct {
 	// source that is both stale and failing doesn't lose one signal because
 	// the other already consumed the cooldown window.
 	lastFailureAlertTimes map[string]time.Time
+
+	// inFlightAlerts tracks sends that have been queued but not yet
+	// completed, keyed by sourceID. Prevents duplicate alerts when
+	// concurrent callers both see "no cooldown set" and both try to
+	// fire. The flag is set synchronously in the Send* method and
+	// cleared inside the background goroutine after sendWithPrefs
+	// returns, regardless of delivery success.
+	inFlightAlerts map[string]bool
 }
 
 // New creates a new Notifier.
@@ -96,6 +108,7 @@ func New(cfg *Config) *Notifier {
 		lastAlertTimes:        make(map[string]time.Time),
 		staleState:            make(map[string]bool),
 		lastFailureAlertTimes: make(map[string]time.Time),
+		inFlightAlerts:        make(map[string]bool),
 	}
 }
 
@@ -462,11 +475,14 @@ func (n *Notifier) sendEmailTLS(addr string, auth smtp.Auth, from string, to []s
 }
 
 // ClearStaleState clears the stale state for a source (used on source deletion).
+// Also clears any in-flight stale alert guard so a new source reusing the
+// same ID starts with a clean slate.
 func (n *Notifier) ClearStaleState(sourceID string) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	delete(n.staleState, sourceID)
 	delete(n.lastAlertTimes, sourceID)
+	delete(n.inFlightAlerts, "stale:"+sourceID)
 }
 
 // GetStaleSourceIDs returns a list of currently stale source IDs.
@@ -485,23 +501,46 @@ func (n *Notifier) GetStaleSourceIDs() []string {
 
 // SendStaleAlertWithPrefs sends an alert for a stale source using per-user preferences.
 // userPrefs can be nil to use global defaults only.
+//
+// Since Issue #33, the cooldown timestamp is recorded only AFTER the
+// background send reports successful delivery. Previously it was set
+// synchronously before the goroutine fired, which meant a failed send
+// consumed the cooldown and the user got zero alerts for the entire
+// cooldown period on a broken alert endpoint.
+//
+// To prevent concurrent duplicate sends (two callers both seeing no
+// cooldown and both firing), an inFlightAlerts guard suppresses overlap
+// while a previous send is still in-flight.
 func (n *Notifier) SendStaleAlertWithPrefs(ctx context.Context, sourceID, sourceName, userEmail string, timeSinceSync, threshold time.Duration, userPrefs *UserPreferences) bool {
 	cooldown := n.getCooldownPeriod(userPrefs)
 
-	n.mu.Lock()
-	defer n.mu.Unlock()
+	// inFlightAlerts is keyed by "{type}:{sourceID}" so stale and failure
+	// alerts have independent in-flight slots and can fire concurrently
+	// for the same source.
+	inFlightKey := "stale:" + sourceID
 
-	// Check if already in stale state and in cooldown
+	n.mu.Lock()
+
+	// Check if already in stale state and in cooldown. lastAlertTimes
+	// now reflects the last SUCCESSFUL delivery, so a failed prior send
+	// won't block this one.
 	if n.staleState[sourceID] {
-		lastAlert, exists := n.lastAlertTimes[sourceID]
-		if exists && time.Since(lastAlert) < cooldown {
+		if lastAlert, exists := n.lastAlertTimes[sourceID]; exists && time.Since(lastAlert) < cooldown {
+			n.mu.Unlock()
 			return false // Still in cooldown
 		}
 	}
 
-	// Mark as stale and update alert time
+	// Deduplication: if a stale alert for this source is already in
+	// flight, suppress this one to avoid two concurrent sends.
+	if n.inFlightAlerts[inFlightKey] {
+		n.mu.Unlock()
+		return false
+	}
+	n.inFlightAlerts[inFlightKey] = true
 	n.staleState[sourceID] = true
-	n.lastAlertTimes[sourceID] = time.Now()
+
+	n.mu.Unlock()
 
 	alert := Alert{
 		Type:       AlertTypeStale,
@@ -513,8 +552,18 @@ func (n *Notifier) SendStaleAlertWithPrefs(ctx context.Context, sourceID, source
 		Timestamp:  time.Now(),
 	}
 
-	// Send in background to not block
-	go n.sendWithPrefs(ctx, alert, userPrefs)
+	// Send in background so the scheduler tick isn't blocked by SMTP
+	// or webhook latency. The cooldown is recorded inside the goroutine
+	// only if sendWithPrefs reports that at least one channel delivered.
+	go func() {
+		delivered := n.sendWithPrefs(ctx, alert, userPrefs)
+		n.mu.Lock()
+		delete(n.inFlightAlerts, inFlightKey)
+		if delivered {
+			n.lastAlertTimes[sourceID] = time.Now()
+		}
+		n.mu.Unlock()
+	}()
 	return true
 }
 
@@ -563,28 +612,43 @@ func (n *Notifier) getCooldownPeriod(userPrefs *UserPreferences) time.Duration {
 // a source that is both stale AND failing will not lose one signal because
 // the other already consumed the cooldown.
 //
+// Since Issue #33, the cooldown timestamp is recorded only AFTER the
+// background send reports successful delivery. Previously it was set
+// synchronously before the goroutine fired, which meant a failed send
+// consumed the cooldown for the full window.
+//
 // errorMessage is a short human-readable summary shown in the alert subject.
 // details is the full error/warning text shown in the alert body.
 //
-// Returns true if the alert was queued for send, false if still in cooldown.
+// Returns true if the alert was queued for send, false if still in cooldown
+// or a prior send is still in flight.
 func (n *Notifier) SendSyncFailureAlertWithPrefs(
 	ctx context.Context,
 	sourceID, sourceName, userEmail, errorMessage, details string,
 	userPrefs *UserPreferences,
 ) bool {
 	cooldown := n.getCooldownPeriod(userPrefs)
+	inFlightKey := "failure:" + sourceID
 
 	n.mu.Lock()
-	defer n.mu.Unlock()
 
 	// Cooldown check — failure alerts use their own map, independent of
-	// the stale-alert cooldown.
-	if lastAlert, exists := n.lastFailureAlertTimes[sourceID]; exists {
-		if time.Since(lastAlert) < cooldown {
-			return false
-		}
+	// the stale-alert cooldown. lastFailureAlertTimes now reflects the
+	// last SUCCESSFUL delivery.
+	if lastAlert, exists := n.lastFailureAlertTimes[sourceID]; exists && time.Since(lastAlert) < cooldown {
+		n.mu.Unlock()
+		return false
 	}
-	n.lastFailureAlertTimes[sourceID] = time.Now()
+
+	// Deduplication: if a failure alert for this source is already in
+	// flight, suppress this one.
+	if n.inFlightAlerts[inFlightKey] {
+		n.mu.Unlock()
+		return false
+	}
+	n.inFlightAlerts[inFlightKey] = true
+
+	n.mu.Unlock()
 
 	alert := Alert{
 		Type:       AlertTypeError,
@@ -596,18 +660,29 @@ func (n *Notifier) SendSyncFailureAlertWithPrefs(
 		Timestamp:  time.Now(),
 	}
 
-	// Send in background to not block the scheduler.
-	go n.sendWithPrefs(ctx, alert, userPrefs)
+	// Send in background. Cooldown is recorded inside the goroutine only
+	// if at least one channel delivered.
+	go func() {
+		delivered := n.sendWithPrefs(ctx, alert, userPrefs)
+		n.mu.Lock()
+		delete(n.inFlightAlerts, inFlightKey)
+		if delivered {
+			n.lastFailureAlertTimes[sourceID] = time.Now()
+		}
+		n.mu.Unlock()
+	}()
 	return true
 }
 
 // ClearFailureAlertState clears the failure-alert cooldown for a source
 // (used on source deletion). Safe to call for sources that have never
-// triggered a failure alert.
+// triggered a failure alert. Also clears any in-flight failure alert
+// guard so a new source reusing the same ID starts with a clean slate.
 func (n *Notifier) ClearFailureAlertState(sourceID string) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	delete(n.lastFailureAlertTimes, sourceID)
+	delete(n.inFlightAlerts, "failure:"+sourceID)
 }
 
 // IsDangerousWarning returns true if a sync warning indicates a data-loss
@@ -630,8 +705,20 @@ func IsDangerousWarning(w string) bool {
 		strings.Contains(w, "exceeds safety threshold")
 }
 
-// sendWithPrefs sends the alert via configured channels, respecting per-user preferences.
-func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *UserPreferences) {
+// sendWithPrefs sends the alert via configured channels, respecting per-user
+// preferences. Returns true if at least one configured channel delivered
+// successfully — meaning the user actually received a notification.
+// Returns false if all configured channels failed, in which case the caller
+// must NOT record the cooldown timestamp (so the next retry can fire
+// immediately instead of being silenced for the full cooldown window).
+//
+// Since Issue #33, this return value is what distinguishes
+// "alert delivered, start the cooldown" from "alert attempted but bounced,
+// please retry on the next tick".
+func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *UserPreferences) bool {
+	anyAttempted := false
+	anyDelivered := false
+
 	// Determine if webhook is enabled (user pref overrides global)
 	webhookEnabled := n.cfg.WebhookEnabled
 	if userPrefs != nil && userPrefs.WebhookEnabled != nil {
@@ -640,8 +727,11 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 
 	// Send to global webhook if enabled
 	if webhookEnabled && n.cfg.WebhookURL != "" {
+		anyAttempted = true
 		if err := n.sendWebhook(ctx, alert); err != nil {
 			log.Printf("[Notify] Webhook error: %v", err)
+		} else {
+			anyDelivered = true
 		}
 	}
 
@@ -652,8 +742,11 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 			userWebhookEnabled = *userPrefs.WebhookEnabled
 		}
 		if userWebhookEnabled {
+			anyAttempted = true
 			if err := n.sendWebhookToURL(ctx, alert, userPrefs.WebhookURL); err != nil {
 				log.Printf("[Notify] User webhook error: %v", err)
+			} else {
+				anyDelivered = true
 			}
 		}
 	}
@@ -685,11 +778,23 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 		}
 
 		if len(recipients) > 0 {
+			anyAttempted = true
 			if err := n.sendEmail(alert, recipients); err != nil {
 				log.Printf("[Notify] Email error: %v", err)
+			} else {
+				anyDelivered = true
 			}
 		}
 	}
+
+	// If no channel was even configured/attempted, treat as "delivered" so
+	// the cooldown still applies — otherwise a notifier with no channels
+	// would busy-loop the scheduler. This matches the prior fire-and-forget
+	// behavior for the no-channel case.
+	if !anyAttempted {
+		return true
+	}
+	return anyDelivered
 }
 
 // sendWebhookToURL sends a webhook to a specific URL (for user webhooks).

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -48,14 +48,14 @@ type Config struct {
 	WebhookURL     string
 
 	// Email settings
-	EmailEnabled   bool
-	SMTPHost       string
-	SMTPPort       int
-	SMTPUsername   string
-	SMTPPassword   string
-	SMTPFrom       string
-	SMTPTo         []string // Recipients
-	SMTPTLS        bool
+	EmailEnabled bool
+	SMTPHost     string
+	SMTPPort     int
+	SMTPUsername string
+	SMTPPassword string
+	SMTPFrom     string
+	SMTPTo       []string // Recipients
+	SMTPTLS      bool
 
 	// Alert settings
 	CooldownPeriod time.Duration // How long to wait before re-alerting for same source
@@ -79,6 +79,11 @@ type Notifier struct {
 	mu             sync.RWMutex
 	lastAlertTimes map[string]time.Time
 	staleState     map[string]bool // Track if source is currently in stale state
+
+	// Failure alert cooldown is tracked separately from stale alerts so a
+	// source that is both stale and failing doesn't lose one signal because
+	// the other already consumed the cooldown window.
+	lastFailureAlertTimes map[string]time.Time
 }
 
 // New creates a new Notifier.
@@ -88,8 +93,9 @@ func New(cfg *Config) *Notifier {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		lastAlertTimes: make(map[string]time.Time),
-		staleState:     make(map[string]bool),
+		lastAlertTimes:        make(map[string]time.Time),
+		staleState:            make(map[string]bool),
+		lastFailureAlertTimes: make(map[string]time.Time),
 	}
 }
 
@@ -547,6 +553,81 @@ func (n *Notifier) getCooldownPeriod(userPrefs *UserPreferences) time.Duration {
 		return time.Duration(*userPrefs.CooldownMinutes) * time.Minute
 	}
 	return n.cfg.CooldownPeriod
+}
+
+// SendSyncFailureAlertWithPrefs sends an alert when a sync fails or when a
+// data-loss protection guard is triggered, using per-user preferences.
+// userPrefs can be nil to use global defaults only.
+//
+// This method has its own cooldown window independent from stale alerts:
+// a source that is both stale AND failing will not lose one signal because
+// the other already consumed the cooldown.
+//
+// errorMessage is a short human-readable summary shown in the alert subject.
+// details is the full error/warning text shown in the alert body.
+//
+// Returns true if the alert was queued for send, false if still in cooldown.
+func (n *Notifier) SendSyncFailureAlertWithPrefs(
+	ctx context.Context,
+	sourceID, sourceName, userEmail, errorMessage, details string,
+	userPrefs *UserPreferences,
+) bool {
+	cooldown := n.getCooldownPeriod(userPrefs)
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	// Cooldown check — failure alerts use their own map, independent of
+	// the stale-alert cooldown.
+	if lastAlert, exists := n.lastFailureAlertTimes[sourceID]; exists {
+		if time.Since(lastAlert) < cooldown {
+			return false
+		}
+	}
+	n.lastFailureAlertTimes[sourceID] = time.Now()
+
+	alert := Alert{
+		Type:       AlertTypeError,
+		SourceID:   sourceID,
+		SourceName: sourceName,
+		UserEmail:  userEmail,
+		Message:    errorMessage,
+		Details:    details,
+		Timestamp:  time.Now(),
+	}
+
+	// Send in background to not block the scheduler.
+	go n.sendWithPrefs(ctx, alert, userPrefs)
+	return true
+}
+
+// ClearFailureAlertState clears the failure-alert cooldown for a source
+// (used on source deletion). Safe to call for sources that have never
+// triggered a failure alert.
+func (n *Notifier) ClearFailureAlertState(sourceID string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	delete(n.lastFailureAlertTimes, sourceID)
+}
+
+// IsDangerousWarning returns true if a sync warning indicates a data-loss
+// protection guard was triggered and the user should be alerted, even if
+// the overall sync result reports success.
+//
+// These patterns are produced by planOrphanDeletion in internal/caldav/sync.go
+// (added in PR #22, issue #21). They represent cases where the sync engine
+// refused to delete destination events because the inputs looked unsafe
+// (source returned zero events, or the planned deletion ratio exceeded the
+// configured safety threshold).
+//
+// Harmless warnings (individual event put/delete failures, 403/412 skip
+// counts, etc.) do NOT match and do not trigger alerts.
+func IsDangerousWarning(w string) bool {
+	if w == "" {
+		return false
+	}
+	return strings.Contains(w, "previously-synced records exist") ||
+		strings.Contains(w, "exceeds safety threshold")
 }
 
 // sendWithPrefs sends the alert via configured channels, respecting per-user preferences.

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -8,15 +8,23 @@ import (
 	"time"
 )
 
+// drainTimeout is the max time we wait for in-flight alert sends to
+// complete in tests. Must comfortably exceed the full retry window
+// (defaultMaxSendAttempts attempts with exponential backoff + jitter,
+// ~1.5s total for 3 attempts at 500ms base) for tests that exercise
+// failure paths. Issue #39 introduced the retry behavior that pushed
+// failed-send durations into the low-seconds range.
+const drainTimeout = 5 * time.Second
+
 // waitForDrain blocks until all in-flight alert sends have completed,
-// or until the timeout expires. Test helper for sequencing multi-alert
+// or until drainTimeout expires. Test helper for sequencing multi-alert
 // scenarios — since Issue #33, the cooldown timestamp is recorded
 // inside the background goroutine only after sendWithPrefs returns,
 // so tests that rely on cooldown-after-first-send must wait for
 // that goroutine to finish before making assertions about state.
 func waitForDrain(t *testing.T, n *Notifier) {
 	t.Helper()
-	deadline := time.Now().Add(100 * time.Millisecond)
+	deadline := time.Now().Add(drainTimeout)
 	for time.Now().Before(deadline) {
 		n.mu.RLock()
 		empty := len(n.inFlightAlerts) == 0
@@ -24,9 +32,9 @@ func waitForDrain(t *testing.T, n *Notifier) {
 		if empty {
 			return
 		}
-		time.Sleep(500 * time.Microsecond)
+		time.Sleep(time.Millisecond)
 	}
-	t.Fatal("in-flight alerts did not drain within 100ms")
+	t.Fatalf("in-flight alerts did not drain within %v", drainTimeout)
 }
 
 // waitForKeyDrain blocks until a specific in-flight key has cleared.
@@ -34,7 +42,7 @@ func waitForDrain(t *testing.T, n *Notifier) {
 // for only the real goroutine(s) to finish, not the synthetic ones.
 func waitForKeyDrain(t *testing.T, n *Notifier, key string) {
 	t.Helper()
-	deadline := time.Now().Add(100 * time.Millisecond)
+	deadline := time.Now().Add(drainTimeout)
 	for time.Now().Before(deadline) {
 		n.mu.RLock()
 		gone := !n.inFlightAlerts[key]
@@ -42,9 +50,9 @@ func waitForKeyDrain(t *testing.T, n *Notifier, key string) {
 		if gone {
 			return
 		}
-		time.Sleep(500 * time.Microsecond)
+		time.Sleep(time.Millisecond)
 	}
-	t.Fatalf("in-flight key %q did not clear within 100ms", key)
+	t.Fatalf("in-flight key %q did not clear within %v", key, drainTimeout)
 }
 
 func TestValidateConfig(t *testing.T) {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,9 +1,51 @@
 package notify
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
+
+// waitForDrain blocks until all in-flight alert sends have completed,
+// or until the timeout expires. Test helper for sequencing multi-alert
+// scenarios — since Issue #33, the cooldown timestamp is recorded
+// inside the background goroutine only after sendWithPrefs returns,
+// so tests that rely on cooldown-after-first-send must wait for
+// that goroutine to finish before making assertions about state.
+func waitForDrain(t *testing.T, n *Notifier) {
+	t.Helper()
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		n.mu.RLock()
+		empty := len(n.inFlightAlerts) == 0
+		n.mu.RUnlock()
+		if empty {
+			return
+		}
+		time.Sleep(500 * time.Microsecond)
+	}
+	t.Fatal("in-flight alerts did not drain within 100ms")
+}
+
+// waitForKeyDrain blocks until a specific in-flight key has cleared.
+// Used by tests that synthetically populate some keys and want to wait
+// for only the real goroutine(s) to finish, not the synthetic ones.
+func waitForKeyDrain(t *testing.T, n *Notifier, key string) {
+	t.Helper()
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		n.mu.RLock()
+		gone := !n.inFlightAlerts[key]
+		n.mu.RUnlock()
+		if gone {
+			return
+		}
+		time.Sleep(500 * time.Microsecond)
+	}
+	t.Fatalf("in-flight key %q did not clear within 100ms", key)
+}
 
 func TestValidateConfig(t *testing.T) {
 	tests := []struct {
@@ -473,6 +515,14 @@ func TestSendSyncFailureAlertUserCooldownOverride(t *testing.T) {
 		t.Fatal("first failure alert should fire")
 	}
 
+	// Wait for the first send's background goroutine to finish and
+	// clear its in-flight guard before attempting the second call.
+	// The in-flight dedup is Issue #33's fix for concurrent duplicate
+	// sends; without this wait the second call would be legitimately
+	// suppressed by the in-flight guard even though the cooldown
+	// itself is zero.
+	waitForDrain(t, n)
+
 	// With zero cooldown the second alert fires immediately.
 	sent = n.SendSyncFailureAlertWithPrefs(
 		nil, "source1", "Test Source", "user@example.com",
@@ -480,6 +530,265 @@ func TestSendSyncFailureAlertUserCooldownOverride(t *testing.T) {
 	)
 	if !sent {
 		t.Error("second alert should fire with zero-minute user cooldown")
+	}
+}
+
+// TestCooldownNotConsumedByFailedSend verifies Issue #33's core fix:
+// when a webhook send fails, the cooldown timestamp must NOT be recorded,
+// so the next alert attempt can fire immediately rather than being
+// silenced for the full cooldown window.
+//
+// Setup: point the webhook at an httptest server that always returns
+// HTTP 500, so the send reaches the server but sendWebhook reports a
+// delivery failure.
+func TestCooldownNotConsumedByFailedSend(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		WebhookEnabled: true,
+		WebhookURL:     server.URL,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+	ctx := context.Background()
+
+	// First attempt. Returns true (queued) but the background send will
+	// fail because the webhook returns 500.
+	sent := n.SendSyncFailureAlertWithPrefs(
+		ctx, "source1", "Test Source", "user@example.com",
+		"Sync failed", "first attempt", nil,
+	)
+	if !sent {
+		t.Fatal("first failure alert should be queued")
+	}
+
+	// Wait for the background send to finish failing.
+	waitForDrain(t, n)
+
+	// Cooldown should NOT be set because the delivery failed.
+	n.mu.RLock()
+	_, cooldownSet := n.lastFailureAlertTimes["source1"]
+	n.mu.RUnlock()
+	if cooldownSet {
+		t.Error("cooldown should NOT be set after a failed send; failed deliveries must not consume the cooldown window")
+	}
+
+	// Second attempt must succeed because the cooldown was not consumed.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		ctx, "source1", "Test Source", "user@example.com",
+		"Sync failed", "second attempt", nil,
+	)
+	if !sent {
+		t.Error("second alert should fire immediately because the first delivery failed (no cooldown consumed)")
+	}
+	waitForDrain(t, n)
+}
+
+// TestCooldownRecordedAfterSuccessfulSend verifies that when a delivery
+// DOES succeed, the cooldown is recorded correctly so repeat alerts
+// are suppressed. This is the happy path for Issue #33.
+//
+// Setup: webhook points at an httptest server that returns 200, so
+// sendWebhook reports a successful delivery.
+func TestCooldownRecordedAfterSuccessfulSend(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		WebhookEnabled: true,
+		WebhookURL:     server.URL,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+	ctx := context.Background()
+
+	sent := n.SendSyncFailureAlertWithPrefs(
+		ctx, "source1", "Test Source", "user@example.com",
+		"Sync failed", "first", nil,
+	)
+	if !sent {
+		t.Fatal("first alert should fire")
+	}
+
+	// Wait for the background send to complete successfully.
+	waitForDrain(t, n)
+
+	// Cooldown should be set now.
+	n.mu.RLock()
+	_, cooldownSet := n.lastFailureAlertTimes["source1"]
+	n.mu.RUnlock()
+	if !cooldownSet {
+		t.Fatal("cooldown should be set after a successful webhook 200 response")
+	}
+
+	// Second attempt must be blocked by the cooldown.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		ctx, "source1", "Test Source", "user@example.com",
+		"Sync failed", "second", nil,
+	)
+	if sent {
+		t.Error("second alert should be blocked by the cooldown set by the first successful send")
+	}
+}
+
+// TestInFlightGuardSuppressesSameSourceAndType verifies that a concurrent
+// second caller for the same source AND same alert type is suppressed
+// while a prior send is still in flight. Uses a manually-set in-flight
+// flag to avoid racing real goroutines.
+func TestInFlightGuardSuppressesSameSourceAndType(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Manually set in-flight to simulate a send in progress. We do this
+	// synthetically rather than kicking off a real send so the test
+	// doesn't race against goroutine scheduling.
+	n.mu.Lock()
+	n.inFlightAlerts["failure:source1"] = true
+	n.mu.Unlock()
+
+	// Concurrent attempt for the same source+type must be suppressed.
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "concurrent attempt", nil,
+	)
+	if sent {
+		t.Error("alert must be suppressed while an in-flight send exists for the same source+type")
+	}
+
+	// Clean up so the test leaves no stale state.
+	n.mu.Lock()
+	delete(n.inFlightAlerts, "failure:source1")
+	n.mu.Unlock()
+}
+
+// TestInFlightGuardIsScopedByAlertType verifies that a stale alert in
+// flight does NOT block a failure alert for the same source. The two
+// alert types use different key prefixes in inFlightAlerts so they can
+// fire concurrently for the same source.
+func TestInFlightGuardIsScopedByAlertType(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Synthetically mark a stale-alert in flight for source1. This
+	// simulates a stale-alert goroutine that hasn't finished yet.
+	n.mu.Lock()
+	n.inFlightAlerts["stale:source1"] = true
+	n.mu.Unlock()
+
+	// A failure alert for the SAME source should fire — different key.
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "different type", nil,
+	)
+	if !sent {
+		t.Error("failure alert must not be blocked by a stale alert in flight (different key prefix)")
+	}
+
+	// Wait only for the failure key to drain — the synthetic stale key
+	// will never clear because there's no goroutine behind it.
+	waitForKeyDrain(t, n, "failure:source1")
+
+	// Clean up the synthetic stale entry.
+	n.mu.Lock()
+	delete(n.inFlightAlerts, "stale:source1")
+	n.mu.Unlock()
+}
+
+// TestInFlightGuardIsScopedBySourceID verifies that an in-flight alert
+// for one source does not block alerts for a different source.
+func TestInFlightGuardIsScopedBySourceID(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Synthetically mark a failure alert in flight for source1.
+	n.mu.Lock()
+	n.inFlightAlerts["failure:source1"] = true
+	n.mu.Unlock()
+
+	// A failure alert for source2 must not be blocked.
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source2", "Other Source", "user@example.com",
+		"Sync failed", "other source", nil,
+	)
+	if !sent {
+		t.Error("source2 must not be blocked by source1's in-flight guard")
+	}
+
+	// Wait only for the source2 key to drain; source1's synthetic entry
+	// will never clear because no goroutine is running it.
+	waitForKeyDrain(t, n, "failure:source2")
+
+	// Clean up the synthetic source1 entry.
+	n.mu.Lock()
+	delete(n.inFlightAlerts, "failure:source1")
+	n.mu.Unlock()
+}
+
+// TestClearFailureAlertStateClearsInFlight verifies that
+// ClearFailureAlertState cleans up in-flight state too, so a newly
+// re-created source (reusing the same ID) starts with a clean slate.
+func TestClearFailureAlertStateClearsInFlight(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Manually set in-flight
+	n.mu.Lock()
+	n.inFlightAlerts["failure:source1"] = true
+	n.mu.Unlock()
+
+	n.ClearFailureAlertState("source1")
+
+	n.mu.RLock()
+	stillInFlight := n.inFlightAlerts["failure:source1"]
+	n.mu.RUnlock()
+	if stillInFlight {
+		t.Error("ClearFailureAlertState must also clear in-flight guard")
+	}
+}
+
+// TestClearStaleStateClearsInFlight — same contract for stale path.
+func TestClearStaleStateClearsInFlight(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	n.mu.Lock()
+	n.inFlightAlerts["stale:source1"] = true
+	n.mu.Unlock()
+
+	n.ClearStaleState("source1")
+
+	n.mu.RLock()
+	stillInFlight := n.inFlightAlerts["stale:source1"]
+	n.mu.RUnlock()
+	if stillInFlight {
+		t.Error("ClearStaleState must also clear in-flight guard")
 	}
 }
 

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -341,6 +341,198 @@ func TestClearStaleState(t *testing.T) {
 	}
 }
 
+// TestSendSyncFailureAlertCooldown verifies that a second failure alert for
+// the same source inside the cooldown window is rejected, preventing alert
+// storms on a persistently broken source.
+func TestSendSyncFailureAlertCooldown(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "connection refused", nil,
+	)
+	if !sent {
+		t.Error("first failure alert should be sent")
+	}
+
+	// Second alert within cooldown should be suppressed.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "connection refused", nil,
+	)
+	if sent {
+		t.Error("second failure alert within cooldown should be suppressed")
+	}
+
+	// Different source should still work.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source2", "Test Source 2", "user@example.com",
+		"Sync failed", "auth expired", nil,
+	)
+	if !sent {
+		t.Error("failure alert for a different source should be sent")
+	}
+}
+
+// TestSendSyncFailureAlertIndependentFromStale verifies that the failure
+// cooldown and the stale cooldown are tracked separately. A source that is
+// both stale AND failing should be able to fire BOTH alert types without
+// one consuming the other's cooldown.
+func TestSendSyncFailureAlertIndependentFromStale(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Fire a stale alert first.
+	sent := n.SendStaleAlert(nil, "source1", "Test Source", "user@example.com", 2*time.Hour, time.Hour)
+	if !sent {
+		t.Fatal("stale alert should fire")
+	}
+
+	// A failure alert for the same source should NOT be blocked by the
+	// stale cooldown — they use independent maps.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "some error", nil,
+	)
+	if !sent {
+		t.Error("failure alert should not be blocked by stale cooldown")
+	}
+}
+
+// TestClearFailureAlertState verifies that clearing the failure-alert state
+// lets the next failure fire immediately instead of waiting for cooldown.
+func TestClearFailureAlertState(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "connection refused", nil,
+	)
+	if !sent {
+		t.Fatal("first failure alert should fire")
+	}
+
+	// Before clear, second alert is blocked.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "connection refused", nil,
+	)
+	if sent {
+		t.Fatal("second failure alert should be blocked before clear")
+	}
+
+	n.ClearFailureAlertState("source1")
+
+	// After clear, next alert fires.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "connection refused", nil,
+	)
+	if !sent {
+		t.Error("failure alert should fire after ClearFailureAlertState")
+	}
+
+	// ClearFailureAlertState must be safe for unknown source IDs.
+	n.ClearFailureAlertState("never-alerted-source")
+}
+
+// TestSendSyncFailureAlertUserCooldownOverride verifies that user preferences
+// can shorten or lengthen the failure cooldown independently of the global
+// cooldown setting.
+func TestSendSyncFailureAlertUserCooldownOverride(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Zero-minute cooldown via user pref — second alert should fire immediately.
+	zero := 0
+	prefs := &UserPreferences{CooldownMinutes: &zero}
+
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "first", prefs,
+	)
+	if !sent {
+		t.Fatal("first failure alert should fire")
+	}
+
+	// With zero cooldown the second alert fires immediately.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "second", prefs,
+	)
+	if !sent {
+		t.Error("second alert should fire with zero-minute user cooldown")
+	}
+}
+
+// TestIsDangerousWarning verifies the pattern match for data-loss protection
+// warnings. The scheduler uses this to decide whether a "successful" sync
+// with warnings should still fire an alert.
+func TestIsDangerousWarning(t *testing.T) {
+	tests := []struct {
+		name    string
+		warning string
+		want    bool
+	}{
+		{
+			name:    "empty-source guard warning from planOrphanDeletion",
+			warning: "source returned 0 events but 42 previously-synced records exist - skipping one-way orphan deletion for safety (possible auth failure or broken source)",
+			want:    true,
+		},
+		{
+			name:    "mass-delete threshold warning from planOrphanDeletion",
+			warning: "one-way orphan deletion would remove 80 of 100 previously-synced events (80%), exceeds safety threshold 50% - skipping deletion",
+			want:    true,
+		},
+		{
+			name:    "harmless individual delete failure",
+			warning: "Failed to delete orphan event: 404 not found",
+			want:    false,
+		},
+		{
+			name:    "harmless 403 skip",
+			warning: "Two-way sync: 3 events skipped (source calendar read-only)",
+			want:    false,
+		},
+		{
+			name:    "empty string",
+			warning: "",
+			want:    false,
+		},
+		{
+			name:    "unrelated warning containing none of the patterns",
+			warning: "Failed to update sync log",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsDangerousWarning(tt.warning)
+			if got != tt.want {
+				t.Errorf("IsDangerousWarning(%q) = %v, want %v", tt.warning, got, tt.want)
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
 		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))

--- a/internal/notify/retry.go
+++ b/internal/notify/retry.go
@@ -1,0 +1,136 @@
+package notify
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+// defaultMaxSendAttempts is the maximum total attempts (initial + retries)
+// for a single webhook or email send. 3 attempts with the default backoff
+// sequence of 500ms and 1s yields ~1.5s worst-case for a fully failed send
+// before the outer loop (PR #34 cooldown-not-consumed-on-failure)
+// schedules another attempt on the next tick.
+const defaultMaxSendAttempts = 3
+
+// defaultInitialBackoff is the base delay before the first retry. Retry
+// N uses defaultInitialBackoff * 2^(N-1) plus up to 25% jitter.
+const defaultInitialBackoff = 500 * time.Millisecond
+
+// retryTransient calls fn up to maxAttempts times with exponential backoff
+// and jitter between attempts. If fn returns nil on any attempt, the
+// function returns nil. If fn returns an error and isTransient(err) is
+// false, the function returns the error immediately without retrying.
+// If fn returns a transient error on every attempt, the function returns
+// the last error.
+//
+// Context cancellation is honored during the backoff sleep: if ctx is
+// cancelled while waiting to retry, the function returns the last error
+// immediately rather than waiting out the full backoff.
+//
+// Backoff sequence with defaultInitialBackoff=500ms:
+//
+//	attempt 1: no delay
+//	attempt 2: 500ms + jitter (retry after first failure)
+//	attempt 3: 1s + jitter (retry after second failure)
+//
+// Jitter is uniform random in [0, backoff/4) to avoid thundering-herd
+// retries from multiple concurrent failed sends synchronizing.
+func retryTransient(ctx context.Context, maxAttempts int, fn func(ctx context.Context) error, isTransient func(error) bool) error {
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			// Exponential backoff with jitter.
+			backoff := defaultInitialBackoff * time.Duration(1<<(attempt-1))
+			jitterMax := int64(backoff / 4)
+			var jitter time.Duration
+			if jitterMax > 0 {
+				jitter = time.Duration(rand.Int63n(jitterMax))
+			}
+			timer := time.NewTimer(backoff + jitter)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return lastErr
+			case <-timer.C:
+			}
+		}
+
+		err := fn(ctx)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isTransient(err) {
+			return err
+		}
+	}
+	return lastErr
+}
+
+// isTransientHTTPError classifies an HTTP send error as either transient
+// (worth retrying) or permanent (retry would give the same result).
+//
+// Transient:
+//   - Network errors (DNS, TCP, TLS, read timeouts): the error message
+//     doesn't contain "status" since the request never got an HTTP
+//     response back
+//   - 5xx server errors: "webhook returned status 5xx"
+//
+// Permanent:
+//   - 4xx client errors: "webhook returned status 4xx"
+//   - URL validation failures: "invalid webhook URL"
+//   - Request construction: "create request"
+//   - Payload marshaling: "marshal payload"
+//
+// The classification is string-based rather than type-based because the
+// error paths in sendWebhook / sendWebhookToURL wrap the low-level
+// errors into formatted messages, losing the original type. Since all
+// those messages are under our control, string matching is stable.
+func isTransientHTTPError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+
+	// Permanent: URL or payload setup failures — retry would give the
+	// same result.
+	if strings.Contains(msg, "invalid webhook URL") ||
+		strings.Contains(msg, "marshal payload") ||
+		strings.Contains(msg, "create request") {
+		return false
+	}
+
+	// Permanent: 4xx responses. Note that "status 5xx" is transient so
+	// we must check for the explicit 4xx pattern — a naive "status 4"
+	// substring would also match "status 500"'s wraps if we happened
+	// to format them in an odd way, but the current format is
+	// "webhook returned status N" where N is a decimal code.
+	if strings.Contains(msg, "returned status 4") {
+		return false
+	}
+
+	// Everything else — network errors, 5xx, read timeouts — is
+	// transient and worth retrying.
+	return true
+}
+
+// isTransientSMTPError classifies an SMTP send error. SMTP error taxonomy
+// is much less crisp than HTTP, so the default is to retry everything
+// except for the very clearly permanent cases. The cooldown-not-consumed
+// outer loop (PR #34) ensures that even permanent errors are eventually
+// given up on rather than looped forever.
+func isTransientSMTPError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Very few SMTP errors are deterministically permanent at the
+	// Go SDK level. "530 authentication required" is, but the error
+	// message varies by server. For now, retry everything and let
+	// the outer cooldown loop handle persistent failures.
+	return true
+}

--- a/internal/notify/retry_test.go
+++ b/internal/notify/retry_test.go
@@ -1,0 +1,306 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRetryTransient_ReturnsNilOnFirstSuccess verifies the happy path:
+// a function that succeeds on its first attempt returns nil without
+// the retry loop ever sleeping or running a second attempt.
+func TestRetryTransient_ReturnsNilOnFirstSuccess(t *testing.T) {
+	var attempts int32
+	err := retryTransient(context.Background(), 3, func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return nil
+	}, func(error) bool { return true })
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected 1 attempt, got %d", got)
+	}
+}
+
+// TestRetryTransient_StopsImmediatelyOnPermanentError verifies that a
+// permanent error (as classified by the isTransient callback) does not
+// trigger any retries. This prevents wasted work on deterministic
+// failures like invalid URLs or 4xx responses.
+func TestRetryTransient_StopsImmediatelyOnPermanentError(t *testing.T) {
+	var attempts int32
+	permanentErr := errors.New("permanent failure")
+	err := retryTransient(context.Background(), 5, func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return permanentErr
+	}, func(error) bool { return false })
+	if !errors.Is(err, permanentErr) {
+		t.Errorf("expected permanentErr, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected 1 attempt (no retries on permanent error), got %d", got)
+	}
+}
+
+// TestRetryTransient_RetriesUpToMaxOnTransientError verifies that a
+// transient error is retried up to maxAttempts times, and the last
+// error is returned if all attempts fail.
+func TestRetryTransient_RetriesUpToMaxOnTransientError(t *testing.T) {
+	var attempts int32
+	transientErr := errors.New("transient failure")
+	err := retryTransient(context.Background(), 3, func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return transientErr
+	}, func(error) bool { return true })
+	if !errors.Is(err, transientErr) {
+		t.Errorf("expected transientErr, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+}
+
+// TestRetryTransient_SuccessAfterTransientFailures verifies the most
+// valuable case: a function that fails transiently on the first N-1
+// attempts and succeeds on the last one returns nil and reports the
+// correct attempt count.
+func TestRetryTransient_SuccessAfterTransientFailures(t *testing.T) {
+	var attempts int32
+	err := retryTransient(context.Background(), 3, func(_ context.Context) error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			return errors.New("still flaky")
+		}
+		return nil
+	}, func(error) bool { return true })
+	if err != nil {
+		t.Errorf("expected nil on eventual success, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 attempts (2 failures + 1 success), got %d", got)
+	}
+}
+
+// TestRetryTransient_RespectsContextCancellation verifies that context
+// cancellation during the backoff sleep returns the last error
+// immediately rather than waiting out the full backoff. This is
+// critical for tests and for graceful shutdown: a broken endpoint
+// shouldn't keep the daemon alive during teardown.
+func TestRetryTransient_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var attempts int32
+
+	// Cancel the context after the first attempt starts.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := retryTransient(ctx, 5, func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return errors.New("always fails")
+	}, func(error) bool { return true })
+	elapsed := time.Since(start)
+
+	// The first attempt runs immediately, then we sleep for
+	// defaultInitialBackoff (500ms). Cancellation after 50ms should
+	// cut the sleep short, so the total should be well under the
+	// combined backoff time of ~1.5s for 3 attempts.
+	if elapsed > time.Second {
+		t.Errorf("expected early exit on cancel, took %v (>1s)", elapsed)
+	}
+	// We should have made at most 2 attempts (the first one + one
+	// cancelled during backoff).
+	if got := atomic.LoadInt32(&attempts); got > 2 {
+		t.Errorf("expected at most 2 attempts before cancel, got %d", got)
+	}
+	if err == nil {
+		t.Error("expected non-nil error from cancelled retry")
+	}
+}
+
+// TestIsTransientHTTPError verifies the classifier used by sendWebhook
+// and sendWebhookToURL. The classification contract is fragile
+// (string-based on internally-formatted messages) so these tests lock
+// in the expected behavior.
+func TestIsTransientHTTPError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error is not transient",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "invalid webhook URL is permanent",
+			err:  fmt.Errorf("invalid webhook URL: localhost not allowed"),
+			want: false,
+		},
+		{
+			name: "marshal payload is permanent",
+			err:  fmt.Errorf("marshal payload: unsupported type"),
+			want: false,
+		},
+		{
+			name: "create request is permanent",
+			err:  fmt.Errorf("create request: invalid URL"),
+			want: false,
+		},
+		{
+			name: "404 response is permanent",
+			err:  fmt.Errorf("webhook returned status 404"),
+			want: false,
+		},
+		{
+			name: "403 response is permanent",
+			err:  fmt.Errorf("webhook returned status 403"),
+			want: false,
+		},
+		{
+			name: "500 response is transient",
+			err:  fmt.Errorf("webhook returned status 500"),
+			want: true,
+		},
+		{
+			name: "503 response is transient",
+			err:  fmt.Errorf("webhook returned status 503"),
+			want: true,
+		},
+		{
+			name: "network error is transient",
+			err:  fmt.Errorf("send request: dial tcp: i/o timeout"),
+			want: true,
+		},
+		{
+			name: "DNS error is transient",
+			err:  fmt.Errorf("send request: no such host"),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTransientHTTPError(tt.err)
+			if got != tt.want {
+				t.Errorf("isTransientHTTPError(%q) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSendWebhook_RetriesOn5xxAndEventuallySucceeds verifies the full
+// integration from sendWebhook through retryTransient against a real
+// httptest server that fails the first two attempts with 500 and
+// succeeds on the third. If retry is wired correctly, the third
+// attempt's 200 turns the overall send into a success.
+func TestSendWebhook_RetriesOn5xxAndEventuallySucceeds(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	n := New(&Config{
+		WebhookEnabled: true,
+		WebhookURL:     server.URL,
+		CooldownPeriod: time.Hour,
+	})
+
+	alert := Alert{
+		Type:       AlertTypeError,
+		SourceID:   "src1",
+		SourceName: "Test Source",
+		Message:    "test message",
+		Details:    "test details",
+		Timestamp:  time.Now(),
+	}
+
+	err := n.sendWebhook(context.Background(), alert)
+	if err != nil {
+		t.Errorf("expected successful send after retries, got %v", err)
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 3 {
+		t.Errorf("expected 3 attempts (2 failures + 1 success), server saw %d", got)
+	}
+}
+
+// TestSendWebhook_StopsImmediatelyOn4xx verifies that a 404 response
+// does NOT trigger any retries — it's a permanent failure from the
+// classifier's point of view.
+func TestSendWebhook_StopsImmediatelyOn4xx(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	n := New(&Config{
+		WebhookEnabled: true,
+		WebhookURL:     server.URL,
+		CooldownPeriod: time.Hour,
+	})
+
+	alert := Alert{
+		Type:       AlertTypeError,
+		SourceID:   "src1",
+		SourceName: "Test Source",
+		Message:    "test message",
+		Timestamp:  time.Now(),
+	}
+
+	err := n.sendWebhook(context.Background(), alert)
+	if err == nil {
+		t.Error("expected error on 404, got nil")
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Errorf("expected exactly 1 attempt on permanent 4xx, server saw %d", got)
+	}
+}
+
+// TestSendWebhook_RetriesAllAttemptsOn5xx verifies the worst case: all
+// attempts fail with 500, the last error is returned, and the server
+// saw exactly defaultMaxSendAttempts requests.
+func TestSendWebhook_RetriesAllAttemptsOn5xx(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	n := New(&Config{
+		WebhookEnabled: true,
+		WebhookURL:     server.URL,
+		CooldownPeriod: time.Hour,
+	})
+
+	alert := Alert{
+		Type:       AlertTypeError,
+		SourceID:   "src1",
+		SourceName: "Test Source",
+		Message:    "test message",
+		Timestamp:  time.Now(),
+	}
+
+	err := n.sendWebhook(context.Background(), alert)
+	if err == nil {
+		t.Error("expected error after all retries exhausted, got nil")
+	}
+	if got := atomic.LoadInt32(&requestCount); got != int32(defaultMaxSendAttempts) {
+		t.Errorf("expected %d attempts, server saw %d", defaultMaxSendAttempts, got)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,7 +2,9 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,12 +14,12 @@ import (
 )
 
 const (
-	cleanupInterval     = 24 * time.Hour
-	logRetentionDays    = 30
-	syncTimeout         = 120 * time.Minute // Maximum time for a single sync operation (2 hours for slow iCloud with multiple calendars)
-	healthLogInterval   = 5 * time.Minute   // Interval for scheduler health logging
-	staleMultiplier     = 2                 // Source is stale if last sync > staleMultiplier * interval
-	startupStagger      = 30 * time.Second  // Delay between starting each source's first sync
+	cleanupInterval   = 24 * time.Hour
+	logRetentionDays  = 30
+	syncTimeout       = 120 * time.Minute // Maximum time for a single sync operation (2 hours for slow iCloud with multiple calendars)
+	healthLogInterval = 5 * time.Minute   // Interval for scheduler health logging
+	staleMultiplier   = 2                 // Source is stale if last sync > staleMultiplier * interval
+	startupStagger    = 30 * time.Second  // Delay between starting each source's first sync
 )
 
 // Job represents a scheduled sync job.
@@ -204,9 +206,12 @@ func (s *Scheduler) RemoveJob(sourceID string) {
 		log.Printf("Removed sync job for source %s", sourceID)
 	}
 
-	// Clear stale state in notifier if configured
+	// Clear alert state in notifier if configured. Both stale and failure
+	// cooldowns must be cleared so a newly-added source with a reused ID
+	// (unlikely but possible) starts with a clean slate.
 	if s.notifier != nil {
 		s.notifier.ClearStaleState(sourceID)
+		s.notifier.ClearFailureAlertState(sourceID)
 	}
 }
 
@@ -410,6 +415,79 @@ func (s *Scheduler) executeSync(sourceID string) {
 	} else {
 		log.Printf("Sync failed for source %s: %s", source.Name, result.Message)
 	}
+
+	// Fire a failure alert when appropriate. This covers two cases:
+	//   1. The sync itself returned Success=false (hard failure).
+	//   2. The sync succeeded but a data-loss protection guard was
+	//      triggered, producing a "dangerous" warning in result.Warnings.
+	//      These warnings come from planOrphanDeletion in caldav/sync.go
+	//      (PR #22 / issue #21) and indicate that the sync refused to
+	//      delete events because the inputs looked unsafe. The user MUST
+	//      know about these — before PR #22 they would have silently
+	//      deleted data; after PR #22 they silently preserve data, but
+	//      the underlying problem (broken source, auth expired, etc.)
+	//      still needs user attention.
+	s.maybeSendFailureAlert(sourceID, source, result)
+}
+
+// maybeSendFailureAlert inspects a sync result and fires a failure alert if
+// the sync failed or if any data-loss protection guard was triggered.
+// It respects the notifier's cooldown window — called on every sync, the
+// per-source cooldown map prevents alert storms on a persistently broken
+// source.
+func (s *Scheduler) maybeSendFailureAlert(sourceID string, source *db.Source, result *caldav.SyncResult) {
+	if s.notifier == nil || !s.notifier.IsEnabled() {
+		return
+	}
+
+	var (
+		shouldAlert  bool
+		alertMessage string
+		alertDetails string
+	)
+
+	if !result.Success {
+		shouldAlert = true
+		alertMessage = fmt.Sprintf("Sync failed for source '%s'", source.Name)
+		if len(result.Errors) > 0 {
+			alertDetails = strings.Join(result.Errors, "\n")
+		} else {
+			alertDetails = result.Message
+		}
+	} else {
+		// Successful sync — check warnings for data-loss protection signals.
+		var dangerous []string
+		for _, w := range result.Warnings {
+			if notify.IsDangerousWarning(w) {
+				dangerous = append(dangerous, w)
+			}
+		}
+		if len(dangerous) > 0 {
+			shouldAlert = true
+			alertMessage = fmt.Sprintf("Data-loss protection triggered for source '%s'", source.Name)
+			alertDetails = strings.Join(dangerous, "\n")
+		}
+	}
+
+	if !shouldAlert {
+		return
+	}
+
+	// Look up user email for per-user notifications. nil-safe so tests
+	// can exercise this path with a no-DB scheduler; production always
+	// has a real db.
+	userEmail := ""
+	if s.db != nil {
+		if user, err := s.db.GetUserByID(source.UserID); err == nil {
+			userEmail = user.Email
+		}
+	}
+	userPrefs := s.getUserAlertPrefs(source.UserID)
+
+	s.notifier.SendSyncFailureAlertWithPrefs(
+		s.ctx, sourceID, source.Name, userEmail,
+		alertMessage, alertDetails, userPrefs,
+	)
 }
 
 // cleanupRoutine runs periodic cleanup of old sync logs.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -4,6 +4,10 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/macjediwizard/calbridgesync/internal/caldav"
+	"github.com/macjediwizard/calbridgesync/internal/db"
+	"github.com/macjediwizard/calbridgesync/internal/notify"
 )
 
 func TestNew(t *testing.T) {
@@ -563,4 +567,153 @@ func TestContextCancellation(t *testing.T) {
 		// Cancel should not panic
 		sched.cancel()
 	})
+}
+
+// newTestSchedulerWithNotifier returns a Scheduler wired to a real Notifier
+// with webhook/email disabled (no network I/O) and a nil DB. This exercises
+// the full scheduler → notifier pipeline without standing up mock
+// infrastructure. The disabled channels mean the background send goroutine
+// exits immediately, leaving only the cooldown-map side effects — which is
+// exactly what the tests need to observe.
+func newTestSchedulerWithNotifier(t *testing.T) (*Scheduler, *notify.Notifier) {
+	t.Helper()
+	n := notify.New(&notify.Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	})
+	// Notifier must be "enabled" for the scheduler to call it. With both
+	// channels disabled, IsEnabled() returns false — so to exercise the
+	// path we enable webhook but do not set a URL. sendWithPrefs then
+	// no-ops on the empty URL branch.
+	n = notify.New(&notify.Config{
+		WebhookEnabled: true,
+		WebhookURL:     "", // empty URL — send is a no-op
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	})
+	sched := New(nil, nil, n)
+	return sched, n
+}
+
+// TestMaybeSendFailureAlert_HardFailureFiresAlert verifies that a sync
+// result with Success=false triggers a failure alert via the notifier.
+func TestMaybeSendFailureAlert_HardFailureFiresAlert(t *testing.T) {
+	sched, n := newTestSchedulerWithNotifier(t)
+	defer sched.cancel()
+
+	source := &db.Source{ID: "src-1", Name: "Test Source", UserID: "u1"}
+	result := &caldav.SyncResult{
+		Success: false,
+		Message: "sync failed",
+		Errors:  []string{"connection refused"},
+	}
+
+	sched.maybeSendFailureAlert(source.ID, source, result)
+
+	// Verify by probing the notifier's cooldown: a direct call with the
+	// same source should now be blocked, proving the scheduler populated
+	// the failure-alert cooldown map.
+	fired := n.SendSyncFailureAlertWithPrefs(
+		nil, source.ID, source.Name, "",
+		"probe", "probe", nil,
+	)
+	if fired {
+		t.Error("expected scheduler to have populated the failure cooldown (probe should return false)")
+	}
+}
+
+// TestMaybeSendFailureAlert_DangerousWarningFiresAlert verifies that a
+// successful sync with a data-loss-protection warning still triggers a
+// failure alert. This is the scenario that explains why the user's
+// calendar data disappeared without any alert reaching them: after PR #22,
+// the safety guards will emit these warnings, and the scheduler must
+// surface them as alerts.
+func TestMaybeSendFailureAlert_DangerousWarningFiresAlert(t *testing.T) {
+	sched, n := newTestSchedulerWithNotifier(t)
+	defer sched.cancel()
+
+	source := &db.Source{ID: "src-2", Name: "Test Source 2", UserID: "u1"}
+	result := &caldav.SyncResult{
+		Success: true,
+		Warnings: []string{
+			"source returned 0 events but 42 previously-synced records exist - skipping one-way orphan deletion for safety (possible auth failure or broken source)",
+		},
+	}
+
+	sched.maybeSendFailureAlert(source.ID, source, result)
+
+	fired := n.SendSyncFailureAlertWithPrefs(
+		nil, source.ID, source.Name, "",
+		"probe", "probe", nil,
+	)
+	if fired {
+		t.Error("expected scheduler to alert on dangerous warning even on success (probe should return false)")
+	}
+}
+
+// TestMaybeSendFailureAlert_HarmlessWarningDoesNotFire verifies that a
+// successful sync with only routine warnings (e.g. individual event delete
+// failures, 403 skips) does NOT trigger a failure alert. This prevents
+// alert noise from day-to-day sync operations.
+func TestMaybeSendFailureAlert_HarmlessWarningDoesNotFire(t *testing.T) {
+	sched, n := newTestSchedulerWithNotifier(t)
+	defer sched.cancel()
+
+	source := &db.Source{ID: "src-3", Name: "Test Source 3", UserID: "u1"}
+	result := &caldav.SyncResult{
+		Success: true,
+		Warnings: []string{
+			"Failed to delete orphan event: 404 not found",
+			"Two-way sync: 2 events skipped (source calendar read-only)",
+		},
+	}
+
+	sched.maybeSendFailureAlert(source.ID, source, result)
+
+	// Direct call should still fire — cooldown was never populated.
+	fired := n.SendSyncFailureAlertWithPrefs(
+		nil, source.ID, source.Name, "",
+		"probe", "probe", nil,
+	)
+	if !fired {
+		t.Error("expected direct call to fire (scheduler must not have populated cooldown on harmless warnings)")
+	}
+}
+
+// TestMaybeSendFailureAlert_SuccessWithNoWarningsDoesNotFire verifies the
+// happy path: a clean successful sync with no warnings triggers zero alerts.
+func TestMaybeSendFailureAlert_SuccessWithNoWarningsDoesNotFire(t *testing.T) {
+	sched, n := newTestSchedulerWithNotifier(t)
+	defer sched.cancel()
+
+	source := &db.Source{ID: "src-4", Name: "Test Source 4", UserID: "u1"}
+	result := &caldav.SyncResult{
+		Success:  true,
+		Warnings: nil,
+	}
+
+	sched.maybeSendFailureAlert(source.ID, source, result)
+
+	fired := n.SendSyncFailureAlertWithPrefs(
+		nil, source.ID, source.Name, "",
+		"probe", "probe", nil,
+	)
+	if !fired {
+		t.Error("expected direct call to fire (scheduler must not have populated cooldown on clean success)")
+	}
+}
+
+// TestMaybeSendFailureAlert_NilNotifierSafe verifies the nil-notifier
+// guard. A scheduler without a notifier (tests, stripped-down deploys)
+// must not panic.
+func TestMaybeSendFailureAlert_NilNotifierSafe(t *testing.T) {
+	sched := New(nil, nil, nil)
+	defer sched.cancel()
+
+	source := &db.Source{ID: "src-5", Name: "Test Source 5", UserID: "u1"}
+	result := &caldav.SyncResult{Success: false, Message: "sync failed"}
+
+	// Must not panic.
+	sched.maybeSendFailureAlert(source.ID, source, result)
 }


### PR DESCRIPTION
## Summary

Closes #39. **Stacks on PR #34** (which stacks on PR #24). Adds fine-grained intra-send retries to webhook and email sends. Combined with PR #34, there are now two levels of retry:

- **Fast retries WITHIN a single send** (this PR, ~1.5s worst case for 3 attempts)
- **Slow retries ACROSS scheduler ticks** (PR #34, ~1 min gap)

A 100ms TLS hiccup or a brief 5xx from your webhook endpoint no longer delays an alert by up to 60 seconds.

## The fix

### `internal/notify/retry.go` (new file)

```go
const defaultMaxSendAttempts = 3
const defaultInitialBackoff  = 500 * time.Millisecond

func retryTransient(ctx, maxAttempts, fn, isTransient) error { ... }
func isTransientHTTPError(err) bool { ... }
func isTransientSMTPError(err) bool { ... }
```

`retryTransient`:
- Runs `fn` up to `maxAttempts` times
- Exponential backoff (500ms, 1s) + up to 25% jitter between attempts
- Bails immediately on permanent errors (skips the backoff)
- Honors `ctx` cancellation during backoff sleeps — a cancelled ctx returns the last error immediately rather than waiting out the full retry window

`isTransientHTTPError`:
- **Permanent**: invalid URL, marshal payload, create request, 4xx responses
- **Transient**: 5xx responses, network/DNS/TCP/TLS errors

`isTransientSMTPError`:
- Very permissive — retries all non-nil errors. SMTP error taxonomy at the Go SDK level is not crisp enough to safely classify. The outer cooldown loop (PR #34) handles persistent failures.

### `internal/notify/notify.go`

Wrapped the HTTP/SMTP call in each send function with `retryTransient`. Idempotent setup (payload build, JSON marshal, sanitization) stays outside the retry — re-marshaling the same payload on every attempt would be wasted work.

- `sendWebhook` — HTTP call wrapped
- `sendWebhookToURL` — HTTP call wrapped; `validateWebhookURL` stays outside because validation failures are permanent
- `sendEmail` — **now takes a `context.Context` parameter**. SMTP call wrapped. Updated both call sites (`n.send` and `n.sendWithPrefs`) to pass ctx through.

## Tests

### `internal/notify/retry_test.go` (new, 10 tests)

**Unit tests for `retryTransient`** (pure logic):
- `ReturnsNilOnFirstSuccess` — happy path
- `StopsImmediatelyOnPermanentError` — 1 attempt on permanent error
- `RetriesUpToMaxOnTransientError` — 3 attempts when all fail
- `SuccessAfterTransientFailures` — recovery on the last attempt
- `RespectsContextCancellation` — ctx cancel during backoff returns last error immediately, bounded by `time.After` so a broken implementation times out fast

**Unit tests for `isTransientHTTPError`** (table-driven):
- nil, invalid URL, marshal payload, create request, 4xx (permanent), 5xx (transient), network/DNS errors (transient)

**Integration tests against real `httptest` servers**:
- `SendWebhook_RetriesOn5xxAndEventuallySucceeds` — server returns 500 for first 2 requests then 200, verifies 3 attempts were made and the send succeeded
- `SendWebhook_StopsImmediatelyOn4xx` — server returns 404, verifies exactly 1 attempt (no retries)
- `SendWebhook_RetriesAllAttemptsOn5xx` — server returns 500 always, verifies all 3 attempts were made

The retry tests take real time (~1.5s each for the failure paths) because the backoff is real. Mocking time would hide the actual retry behavior and is brittle.

### `internal/notify/notify_test.go` (updated)

`drainTimeout` constant raised from 100ms to 5s. PR #34's `waitForDrain` helper assumed failed sends were near-instant; after this PR they take up to ~1.5s due to retry backoff. `TestCooldownNotConsumedByFailedSend` from PR #34 now waits the full retry window.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/notify/...` — all new + existing tests pass (10.8s total due to real backoff sleeps)
- [x] `go test ./...` — full suite green
- [x] `go test -race ./internal/notify/...` — **race detector clean**
- [ ] After deploy: verify alerts arrive faster during transient endpoint issues (expected delta: ~100ms instead of ~60s)
- [ ] After deploy: check logs for `[Notify] Webhook error:` entries that appear 1-2 times in quick succession (indicating a retry cycle) followed by eventual success

## Rollback

Four files touched: two new (`retry.go`, `retry_test.go`), two modified (`notify.go`, `notify_test.go`). No schema change. No config change. `git revert` removes cleanly.

## Base branch

This PR's base is `fix/33-cooldown-timing-bug` (PR #34), which stacks on `fix/23-wire-sync-failure-alerts` (PR #24). Full chain: `main → #24 → #34 → #39`. GitHub will auto-retarget to main as each parent merges. **Merge order: PR #24, PR #34, then this PR.**

## Explicitly NOT in scope

- **Configurable retry limits** — `defaultMaxSendAttempts` and `defaultInitialBackoff` are package constants. Easy to expose via `Config` in a follow-up if an operator wants different values. Current defaults are fine for the 3-user prod instance.
- **Retry-After header respect** for 429 responses — Slack webhooks don't use 429 in practice; a 429 would currently be treated as permanent (4xx branch). If users hit this, follow-up.
- **Ctx-aware `smtp.SendMail`** — stdlib doesn't support it. Would require a custom SMTP implementation.

## Protected regions (not touched)

- PR #22, PR #24, PR #34 behaviors (this PR extends them, doesn't modify them)
- All other open PRs touch different packages
- Recurring events dedup, RRULE filter, cross-calendar fix, WebDAV-Sync helpers

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)