### PR TITLE
fix: record alert cooldown after successful send, not before (#33)

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -75,7 +75,11 @@ type Notifier struct {
 	cfg        *Config
 	httpClient *http.Client
 
-	// Track last alert time per source to implement cooldown
+	// Track last SUCCESSFUL alert time per source to implement cooldown.
+	// Previously this was set BEFORE the background send fired, so a
+	// failed send still consumed the cooldown window. Since Issue #33,
+	// the timestamp is recorded only after sendWithPrefs confirms at
+	// least one channel delivered.
 	mu             sync.RWMutex
 	lastAlertTimes map[string]time.Time
 	staleState     map[string]bool // Track if source is currently in stale state
@@ -84,6 +88,14 @@ type Notifier struct {
 	// source that is both stale and failing doesn't lose one signal because
 	// the other already consumed the cooldown window.
 	lastFailureAlertTimes map[string]time.Time
+
+	// inFlightAlerts tracks sends that have been queued but not yet
+	// completed, keyed by sourceID. Prevents duplicate alerts when
+	// concurrent callers both see "no cooldown set" and both try to
+	// fire. The flag is set synchronously in the Send* method and
+	// cleared inside the background goroutine after sendWithPrefs
+	// returns, regardless of delivery success.
+	inFlightAlerts map[string]bool
 }
 
 // New creates a new Notifier.
@@ -96,6 +108,7 @@ func New(cfg *Config) *Notifier {
 		lastAlertTimes:        make(map[string]time.Time),
 		staleState:            make(map[string]bool),
 		lastFailureAlertTimes: make(map[string]time.Time),
+		inFlightAlerts:        make(map[string]bool),
 	}
 }
 
@@ -462,11 +475,14 @@ func (n *Notifier) sendEmailTLS(addr string, auth smtp.Auth, from string, to []s
 }
 
 // ClearStaleState clears the stale state for a source (used on source deletion).
+// Also clears any in-flight stale alert guard so a new source reusing the
+// same ID starts with a clean slate.
 func (n *Notifier) ClearStaleState(sourceID string) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	delete(n.staleState, sourceID)
 	delete(n.lastAlertTimes, sourceID)
+	delete(n.inFlightAlerts, "stale:"+sourceID)
 }
 
 // GetStaleSourceIDs returns a list of currently stale source IDs.
@@ -485,23 +501,46 @@ func (n *Notifier) GetStaleSourceIDs() []string {
 
 // SendStaleAlertWithPrefs sends an alert for a stale source using per-user preferences.
 // userPrefs can be nil to use global defaults only.
+//
+// Since Issue #33, the cooldown timestamp is recorded only AFTER the
+// background send reports successful delivery. Previously it was set
+// synchronously before the goroutine fired, which meant a failed send
+// consumed the cooldown and the user got zero alerts for the entire
+// cooldown period on a broken alert endpoint.
+//
+// To prevent concurrent duplicate sends (two callers both seeing no
+// cooldown and both firing), an inFlightAlerts guard suppresses overlap
+// while a previous send is still in-flight.
 func (n *Notifier) SendStaleAlertWithPrefs(ctx context.Context, sourceID, sourceName, userEmail string, timeSinceSync, threshold time.Duration, userPrefs *UserPreferences) bool {
 	cooldown := n.getCooldownPeriod(userPrefs)
 
-	n.mu.Lock()
-	defer n.mu.Unlock()
+	// inFlightAlerts is keyed by "{type}:{sourceID}" so stale and failure
+	// alerts have independent in-flight slots and can fire concurrently
+	// for the same source.
+	inFlightKey := "stale:" + sourceID
 
-	// Check if already in stale state and in cooldown
+	n.mu.Lock()
+
+	// Check if already in stale state and in cooldown. lastAlertTimes
+	// now reflects the last SUCCESSFUL delivery, so a failed prior send
+	// won't block this one.
 	if n.staleState[sourceID] {
-		lastAlert, exists := n.lastAlertTimes[sourceID]
-		if exists && time.Since(lastAlert) < cooldown {
+		if lastAlert, exists := n.lastAlertTimes[sourceID]; exists && time.Since(lastAlert) < cooldown {
+			n.mu.Unlock()
 			return false // Still in cooldown
 		}
 	}
 
-	// Mark as stale and update alert time
+	// Deduplication: if a stale alert for this source is already in
+	// flight, suppress this one to avoid two concurrent sends.
+	if n.inFlightAlerts[inFlightKey] {
+		n.mu.Unlock()
+		return false
+	}
+	n.inFlightAlerts[inFlightKey] = true
 	n.staleState[sourceID] = true
-	n.lastAlertTimes[sourceID] = time.Now()
+
+	n.mu.Unlock()
 
 	alert := Alert{
 		Type:       AlertTypeStale,
@@ -513,8 +552,18 @@ func (n *Notifier) SendStaleAlertWithPrefs(ctx context.Context, sourceID, source
 		Timestamp:  time.Now(),
 	}
 
-	// Send in background to not block
-	go n.sendWithPrefs(ctx, alert, userPrefs)
+	// Send in background so the scheduler tick isn't blocked by SMTP
+	// or webhook latency. The cooldown is recorded inside the goroutine
+	// only if sendWithPrefs reports that at least one channel delivered.
+	go func() {
+		delivered := n.sendWithPrefs(ctx, alert, userPrefs)
+		n.mu.Lock()
+		delete(n.inFlightAlerts, inFlightKey)
+		if delivered {
+			n.lastAlertTimes[sourceID] = time.Now()
+		}
+		n.mu.Unlock()
+	}()
 	return true
 }
 
@@ -563,28 +612,43 @@ func (n *Notifier) getCooldownPeriod(userPrefs *UserPreferences) time.Duration {
 // a source that is both stale AND failing will not lose one signal because
 // the other already consumed the cooldown.
 //
+// Since Issue #33, the cooldown timestamp is recorded only AFTER the
+// background send reports successful delivery. Previously it was set
+// synchronously before the goroutine fired, which meant a failed send
+// consumed the cooldown for the full window.
+//
 // errorMessage is a short human-readable summary shown in the alert subject.
 // details is the full error/warning text shown in the alert body.
 //
-// Returns true if the alert was queued for send, false if still in cooldown.
+// Returns true if the alert was queued for send, false if still in cooldown
+// or a prior send is still in flight.
 func (n *Notifier) SendSyncFailureAlertWithPrefs(
 	ctx context.Context,
 	sourceID, sourceName, userEmail, errorMessage, details string,
 	userPrefs *UserPreferences,
 ) bool {
 	cooldown := n.getCooldownPeriod(userPrefs)
+	inFlightKey := "failure:" + sourceID
 
 	n.mu.Lock()
-	defer n.mu.Unlock()
 
 	// Cooldown check — failure alerts use their own map, independent of
-	// the stale-alert cooldown.
-	if lastAlert, exists := n.lastFailureAlertTimes[sourceID]; exists {
-		if time.Since(lastAlert) < cooldown {
-			return false
-		}
+	// the stale-alert cooldown. lastFailureAlertTimes now reflects the
+	// last SUCCESSFUL delivery.
+	if lastAlert, exists := n.lastFailureAlertTimes[sourceID]; exists && time.Since(lastAlert) < cooldown {
+		n.mu.Unlock()
+		return false
 	}
-	n.lastFailureAlertTimes[sourceID] = time.Now()
+
+	// Deduplication: if a failure alert for this source is already in
+	// flight, suppress this one.
+	if n.inFlightAlerts[inFlightKey] {
+		n.mu.Unlock()
+		return false
+	}
+	n.inFlightAlerts[inFlightKey] = true
+
+	n.mu.Unlock()
 
 	alert := Alert{
 		Type:       AlertTypeError,
@@ -596,18 +660,29 @@ func (n *Notifier) SendSyncFailureAlertWithPrefs(
 		Timestamp:  time.Now(),
 	}
 
-	// Send in background to not block the scheduler.
-	go n.sendWithPrefs(ctx, alert, userPrefs)
+	// Send in background. Cooldown is recorded inside the goroutine only
+	// if at least one channel delivered.
+	go func() {
+		delivered := n.sendWithPrefs(ctx, alert, userPrefs)
+		n.mu.Lock()
+		delete(n.inFlightAlerts, inFlightKey)
+		if delivered {
+			n.lastFailureAlertTimes[sourceID] = time.Now()
+		}
+		n.mu.Unlock()
+	}()
 	return true
 }
 
 // ClearFailureAlertState clears the failure-alert cooldown for a source
 // (used on source deletion). Safe to call for sources that have never
-// triggered a failure alert.
+// triggered a failure alert. Also clears any in-flight failure alert
+// guard so a new source reusing the same ID starts with a clean slate.
 func (n *Notifier) ClearFailureAlertState(sourceID string) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	delete(n.lastFailureAlertTimes, sourceID)
+	delete(n.inFlightAlerts, "failure:"+sourceID)
 }
 
 // IsDangerousWarning returns true if a sync warning indicates a data-loss
@@ -630,8 +705,20 @@ func IsDangerousWarning(w string) bool {
 		strings.Contains(w, "exceeds safety threshold")
 }
 
-// sendWithPrefs sends the alert via configured channels, respecting per-user preferences.
-func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *UserPreferences) {
+// sendWithPrefs sends the alert via configured channels, respecting per-user
+// preferences. Returns true if at least one configured channel delivered
+// successfully — meaning the user actually received a notification.
+// Returns false if all configured channels failed, in which case the caller
+// must NOT record the cooldown timestamp (so the next retry can fire
+// immediately instead of being silenced for the full cooldown window).
+//
+// Since Issue #33, this return value is what distinguishes
+// "alert delivered, start the cooldown" from "alert attempted but bounced,
+// please retry on the next tick".
+func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *UserPreferences) bool {
+	anyAttempted := false
+	anyDelivered := false
+
 	// Determine if webhook is enabled (user pref overrides global)
 	webhookEnabled := n.cfg.WebhookEnabled
 	if userPrefs != nil && userPrefs.WebhookEnabled != nil {
@@ -640,8 +727,11 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 
 	// Send to global webhook if enabled
 	if webhookEnabled && n.cfg.WebhookURL != "" {
+		anyAttempted = true
 		if err := n.sendWebhook(ctx, alert); err != nil {
 			log.Printf("[Notify] Webhook error: %v", err)
+		} else {
+			anyDelivered = true
 		}
 	}
 
@@ -652,8 +742,11 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 			userWebhookEnabled = *userPrefs.WebhookEnabled
 		}
 		if userWebhookEnabled {
+			anyAttempted = true
 			if err := n.sendWebhookToURL(ctx, alert, userPrefs.WebhookURL); err != nil {
 				log.Printf("[Notify] User webhook error: %v", err)
+			} else {
+				anyDelivered = true
 			}
 		}
 	}
@@ -685,11 +778,23 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 		}
 
 		if len(recipients) > 0 {
+			anyAttempted = true
 			if err := n.sendEmail(alert, recipients); err != nil {
 				log.Printf("[Notify] Email error: %v", err)
+			} else {
+				anyDelivered = true
 			}
 		}
 	}
+
+	// If no channel was even configured/attempted, treat as "delivered" so
+	// the cooldown still applies — otherwise a notifier with no channels
+	// would busy-loop the scheduler. This matches the prior fire-and-forget
+	// behavior for the no-channel case.
+	if !anyAttempted {
+		return true
+	}
+	return anyDelivered
 }
 
 // sendWebhookToURL sends a webhook to a specific URL (for user webhooks).

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,9 +1,51 @@
 package notify
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
+
+// waitForDrain blocks until all in-flight alert sends have completed,
+// or until the timeout expires. Test helper for sequencing multi-alert
+// scenarios — since Issue #33, the cooldown timestamp is recorded
+// inside the background goroutine only after sendWithPrefs returns,
+// so tests that rely on cooldown-after-first-send must wait for
+// that goroutine to finish before making assertions about state.
+func waitForDrain(t *testing.T, n *Notifier) {
+	t.Helper()
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		n.mu.RLock()
+		empty := len(n.inFlightAlerts) == 0
+		n.mu.RUnlock()
+		if empty {
+			return
+		}
+		time.Sleep(500 * time.Microsecond)
+	}
+	t.Fatal("in-flight alerts did not drain within 100ms")
+}
+
+// waitForKeyDrain blocks until a specific in-flight key has cleared.
+// Used by tests that synthetically populate some keys and want to wait
+// for only the real goroutine(s) to finish, not the synthetic ones.
+func waitForKeyDrain(t *testing.T, n *Notifier, key string) {
+	t.Helper()
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		n.mu.RLock()
+		gone := !n.inFlightAlerts[key]
+		n.mu.RUnlock()
+		if gone {
+			return
+		}
+		time.Sleep(500 * time.Microsecond)
+	}
+	t.Fatalf("in-flight key %q did not clear within 100ms", key)
+}
 
 func TestValidateConfig(t *testing.T) {
 	tests := []struct {
@@ -473,6 +515,14 @@ func TestSendSyncFailureAlertUserCooldownOverride(t *testing.T) {
 		t.Fatal("first failure alert should fire")
 	}
 
+	// Wait for the first send's background goroutine to finish and
+	// clear its in-flight guard before attempting the second call.
+	// The in-flight dedup is Issue #33's fix for concurrent duplicate
+	// sends; without this wait the second call would be legitimately
+	// suppressed by the in-flight guard even though the cooldown
+	// itself is zero.
+	waitForDrain(t, n)
+
 	// With zero cooldown the second alert fires immediately.
 	sent = n.SendSyncFailureAlertWithPrefs(
 		nil, "source1", "Test Source", "user@example.com",
@@ -480,6 +530,265 @@ func TestSendSyncFailureAlertUserCooldownOverride(t *testing.T) {
 	)
 	if !sent {
 		t.Error("second alert should fire with zero-minute user cooldown")
+	}
+}
+
+// TestCooldownNotConsumedByFailedSend verifies Issue #33's core fix:
+// when a webhook send fails, the cooldown timestamp must NOT be recorded,
+// so the next alert attempt can fire immediately rather than being
+// silenced for the full cooldown window.
+//
+// Setup: point the webhook at an httptest server that always returns
+// HTTP 500, so the send reaches the server but sendWebhook reports a
+// delivery failure.
+func TestCooldownNotConsumedByFailedSend(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		WebhookEnabled: true,
+		WebhookURL:     server.URL,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+	ctx := context.Background()
+
+	// First attempt. Returns true (queued) but the background send will
+	// fail because the webhook returns 500.
+	sent := n.SendSyncFailureAlertWithPrefs(
+		ctx, "source1", "Test Source", "user@example.com",
+		"Sync failed", "first attempt", nil,
+	)
+	if !sent {
+		t.Fatal("first failure alert should be queued")
+	}
+
+	// Wait for the background send to finish failing.
+	waitForDrain(t, n)
+
+	// Cooldown should NOT be set because the delivery failed.
+	n.mu.RLock()
+	_, cooldownSet := n.lastFailureAlertTimes["source1"]
+	n.mu.RUnlock()
+	if cooldownSet {
+		t.Error("cooldown should NOT be set after a failed send; failed deliveries must not consume the cooldown window")
+	}
+
+	// Second attempt must succeed because the cooldown was not consumed.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		ctx, "source1", "Test Source", "user@example.com",
+		"Sync failed", "second attempt", nil,
+	)
+	if !sent {
+		t.Error("second alert should fire immediately because the first delivery failed (no cooldown consumed)")
+	}
+	waitForDrain(t, n)
+}
+
+// TestCooldownRecordedAfterSuccessfulSend verifies that when a delivery
+// DOES succeed, the cooldown is recorded correctly so repeat alerts
+// are suppressed. This is the happy path for Issue #33.
+//
+// Setup: webhook points at an httptest server that returns 200, so
+// sendWebhook reports a successful delivery.
+func TestCooldownRecordedAfterSuccessfulSend(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		WebhookEnabled: true,
+		WebhookURL:     server.URL,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+	ctx := context.Background()
+
+	sent := n.SendSyncFailureAlertWithPrefs(
+		ctx, "source1", "Test Source", "user@example.com",
+		"Sync failed", "first", nil,
+	)
+	if !sent {
+		t.Fatal("first alert should fire")
+	}
+
+	// Wait for the background send to complete successfully.
+	waitForDrain(t, n)
+
+	// Cooldown should be set now.
+	n.mu.RLock()
+	_, cooldownSet := n.lastFailureAlertTimes["source1"]
+	n.mu.RUnlock()
+	if !cooldownSet {
+		t.Fatal("cooldown should be set after a successful webhook 200 response")
+	}
+
+	// Second attempt must be blocked by the cooldown.
+	sent = n.SendSyncFailureAlertWithPrefs(
+		ctx, "source1", "Test Source", "user@example.com",
+		"Sync failed", "second", nil,
+	)
+	if sent {
+		t.Error("second alert should be blocked by the cooldown set by the first successful send")
+	}
+}
+
+// TestInFlightGuardSuppressesSameSourceAndType verifies that a concurrent
+// second caller for the same source AND same alert type is suppressed
+// while a prior send is still in flight. Uses a manually-set in-flight
+// flag to avoid racing real goroutines.
+func TestInFlightGuardSuppressesSameSourceAndType(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Manually set in-flight to simulate a send in progress. We do this
+	// synthetically rather than kicking off a real send so the test
+	// doesn't race against goroutine scheduling.
+	n.mu.Lock()
+	n.inFlightAlerts["failure:source1"] = true
+	n.mu.Unlock()
+
+	// Concurrent attempt for the same source+type must be suppressed.
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "concurrent attempt", nil,
+	)
+	if sent {
+		t.Error("alert must be suppressed while an in-flight send exists for the same source+type")
+	}
+
+	// Clean up so the test leaves no stale state.
+	n.mu.Lock()
+	delete(n.inFlightAlerts, "failure:source1")
+	n.mu.Unlock()
+}
+
+// TestInFlightGuardIsScopedByAlertType verifies that a stale alert in
+// flight does NOT block a failure alert for the same source. The two
+// alert types use different key prefixes in inFlightAlerts so they can
+// fire concurrently for the same source.
+func TestInFlightGuardIsScopedByAlertType(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Synthetically mark a stale-alert in flight for source1. This
+	// simulates a stale-alert goroutine that hasn't finished yet.
+	n.mu.Lock()
+	n.inFlightAlerts["stale:source1"] = true
+	n.mu.Unlock()
+
+	// A failure alert for the SAME source should fire — different key.
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source1", "Test Source", "user@example.com",
+		"Sync failed", "different type", nil,
+	)
+	if !sent {
+		t.Error("failure alert must not be blocked by a stale alert in flight (different key prefix)")
+	}
+
+	// Wait only for the failure key to drain — the synthetic stale key
+	// will never clear because there's no goroutine behind it.
+	waitForKeyDrain(t, n, "failure:source1")
+
+	// Clean up the synthetic stale entry.
+	n.mu.Lock()
+	delete(n.inFlightAlerts, "stale:source1")
+	n.mu.Unlock()
+}
+
+// TestInFlightGuardIsScopedBySourceID verifies that an in-flight alert
+// for one source does not block alerts for a different source.
+func TestInFlightGuardIsScopedBySourceID(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Synthetically mark a failure alert in flight for source1.
+	n.mu.Lock()
+	n.inFlightAlerts["failure:source1"] = true
+	n.mu.Unlock()
+
+	// A failure alert for source2 must not be blocked.
+	sent := n.SendSyncFailureAlertWithPrefs(
+		nil, "source2", "Other Source", "user@example.com",
+		"Sync failed", "other source", nil,
+	)
+	if !sent {
+		t.Error("source2 must not be blocked by source1's in-flight guard")
+	}
+
+	// Wait only for the source2 key to drain; source1's synthetic entry
+	// will never clear because no goroutine is running it.
+	waitForKeyDrain(t, n, "failure:source2")
+
+	// Clean up the synthetic source1 entry.
+	n.mu.Lock()
+	delete(n.inFlightAlerts, "failure:source1")
+	n.mu.Unlock()
+}
+
+// TestClearFailureAlertStateClearsInFlight verifies that
+// ClearFailureAlertState cleans up in-flight state too, so a newly
+// re-created source (reusing the same ID) starts with a clean slate.
+func TestClearFailureAlertStateClearsInFlight(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	// Manually set in-flight
+	n.mu.Lock()
+	n.inFlightAlerts["failure:source1"] = true
+	n.mu.Unlock()
+
+	n.ClearFailureAlertState("source1")
+
+	n.mu.RLock()
+	stillInFlight := n.inFlightAlerts["failure:source1"]
+	n.mu.RUnlock()
+	if stillInFlight {
+		t.Error("ClearFailureAlertState must also clear in-flight guard")
+	}
+}
+
+// TestClearStaleStateClearsInFlight — same contract for stale path.
+func TestClearStaleStateClearsInFlight(t *testing.T) {
+	cfg := &Config{
+		WebhookEnabled: false,
+		EmailEnabled:   false,
+		CooldownPeriod: time.Hour,
+	}
+	n := New(cfg)
+
+	n.mu.Lock()
+	n.inFlightAlerts["stale:source1"] = true
+	n.mu.Unlock()
+
+	n.ClearStaleState("source1")
+
+	n.mu.RLock()
+	stillInFlight := n.inFlightAlerts["stale:source1"]
+	n.mu.RUnlock()
+	if stillInFlight {
+		t.Error("ClearStaleState must also clear in-flight guard")
 	}
 }
 


### PR DESCRIPTION
Re-created after PR #34 was auto-closed when its base branch was deleted on merge of PR #24. Same commits, now targeting main directly. Closes #33.