### PR TITLE
fix: surface finishSync DB write failures in result.Warnings (#45)

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -20,11 +20,11 @@ import (
 )
 
 var (
-	ErrConnectionFailed  = errors.New("connection failed")
-	ErrAuthFailed        = errors.New("authentication failed")
-	ErrNotFound          = errors.New("resource not found")
-	ErrInvalidResponse   = errors.New("invalid server response")
-	ErrMalformedContent  = errors.New("malformed calendar content")
+	ErrConnectionFailed = errors.New("connection failed")
+	ErrAuthFailed       = errors.New("authentication failed")
+	ErrNotFound         = errors.New("resource not found")
+	ErrInvalidResponse  = errors.New("invalid server response")
+	ErrMalformedContent = errors.New("malformed calendar content")
 )
 
 const (
@@ -333,28 +333,38 @@ func (c *Client) getEventsBatch(ctx context.Context, calendarPath string, paths 
 			ETag: obj.ETag,
 		}
 
-		if obj.Data != nil {
-			event.Data = encodeCalendar(obj.Data)
-
-			for _, evt := range obj.Data.Events() {
-				if uid, err := evt.Props.Text(ical.PropUID); err == nil {
-					event.UID = uid
-				}
-				if summary, err := evt.Props.Text(ical.PropSummary); err == nil {
-					event.Summary = summary
-				}
-				if dtstart := evt.Props.Get(ical.PropDateTimeStart); dtstart != nil {
-					event.StartTime = normalizeStartTime(dtstart)
-				}
-			}
-		}
-
-		if event.Data == "" {
+		if obj.Data == nil {
 			if collector != nil {
-				collector.Add(obj.Path, "empty iCalendar data - event may be corrupted or deleted")
+				collector.Add(obj.Path, "nil iCalendar data - event may be corrupted or deleted")
 			}
 			skippedEmpty++
 			continue
+		}
+
+		data, encErr := encodeCalendar(obj.Data)
+		if encErr != nil {
+			// Encode failure is a form of malformed content — the go-ical
+			// encoder rejected calendar data that the library itself had
+			// just parsed. Track it distinctly from the "empty data" case
+			// so the dashboard can surface the real cause.
+			if collector != nil {
+				collector.Add(obj.Path, fmt.Sprintf("failed to encode event: %v", encErr))
+			}
+			skippedMalformed++
+			continue
+		}
+		event.Data = data
+
+		for _, evt := range obj.Data.Events() {
+			if uid, err := evt.Props.Text(ical.PropUID); err == nil {
+				event.UID = uid
+			}
+			if summary, err := evt.Props.Text(ical.PropSummary); err == nil {
+				event.Summary = summary
+			}
+			if dtstart := evt.Props.Get(ical.PropDateTimeStart); dtstart != nil {
+				event.StartTime = normalizeStartTime(dtstart)
+			}
 		}
 
 		events = append(events, event)
@@ -395,31 +405,42 @@ func (c *Client) getEventsIndividually(ctx context.Context, paths []string, coll
 	return events, skippedMalformed, skippedEmpty
 }
 
-// objectsToEvents converts CalDAV objects to Events.
+// objectsToEvents converts CalDAV objects to Events. Events that fail to
+// encode (or have nil data) are skipped and logged — the returned slice
+// may have fewer entries than the input. This is safer than the prior
+// behavior, which silently stored Event{Data: ""} values that then flowed
+// into the sync engine as if they were valid events.
 func (c *Client) objectsToEvents(objects []caldav.CalendarObject) []Event {
 	events := make([]Event, 0, len(objects))
 	for _, obj := range objects {
+		if obj.Data == nil {
+			log.Printf("objectsToEvents: skipping %s with nil data", obj.Path)
+			continue
+		}
+
+		data, encErr := encodeCalendar(obj.Data)
+		if encErr != nil {
+			log.Printf("objectsToEvents: skipping %s, encode failed: %v", obj.Path, encErr)
+			continue
+		}
+
 		event := Event{
 			Path: obj.Path,
 			ETag: obj.ETag,
+			Data: data,
 		}
 
-		if obj.Data != nil {
-			// Encode the calendar to string
-			event.Data = encodeCalendar(obj.Data)
-
-			// Extract UID, Summary, and StartTime from events
-			for _, evt := range obj.Data.Events() {
-				if uid, err := evt.Props.Text(ical.PropUID); err == nil {
-					event.UID = uid
-				}
-				if summary, err := evt.Props.Text(ical.PropSummary); err == nil {
-					event.Summary = summary
-				}
-				// Extract start time for deduplication (normalized to UTC)
-				if dtstart := evt.Props.Get(ical.PropDateTimeStart); dtstart != nil {
-					event.StartTime = normalizeStartTime(dtstart)
-				}
+		// Extract UID, Summary, and StartTime from events
+		for _, evt := range obj.Data.Events() {
+			if uid, err := evt.Props.Text(ical.PropUID); err == nil {
+				event.UID = uid
+			}
+			if summary, err := evt.Props.Text(ical.PropSummary); err == nil {
+				event.Summary = summary
+			}
+			// Extract start time for deduplication (normalized to UTC)
+			if dtstart := evt.Props.Get(ical.PropDateTimeStart); dtstart != nil {
+				event.StartTime = normalizeStartTime(dtstart)
 			}
 		}
 
@@ -550,7 +571,16 @@ func (c *Client) GetEvent(ctx context.Context, eventPath string) (*Event, error)
 	}
 
 	if obj.Data != nil {
-		event.Data = encodeCalendar(obj.Data)
+		data, encErr := encodeCalendar(obj.Data)
+		if encErr != nil {
+			// Encode failure is a form of malformed content. Return an
+			// error so getEventsIndividually's existing malformed-error
+			// detection classifies this correctly and records it in the
+			// MalformedEventCollector, rather than silently returning an
+			// Event{Data: ""} that downstream code would treat as valid.
+			return nil, encErr
+		}
+		event.Data = data
 
 		for _, evt := range obj.Data.Events() {
 			if uid, err := evt.Props.Text(ical.PropUID); err == nil {
@@ -635,14 +665,30 @@ func parseICalendar(data string) (*ical.Calendar, error) {
 	return cal, nil
 }
 
-// encodeCalendar encodes a calendar object to iCalendar string.
-func encodeCalendar(cal *ical.Calendar) string {
+// encodeCalendar encodes a calendar object to iCalendar string form.
+//
+// Returns an error wrapping ErrMalformedContent if the go-ical encoder
+// fails. Previously this function silently returned an empty string on
+// encode failure, which led to three distinct forms of data corruption:
+//
+//  1. getEventsBatch misclassified encode failures as "empty iCalendar
+//     data" in the MalformedEventCollector, hiding the real cause.
+//  2. objectsToEvents silently stored Event{Data: ""} in its returned
+//     slice and never checked, letting corrupt events flow into the
+//     sync engine as if they were normal.
+//  3. GetEvent returned a zero-Data Event with err == nil, so callers
+//     believed the fetch had succeeded.
+//
+// All callers now MUST handle the error explicitly. Encode failures
+// should be treated as malformed events — recorded in a collector where
+// one is available, logged where one is not, and the event skipped.
+func encodeCalendar(cal *ical.Calendar) (string, error) {
 	var buf bytes.Buffer
 	enc := ical.NewEncoder(&buf)
 	if err := enc.Encode(cal); err != nil {
-		return ""
+		return "", fmt.Errorf("%w: %w", ErrMalformedContent, err)
 	}
-	return buf.String()
+	return buf.String(), nil
 }
 
 // normalizeStartTime converts a DTSTART property to a normalized UTC string for comparison.

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -25,6 +25,13 @@ var (
 	ErrNotFound         = errors.New("resource not found")
 	ErrInvalidResponse  = errors.New("invalid server response")
 	ErrMalformedContent = errors.New("malformed calendar content")
+	// ErrEventSkipped indicates that PutEvent intentionally did NOT write
+	// the event to the destination (empty data, missing UID, etc.). This
+	// is distinct from a connection/auth/write failure. Callers that
+	// treat all non-nil errors as failures will show these events in
+	// warnings, which is wrong — they are skips, not errors. Use
+	// errors.Is(err, ErrEventSkipped) to distinguish.
+	ErrEventSkipped = errors.New("event skipped")
 )
 
 const (
@@ -599,12 +606,25 @@ func (c *Client) GetEvent(ctx context.Context, eventPath string) (*Event, error)
 	return event, nil
 }
 
-// PutEvent creates or updates an event.
+// PutEvent creates or updates an event on the destination calendar.
+//
+// Return values:
+//   - nil: the event was successfully written.
+//   - wrapped ErrEventSkipped: the event was intentionally NOT written
+//     because it had empty data or no extractable UID. Callers should
+//     count these as "skipped" in the sync result, NOT as "created" or
+//     "updated". Use errors.Is(err, ErrEventSkipped) to detect.
+//   - any other non-nil error: a real failure (parse, connection, auth,
+//     write). Callers should surface these in result.Warnings or
+//     result.Errors as appropriate.
 func (c *Client) PutEvent(ctx context.Context, calendarPath string, event *Event) error {
-	// Skip events with empty data
+	// Skip events with empty data. This is NOT a success — we did not
+	// write anything. Previously this returned nil, which made the
+	// caller's `result.Created++` bookkeeping lie.
 	if event.Data == "" {
 		log.Printf("PutEvent: skipping event with empty data (UID: %s, summary: %s)", event.UID, event.Summary)
-		return nil
+		return fmt.Errorf("%w: empty iCalendar data (UID: %s, summary: %s)",
+			ErrEventSkipped, event.UID, event.Summary)
 	}
 
 	// Parse the iCalendar data
@@ -631,9 +651,12 @@ func (c *Client) PutEvent(ctx context.Context, calendarPath string, event *Event
 		if event.UID != "" {
 			path = strings.TrimSuffix(calendarPath, "/") + "/" + event.UID + ".ics"
 		} else {
-			// Skip events without UID - can't create a valid path
+			// Skip events without UID — can't construct a valid path. Same
+			// honesty contract as the empty-data case above: return a
+			// wrapped sentinel so the caller counts this as a skip.
 			log.Printf("PutEvent: skipping event without UID (summary: %s)", event.Summary)
-			return nil
+			return fmt.Errorf("%w: no UID extractable from event data (summary: %s)",
+				ErrEventSkipped, event.Summary)
 		}
 	}
 

--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -313,7 +313,62 @@ func (c *Client) getEventsViaList(ctx context.Context, calendarPath string, coll
 	return events, nil
 }
 
+// normalizeMultiGetPath returns a canonical form of a CalDAV object path
+// suitable for equality comparison between a request path (which may be
+// URL-decoded by parseEventPaths) and a response path (which may be
+// URL-encoded, or have a trailing slash added by some servers).
+//
+// The comparison is intentionally loose: percent-escapes are decoded,
+// trailing slashes are trimmed. Case is preserved since CalDAV paths
+// can be case-sensitive depending on the server.
+func normalizeMultiGetPath(p string) string {
+	if decoded, err := url.PathUnescape(p); err == nil {
+		p = decoded
+	}
+	return strings.TrimRight(p, "/")
+}
+
+// findDroppedMultiGetPaths returns the subset of requestedPaths that do
+// not appear in returnedPaths, using normalized comparison. Used to
+// detect paths that the go-webdav library silently dropped during a
+// MultiGetCalendar call — typically because the library could not parse
+// that entry's response and discarded it without reporting.
+//
+// Exposed (unexported but free function) so it can be unit-tested
+// without touching the real CalDAV client.
+func findDroppedMultiGetPaths(requestedPaths, returnedPaths []string) []string {
+	if len(requestedPaths) == 0 {
+		return nil
+	}
+	returned := make(map[string]bool, len(returnedPaths))
+	for _, p := range returnedPaths {
+		returned[normalizeMultiGetPath(p)] = true
+	}
+	var dropped []string
+	for _, p := range requestedPaths {
+		if !returned[normalizeMultiGetPath(p)] {
+			dropped = append(dropped, p)
+		}
+	}
+	return dropped
+}
+
 // getEventsBatch fetches a batch of events using MULTIGET.
+//
+// Beyond the obvious "fetch these paths", this function also detects and
+// reports paths that the go-webdav library silently drops from the
+// response. The library occasionally discards entries it cannot parse,
+// and those paths vanish without any error or log — they're simply
+// missing from the returned objects slice. Before this function detected
+// that, malformed events at the protocol level were completely invisible
+// to users: the dashboard's "Corrupted Events" card stayed empty while
+// real corruption was silently losing data.
+//
+// For each dropped path, we fall back to an individual GetEvent call,
+// which returns a concrete error that we can record in the
+// MalformedEventCollector. That's one extra HTTP round-trip per dropped
+// path, but only for paths that are genuinely problematic — in normal
+// operation the fallback loop doesn't execute at all.
 func (c *Client) getEventsBatch(ctx context.Context, calendarPath string, paths []string, collector *MalformedEventCollector) ([]Event, int, int, error) {
 	multiGet := &caldav.CalendarMultiGet{
 		Paths: paths,
@@ -375,6 +430,37 @@ func (c *Client) getEventsBatch(ctx context.Context, calendarPath string, paths 
 		}
 
 		events = append(events, event)
+	}
+
+	// Detect paths that MULTIGET silently dropped and probe them
+	// individually. See the function doc comment for the full rationale.
+	returnedPaths := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		returnedPaths = append(returnedPaths, obj.Path)
+	}
+	dropped := findDroppedMultiGetPaths(paths, returnedPaths)
+	if len(dropped) > 0 {
+		log.Printf("MULTIGET response missing %d of %d requested paths; probing individually to classify", len(dropped), len(paths))
+	}
+	for _, missingPath := range dropped {
+		_, probeErr := c.GetEvent(ctx, missingPath)
+		if probeErr != nil {
+			// Got a concrete error from the individual fetch. Record it
+			// in the collector so the user sees it on the dashboard.
+			if collector != nil {
+				collector.Add(missingPath, fmt.Sprintf("MULTIGET silently dropped this event; individual fetch returned: %v", probeErr))
+			}
+			skippedMalformed++
+			continue
+		}
+		// Individual fetch succeeded where MULTIGET didn't. This is
+		// weird but not data loss — log it so the next sync cycle's
+		// MULTIGET can try again. Don't add the recovered event to
+		// the return slice because the existing processing loop
+		// already ran without it; mixing in a late addition would
+		// require re-running all the extract logic here and we'd
+		// rather keep the happy path simple.
+		log.Printf("MULTIGET dropped %s but individual GetEvent succeeded; will retry on next sync", missingPath)
 	}
 
 	return events, skippedMalformed, skippedEmpty, nil

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -16,9 +16,9 @@ import (
 
 func TestEventDedupeKey(t *testing.T) {
 	testCases := []struct {
-		name      string
-		event     Event
-		expected  string
+		name     string
+		event    Event
+		expected string
 	}{
 		{
 			name: "combines summary and start time",
@@ -962,7 +962,10 @@ func TestEncodeCalendar(t *testing.T) {
 			t.Fatalf("failed to parse: %v", err)
 		}
 
-		result := encodeCalendar(cal)
+		result, err := encodeCalendar(cal)
+		if err != nil {
+			t.Fatalf("unexpected encode error: %v", err)
+		}
 		if result == "" {
 			t.Error("expected non-empty result")
 		}
@@ -979,18 +982,27 @@ func TestEncodeCalendar(t *testing.T) {
 		}
 	})
 
-	t.Run("returns empty string when encoding fails", func(t *testing.T) {
-		// Create a calendar missing required DTSTAMP - encoding should fail
+	t.Run("returns ErrMalformedContent when encoding fails", func(t *testing.T) {
+		// Create a calendar missing required DTSTAMP - encoding should fail.
+		// Previously the function silently returned an empty string; now
+		// it must return a wrapped ErrMalformedContent so callers can
+		// classify this as a malformed event.
 		data := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\nBEGIN:VEVENT\r\nUID:test-uid@example.com\r\nDTSTART:20240115T140000Z\r\nSUMMARY:Test Event\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
 
-		cal, err := parseICalendar(data)
-		if err != nil {
-			t.Fatalf("failed to parse: %v", err)
+		cal, parseErr := parseICalendar(data)
+		if parseErr != nil {
+			t.Fatalf("failed to parse: %v", parseErr)
 		}
 
-		result := encodeCalendar(cal)
+		result, err := encodeCalendar(cal)
+		if err == nil {
+			t.Fatal("expected an error when encoding a calendar missing required DTSTAMP, got nil")
+		}
+		if !errors.Is(err, ErrMalformedContent) {
+			t.Errorf("expected wrapped ErrMalformedContent, got %v", err)
+		}
 		if result != "" {
-			t.Error("expected empty string when encoding fails due to missing DTSTAMP")
+			t.Errorf("expected empty string on error, got %q", result)
 		}
 	})
 }
@@ -1558,7 +1570,14 @@ func TestObjectsToEvents(t *testing.T) {
 		}
 	})
 
-	t.Run("converts object without data", func(t *testing.T) {
+	t.Run("skips object with nil data", func(t *testing.T) {
+		// Issue #29 fix: objects with nil Data are silent-corruption
+		// sources and must NOT be returned to the sync engine as
+		// Event{Data: ""}. The previous behavior returned them with
+		// empty Data, which then flowed into PutEvent at call sites
+		// that didn't bother to check event.Data first. Now they
+		// are logged and skipped so the returned slice only contains
+		// events with valid content.
 		objects := []caldav.CalendarObject{
 			{
 				Path: "/calendars/user/default/event1.ics",
@@ -1567,18 +1586,8 @@ func TestObjectsToEvents(t *testing.T) {
 		}
 
 		events := client.objectsToEvents(objects)
-		if len(events) != 1 {
-			t.Fatalf("expected 1 event, got %d", len(events))
-		}
-
-		if events[0].Path != "/calendars/user/default/event1.ics" {
-			t.Errorf("expected path, got %q", events[0].Path)
-		}
-		if events[0].ETag != "etag123" {
-			t.Errorf("expected etag, got %q", events[0].ETag)
-		}
-		if events[0].Data != "" {
-			t.Errorf("expected empty data, got %q", events[0].Data)
+		if len(events) != 0 {
+			t.Fatalf("expected nil-data object to be skipped, got %d events", len(events))
 		}
 	})
 

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -195,15 +195,16 @@ func TestEventStruct(t *testing.T) {
 
 func TestErrorConstants(t *testing.T) {
 	t.Run("error constants are not nil", func(t *testing.T) {
-		errors := []error{
+		errs := []error{
 			ErrConnectionFailed,
 			ErrAuthFailed,
 			ErrNotFound,
 			ErrInvalidResponse,
 			ErrMalformedContent,
+			ErrEventSkipped,
 		}
 
-		for _, err := range errors {
+		for _, err := range errs {
 			if err == nil {
 				t.Error("expected error constant to be non-nil")
 			}
@@ -219,6 +220,82 @@ func TestErrorConstants(t *testing.T) {
 		}
 		if ErrNotFound.Error() != "resource not found" {
 			t.Errorf("unexpected error message: %q", ErrNotFound.Error())
+		}
+		if ErrEventSkipped.Error() != "event skipped" {
+			t.Errorf("unexpected error message: %q", ErrEventSkipped.Error())
+		}
+	})
+}
+
+// TestPutEventSkipPaths verifies that PutEvent returns a wrapped
+// ErrEventSkipped sentinel (instead of nil) for events that cannot be
+// written due to bad input. This is the Issue #31 fix — previously the
+// two skip paths returned nil, causing callers to falsely increment
+// result.Created / result.Updated and pollute synced_events tracking
+// with UIDs that were never actually written to the destination.
+func TestPutEventSkipPaths(t *testing.T) {
+	// Any URL works here — the short-circuit paths we're testing fire
+	// before any HTTP request is constructed, so the URL is never dialed.
+	client, err := NewClient("https://example.test/cal", "user", "pass")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	t.Run("empty data returns wrapped ErrEventSkipped", func(t *testing.T) {
+		event := &Event{
+			UID:     "some-uid",
+			Summary: "empty data test",
+			Data:    "",
+		}
+
+		putErr := client.PutEvent(context.Background(), "/cal", event)
+		if putErr == nil {
+			t.Fatal("expected error for empty data, got nil — PutEvent is silently skipping (the Issue #31 bug)")
+		}
+		if !errors.Is(putErr, ErrEventSkipped) {
+			t.Errorf("expected wrapped ErrEventSkipped, got %v", putErr)
+		}
+		// The error message should contain context about why the skip happened.
+		if !strings.Contains(putErr.Error(), "empty") {
+			t.Errorf("expected error message to mention 'empty', got %q", putErr.Error())
+		}
+	})
+
+	t.Run("missing UID returns wrapped ErrEventSkipped", func(t *testing.T) {
+		// Valid iCalendar data but no UID property — triggers the second
+		// skip path where PutEvent tries to extract a UID from the parsed
+		// calendar data, fails, and refuses to construct a destination path.
+		data := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nBEGIN:VEVENT\r\nDTSTAMP:20240115T120000Z\r\nDTSTART:20240115T140000Z\r\nSUMMARY:No UID\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+		event := &Event{
+			Summary: "no UID test",
+			Data:    data,
+			// UID and Path deliberately unset
+		}
+
+		putErr := client.PutEvent(context.Background(), "/cal", event)
+		if putErr == nil {
+			t.Fatal("expected error for missing UID, got nil — PutEvent is silently skipping (the Issue #31 bug)")
+		}
+		if !errors.Is(putErr, ErrEventSkipped) {
+			t.Errorf("expected wrapped ErrEventSkipped, got %v", putErr)
+		}
+		if !strings.Contains(putErr.Error(), "UID") {
+			t.Errorf("expected error message to mention 'UID', got %q", putErr.Error())
+		}
+	})
+
+	t.Run("errors.Is distinguishes ErrEventSkipped from other errors", func(t *testing.T) {
+		// Sanity check the errors.Is semantics callers rely on.
+		skipErr := &Event{Data: ""}
+		err := client.PutEvent(context.Background(), "/cal", skipErr)
+		if !errors.Is(err, ErrEventSkipped) {
+			t.Error("errors.Is(err, ErrEventSkipped) should be true for skip errors")
+		}
+		if errors.Is(err, ErrConnectionFailed) {
+			t.Error("errors.Is(err, ErrConnectionFailed) must be false for skip errors — they are not connection failures")
+		}
+		if errors.Is(err, ErrMalformedContent) {
+			t.Error("errors.Is(err, ErrMalformedContent) must be false for skip errors — empty data is not malformed, just absent")
 		}
 	})
 }

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -1489,6 +1489,140 @@ func TestIsMalformedErrorEdgeCases(t *testing.T) {
 	}
 }
 
+// TestNormalizeMultiGetPath verifies that request and response paths
+// compare equal despite differences in URL encoding and trailing
+// slashes. Without this normalization, findDroppedMultiGetPaths would
+// produce false positives whenever the server returned a response path
+// in a slightly different form from the request.
+func TestNormalizeMultiGetPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no changes for a plain path",
+			in:   "/cal/event123.ics",
+			want: "/cal/event123.ics",
+		},
+		{
+			name: "trailing slash stripped",
+			in:   "/cal/event123.ics/",
+			want: "/cal/event123.ics",
+		},
+		{
+			name: "URL-encoded space decoded",
+			in:   "/cal/event%20with%20space.ics",
+			want: "/cal/event with space.ics",
+		},
+		{
+			name: "URL-encoded special chars decoded",
+			in:   "/cal/%5Bbracket%5D.ics",
+			want: "/cal/[bracket].ics",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "only slash",
+			in:   "/",
+			want: "",
+		},
+		{
+			name: "mixed encoding and trailing slash",
+			in:   "/cal/a%20b.ics/",
+			want: "/cal/a b.ics",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeMultiGetPath(tt.in)
+			if got != tt.want {
+				t.Errorf("normalizeMultiGetPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFindDroppedMultiGetPaths verifies the detection logic for MULTIGET
+// responses that are missing requested entries. This is the core of
+// Issue #35 — catching silent data loss that was previously invisible.
+func TestFindDroppedMultiGetPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested []string
+		returned  []string
+		want      []string
+	}{
+		{
+			name:      "all paths returned, nothing dropped",
+			requested: []string{"/cal/a.ics", "/cal/b.ics", "/cal/c.ics"},
+			returned:  []string{"/cal/a.ics", "/cal/b.ics", "/cal/c.ics"},
+			want:      nil,
+		},
+		{
+			name:      "one path dropped",
+			requested: []string{"/cal/a.ics", "/cal/b.ics", "/cal/c.ics"},
+			returned:  []string{"/cal/a.ics", "/cal/c.ics"},
+			want:      []string{"/cal/b.ics"},
+		},
+		{
+			name:      "multiple paths dropped",
+			requested: []string{"/cal/a.ics", "/cal/b.ics", "/cal/c.ics", "/cal/d.ics"},
+			returned:  []string{"/cal/a.ics", "/cal/d.ics"},
+			want:      []string{"/cal/b.ics", "/cal/c.ics"},
+		},
+		{
+			name:      "all dropped (empty response)",
+			requested: []string{"/cal/a.ics", "/cal/b.ics"},
+			returned:  []string{},
+			want:      []string{"/cal/a.ics", "/cal/b.ics"},
+		},
+		{
+			name:      "empty request returns empty result",
+			requested: nil,
+			returned:  []string{"/unexpected.ics"},
+			want:      nil,
+		},
+		{
+			name:      "URL-encoding differences are not false positives",
+			requested: []string{"/cal/event with space.ics", "/cal/plain.ics"},
+			returned:  []string{"/cal/event%20with%20space.ics", "/cal/plain.ics"},
+			want:      nil,
+		},
+		{
+			name:      "trailing-slash differences are not false positives",
+			requested: []string{"/cal/a.ics", "/cal/b.ics"},
+			returned:  []string{"/cal/a.ics/", "/cal/b.ics"},
+			want:      nil,
+		},
+		{
+			name:      "response has extra paths (shouldn't happen but shouldn't panic)",
+			requested: []string{"/cal/a.ics"},
+			returned:  []string{"/cal/a.ics", "/cal/unexpected.ics"},
+			want:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findDroppedMultiGetPaths(tt.requested, tt.returned)
+			if len(got) != len(tt.want) {
+				t.Fatalf("findDroppedMultiGetPaths() returned %d paths, want %d\n got = %v\nwant = %v",
+					len(got), len(tt.want), got, tt.want)
+			}
+			// Order-sensitive comparison: findDroppedMultiGetPaths iterates
+			// requested in order, so the result preserves that order.
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("findDroppedMultiGetPaths()[%d] = %q, want %q", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestMalformedEventCollectorMultipleOperations(t *testing.T) {
 	t.Run("handles large number of events", func(t *testing.T) {
 		collector := NewMalformedEventCollector()

--- a/internal/caldav/ics_client.go
+++ b/internal/caldav/ics_client.go
@@ -183,10 +183,10 @@ func (c *ICSClient) FetchEvents(ctx context.Context, collector *MalformedEventCo
 			singleCal.Children = append(singleCal.Children, vevent)
 		}
 
-		data := encodeCalendar(singleCal)
-		if data == "" {
+		data, encErr := encodeCalendar(singleCal)
+		if encErr != nil {
 			if collector != nil {
-				collector.Add(uid, "failed to encode event")
+				collector.Add(uid, fmt.Sprintf("failed to encode event: %v", encErr))
 			}
 			continue
 		}

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -1089,6 +1089,13 @@ func (se *SyncEngine) TestICSConnection(ctx context.Context, url, username, pass
 	return client.TestConnection(ctx)
 }
 
+// finishSyncPersistenceWarningPrefix is the constant prefix used for
+// warnings that finishSync appends when a DB write fails after all
+// retries. A dedicated prefix lets callers and future alert-classifier
+// extensions detect these persistence failures specifically, without
+// having to parse the full warning text.
+const finishSyncPersistenceWarningPrefix = "sync persistence failure: "
+
 func (se *SyncEngine) finishSync(sourceID string, result *SyncResult) {
 	// Determine status: error > partial > success
 	var status db.SyncStatus
@@ -1100,11 +1107,19 @@ func (se *SyncEngine) finishSync(sourceID string, result *SyncResult) {
 		status = db.SyncStatusSuccess
 	}
 
-	// Update status with retry for concurrent access
+	// Update status with retry for concurrent access. If the write
+	// fails after all retries, append a warning to the result so the
+	// failure is visible to callers (who inspect result.Warnings),
+	// gets recorded in the sync log details below, and surfaces on
+	// the dashboard instead of being silently swallowed as a log
+	// line nobody reads.
 	if err := retryDBOperation(func() error {
 		return se.db.UpdateSourceSyncStatus(sourceID, status, result.Message)
 	}, 5); err != nil {
-		log.Printf("Failed to update sync status after retries: %v", err)
+		msg := fmt.Sprintf("%sfailed to update sync status after retries: %v",
+			finishSyncPersistenceWarningPrefix, err)
+		log.Printf("%s", msg)
+		result.Warnings = append(result.Warnings, msg)
 	}
 
 	// Create sync log with detailed stats
@@ -1121,7 +1136,9 @@ func (se *SyncEngine) finishSync(sourceID string, result *SyncResult) {
 		EventsProcessed: result.EventsProcessed,
 	}
 
-	// Include both errors and warnings in details (sanitized to remove sensitive info)
+	// Include both errors and warnings in details (sanitized to remove sensitive info).
+	// If the UpdateSourceSyncStatus call above failed, its warning was
+	// just appended to result.Warnings and will be captured here.
 	var details []string
 	if len(result.Errors) > 0 {
 		details = append(details, fmt.Sprintf("Errors: %v", result.Errors))
@@ -1133,11 +1150,18 @@ func (se *SyncEngine) finishSync(sourceID string, result *SyncResult) {
 		syncLog.Details = sanitizeLogDetails(strings.Join(details, "\n"))
 	}
 
-	// Create sync log with retry for concurrent access
+	// Create sync log with retry for concurrent access. A failure here
+	// is inherently unrecordable (the sync log is what failed to write),
+	// so we can only append to result.Warnings and log inline. Callers
+	// that inspect the returned SyncResult will still see the warning,
+	// even though it won't appear in the sync_logs table for this run.
 	if err := retryDBOperation(func() error {
 		return se.db.CreateSyncLog(syncLog)
 	}, 5); err != nil {
-		log.Printf("Failed to create sync log after retries: %v", err)
+		msg := fmt.Sprintf("%sfailed to create sync log after retries: %v",
+			finishSyncPersistenceWarningPrefix, err)
+		log.Printf("%s", msg)
+		result.Warnings = append(result.Warnings, msg)
 	}
 
 	// Finish activity tracking

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -377,7 +377,14 @@ func (se *SyncEngine) syncCalendar(ctx context.Context, source *db.Source, sourc
 						Data: item.Data,
 					}
 					if err := destClient.PutEvent(ctx, destCalendarPath, event); err != nil {
-						result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to sync event: %v", err))
+						if errors.Is(err, ErrEventSkipped) {
+							// PutEvent refused to write this event (empty data,
+							// missing UID). Count it as skipped rather than
+							// falsely incrementing Updated.
+							result.Skipped++
+						} else {
+							result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to sync event: %v", err))
+						}
 					} else {
 						result.Updated++
 					}
@@ -722,7 +729,15 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 
 			// Create new event on destination
 			if err := destClient.PutEvent(ctx, destCalendarPath, &sourceEvent); err != nil {
-				result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to create event on dest: %v", err))
+				if errors.Is(err, ErrEventSkipped) {
+					// PutEvent refused (empty data, missing UID). Count
+					// it as skipped. Do NOT mark the event as "ours" in
+					// destDedupeMap or currentUIDs since nothing was
+					// actually written to the destination.
+					result.Skipped++
+				} else {
+					result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to create event on dest: %v", err))
+				}
 			} else {
 				result.Created++
 				if dedupeKey != "|" {
@@ -736,7 +751,15 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 			// Update existing event
 			sourceEvent.Path = destEvent.Path
 			if err := destClient.PutEvent(ctx, destCalendarPath, &sourceEvent); err != nil {
-				result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to update event on dest: %v", err))
+				if errors.Is(err, ErrEventSkipped) {
+					// PutEvent refused. Don't add to currentUIDs —
+					// the destination still has the OLD version of
+					// this event, not an updated one, so we should
+					// not track it as freshly synced.
+					result.Skipped++
+				} else {
+					result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to update event on dest: %v", err))
+				}
 			} else {
 				result.Updated++
 				currentUIDs[sourceEvent.UID] = true
@@ -775,11 +798,15 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 				if source.ConflictStrategy == db.ConflictDestWins {
 					destEvent.Path = sourceEvent.Path
 					if err := sourceClient.PutEvent(ctx, calendar.Path, &destEvent); err != nil {
-						if isAlreadyExistsError(err) {
+						switch {
+						case errors.Is(err, ErrEventSkipped):
+							// Source PutEvent refused. Count as skipped.
+							result.Skipped++
+						case isAlreadyExistsError(err):
 							skippedAlreadyExists++
-						} else if isForbiddenError(err) {
+						case isForbiddenError(err):
 							skippedForbidden++
-						} else {
+						default:
 							result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to update event on source: %v", err))
 						}
 					} else {


### PR DESCRIPTION
## Summary

Closes #45. **Stacks on PR #36**. Fixes a silent-DB-error pattern in `internal/caldav/sync.go:finishSync`. Two DB operations (`UpdateSourceSyncStatus` and `CreateSyncLog`) were wrapped in `retryDBOperation` with log-only error handling. When the DB was busy/locked longer than 5 retries, the sync's final state was never persisted and the user's dashboard showed the previous state indefinitely.

## The fix

Append a warning to `result.Warnings` when either DB operation exhausts its retries. The warning text uses a dedicated prefix constant:

```go
const finishSyncPersistenceWarningPrefix = "sync persistence failure: "
```

This lets a future `notify.IsDangerousWarning` extension detect these specifically without parsing the full warning text.

### Placement matters

- **`UpdateSourceSyncStatus` failure** — warning appended BEFORE `syncLog` is built, so it's captured in `syncLog.Details` alongside other warnings. The user's sync_logs page will show the persistence failure as a visible warning entry.
- **`CreateSyncLog` failure** — warning appended AFTER (the log itself is what failed to write, so it can't record its own failure). Still visible in the returned `SyncResult` and logged inline.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — full suite green
- [ ] After deploy: force a DB write conflict (concurrent sync, file lock) and verify `sync persistence failure: ...` appears in the sync log details

## Behavior change

Additive only. Callers that inspect `result.Warnings` now see these previously-silent DB errors. No signature change. No schema change. Existing callers that ignore warnings see no behavior difference.

## Rollback

Single file change to `sync.go` (29 insertions, 5 deletions). `git revert` removes cleanly.

## Base branch

Stacks on `fix/35-multiget-malformed-detection` (PR #36). Full chain: `main → #30 → #32 → #36 → #45`. Merge order: PR #30, PR #32, PR #36, then this PR.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)