### PR TITLE
feat: retry webhook + email sends on transient failures with exponential backoff (#39)

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -313,7 +313,7 @@ func (n *Notifier) send(ctx context.Context, alert Alert) {
 		}
 
 		if len(recipients) > 0 {
-			if err := n.sendEmail(alert, recipients); err != nil {
+			if err := n.sendEmail(ctx, alert, recipients); err != nil {
 				log.Printf("[Notify] Email error: %v", err)
 			}
 		}
@@ -333,7 +333,9 @@ type WebhookPayload struct {
 }
 
 func (n *Notifier) sendWebhook(ctx context.Context, alert Alert) error {
-	// Build Slack-compatible message
+	// Build Slack-compatible message.
+	// Idempotent setup lives outside the retry: re-marshaling the same
+	// payload every attempt is wasted work.
 	emoji := ""
 	switch alert.Type {
 	case AlertTypeStale:
@@ -359,28 +361,34 @@ func (n *Notifier) sendWebhook(ctx context.Context, alert Alert) error {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", n.cfg.WebhookURL, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
+	// Retry the HTTP call itself on transient failures (DNS, TCP, TLS,
+	// 5xx). Permanent errors (4xx, request construction) fall through
+	// immediately — see isTransientHTTPError for the full taxonomy.
+	return retryTransient(ctx, defaultMaxSendAttempts, func(ctx context.Context) error {
+		req, err := http.NewRequestWithContext(ctx, "POST", n.cfg.WebhookURL, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
 
-	resp, err := n.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("send request: %w", err)
-	}
-	defer resp.Body.Close()
+		resp, err := n.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("send request: %w", err)
+		}
+		defer resp.Body.Close()
 
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
-	}
+		if resp.StatusCode >= 400 {
+			return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+		}
 
-	log.Printf("[Notify] Webhook sent: %s", alert.Message)
-	return nil
+		log.Printf("[Notify] Webhook sent: %s", alert.Message)
+		return nil
+	}, isTransientHTTPError)
 }
 
-func (n *Notifier) sendEmail(alert Alert, recipients []string) error {
-	// Sanitize user-controlled inputs to prevent email header injection
+func (n *Notifier) sendEmail(ctx context.Context, alert Alert, recipients []string) error {
+	// Sanitize user-controlled inputs to prevent email header injection.
+	// This is idempotent setup and stays outside the retry.
 	sanitizedSourceName := sanitizeForEmail(alert.SourceName)
 	sanitizedMessage := sanitizeForEmail(alert.Message)
 	sanitizedDetails := sanitizeForEmail(alert.Details)
@@ -408,19 +416,30 @@ func (n *Notifier) sendEmail(alert Alert, recipients []string) error {
 		auth = smtp.PlainAuth("", n.cfg.SMTPUsername, n.cfg.SMTPPassword, n.cfg.SMTPHost)
 	}
 
-	var err error
-	if n.cfg.SMTPTLS {
-		err = n.sendEmailTLS(addr, auth, n.cfg.SMTPFrom, recipients, []byte(msg))
-	} else {
-		err = smtp.SendMail(addr, auth, n.cfg.SMTPFrom, recipients, []byte(msg))
-	}
-
-	if err != nil {
-		return fmt.Errorf("send email: %w", err)
-	}
-
-	log.Printf("[Notify] Email sent to %d recipients: %s", len(recipients), sanitizedMessage)
-	return nil
+	// Retry transient SMTP failures. SMTP errors are mostly transient
+	// (connection drops, TLS hiccups, temporary server rejection) and
+	// the isTransientSMTPError classifier is intentionally permissive —
+	// the outer cooldown loop (PR #34) will eventually give up on
+	// persistently broken destinations by not retrying for another
+	// full cooldown window.
+	//
+	// Context is honored during backoff sleeps via retryTransient.
+	// Note: the stdlib smtp.SendMail itself does not take a context,
+	// so a mid-attempt cancellation only affects the sleep between
+	// attempts, not the send in progress.
+	return retryTransient(ctx, defaultMaxSendAttempts, func(ctx context.Context) error {
+		var err error
+		if n.cfg.SMTPTLS {
+			err = n.sendEmailTLS(addr, auth, n.cfg.SMTPFrom, recipients, []byte(msg))
+		} else {
+			err = smtp.SendMail(addr, auth, n.cfg.SMTPFrom, recipients, []byte(msg))
+		}
+		if err != nil {
+			return fmt.Errorf("send email: %w", err)
+		}
+		log.Printf("[Notify] Email sent to %d recipients: %s", len(recipients), sanitizedMessage)
+		return nil
+	}, isTransientSMTPError)
 }
 
 // sendEmailTLS sends email over TLS (for port 465).
@@ -779,7 +798,7 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 
 		if len(recipients) > 0 {
 			anyAttempted = true
-			if err := n.sendEmail(alert, recipients); err != nil {
+			if err := n.sendEmail(ctx, alert, recipients); err != nil {
 				log.Printf("[Notify] Email error: %v", err)
 			} else {
 				anyDelivered = true
@@ -799,12 +818,14 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 
 // sendWebhookToURL sends a webhook to a specific URL (for user webhooks).
 func (n *Notifier) sendWebhookToURL(ctx context.Context, alert Alert, webhookURL string) error {
-	// Validate URL before sending (security check)
+	// Validate URL before sending (security check). Validation failures
+	// are permanent — no point retrying a URL that will never pass.
 	if err := validateWebhookURL(webhookURL); err != nil {
 		return fmt.Errorf("invalid webhook URL: %w", err)
 	}
 
-	// Build Slack-compatible message
+	// Build Slack-compatible message. Idempotent setup stays outside
+	// the retry.
 	emoji := ""
 	switch alert.Type {
 	case AlertTypeStale:
@@ -830,24 +851,26 @@ func (n *Notifier) sendWebhookToURL(ctx context.Context, alert Alert, webhookURL
 		return fmt.Errorf("marshal payload: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", webhookURL, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
+	return retryTransient(ctx, defaultMaxSendAttempts, func(ctx context.Context) error {
+		req, err := http.NewRequestWithContext(ctx, "POST", webhookURL, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
 
-	resp, err := n.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("send request: %w", err)
-	}
-	defer resp.Body.Close()
+		resp, err := n.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("send request: %w", err)
+		}
+		defer resp.Body.Close()
 
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
-	}
+		if resp.StatusCode >= 400 {
+			return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+		}
 
-	log.Printf("[Notify] User webhook sent: %s", alert.Message)
-	return nil
+		log.Printf("[Notify] User webhook sent: %s", alert.Message)
+		return nil
+	}, isTransientHTTPError)
 }
 
 // SendTestWebhook sends a test message to a webhook URL.

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -8,15 +8,23 @@ import (
 	"time"
 )
 
+// drainTimeout is the max time we wait for in-flight alert sends to
+// complete in tests. Must comfortably exceed the full retry window
+// (defaultMaxSendAttempts attempts with exponential backoff + jitter,
+// ~1.5s total for 3 attempts at 500ms base) for tests that exercise
+// failure paths. Issue #39 introduced the retry behavior that pushed
+// failed-send durations into the low-seconds range.
+const drainTimeout = 5 * time.Second
+
 // waitForDrain blocks until all in-flight alert sends have completed,
-// or until the timeout expires. Test helper for sequencing multi-alert
+// or until drainTimeout expires. Test helper for sequencing multi-alert
 // scenarios — since Issue #33, the cooldown timestamp is recorded
 // inside the background goroutine only after sendWithPrefs returns,
 // so tests that rely on cooldown-after-first-send must wait for
 // that goroutine to finish before making assertions about state.
 func waitForDrain(t *testing.T, n *Notifier) {
 	t.Helper()
-	deadline := time.Now().Add(100 * time.Millisecond)
+	deadline := time.Now().Add(drainTimeout)
 	for time.Now().Before(deadline) {
 		n.mu.RLock()
 		empty := len(n.inFlightAlerts) == 0
@@ -24,9 +32,9 @@ func waitForDrain(t *testing.T, n *Notifier) {
 		if empty {
 			return
 		}
-		time.Sleep(500 * time.Microsecond)
+		time.Sleep(time.Millisecond)
 	}
-	t.Fatal("in-flight alerts did not drain within 100ms")
+	t.Fatalf("in-flight alerts did not drain within %v", drainTimeout)
 }
 
 // waitForKeyDrain blocks until a specific in-flight key has cleared.
@@ -34,7 +42,7 @@ func waitForDrain(t *testing.T, n *Notifier) {
 // for only the real goroutine(s) to finish, not the synthetic ones.
 func waitForKeyDrain(t *testing.T, n *Notifier, key string) {
 	t.Helper()
-	deadline := time.Now().Add(100 * time.Millisecond)
+	deadline := time.Now().Add(drainTimeout)
 	for time.Now().Before(deadline) {
 		n.mu.RLock()
 		gone := !n.inFlightAlerts[key]
@@ -42,9 +50,9 @@ func waitForKeyDrain(t *testing.T, n *Notifier, key string) {
 		if gone {
 			return
 		}
-		time.Sleep(500 * time.Microsecond)
+		time.Sleep(time.Millisecond)
 	}
-	t.Fatalf("in-flight key %q did not clear within 100ms", key)
+	t.Fatalf("in-flight key %q did not clear within %v", key, drainTimeout)
 }
 
 func TestValidateConfig(t *testing.T) {

--- a/internal/notify/retry.go
+++ b/internal/notify/retry.go
@@ -1,0 +1,136 @@
+package notify
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+// defaultMaxSendAttempts is the maximum total attempts (initial + retries)
+// for a single webhook or email send. 3 attempts with the default backoff
+// sequence of 500ms and 1s yields ~1.5s worst-case for a fully failed send
+// before the outer loop (PR #34 cooldown-not-consumed-on-failure)
+// schedules another attempt on the next tick.
+const defaultMaxSendAttempts = 3
+
+// defaultInitialBackoff is the base delay before the first retry. Retry
+// N uses defaultInitialBackoff * 2^(N-1) plus up to 25% jitter.
+const defaultInitialBackoff = 500 * time.Millisecond
+
+// retryTransient calls fn up to maxAttempts times with exponential backoff
+// and jitter between attempts. If fn returns nil on any attempt, the
+// function returns nil. If fn returns an error and isTransient(err) is
+// false, the function returns the error immediately without retrying.
+// If fn returns a transient error on every attempt, the function returns
+// the last error.
+//
+// Context cancellation is honored during the backoff sleep: if ctx is
+// cancelled while waiting to retry, the function returns the last error
+// immediately rather than waiting out the full backoff.
+//
+// Backoff sequence with defaultInitialBackoff=500ms:
+//
+//	attempt 1: no delay
+//	attempt 2: 500ms + jitter (retry after first failure)
+//	attempt 3: 1s + jitter (retry after second failure)
+//
+// Jitter is uniform random in [0, backoff/4) to avoid thundering-herd
+// retries from multiple concurrent failed sends synchronizing.
+func retryTransient(ctx context.Context, maxAttempts int, fn func(ctx context.Context) error, isTransient func(error) bool) error {
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			// Exponential backoff with jitter.
+			backoff := defaultInitialBackoff * time.Duration(1<<(attempt-1))
+			jitterMax := int64(backoff / 4)
+			var jitter time.Duration
+			if jitterMax > 0 {
+				jitter = time.Duration(rand.Int63n(jitterMax))
+			}
+			timer := time.NewTimer(backoff + jitter)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return lastErr
+			case <-timer.C:
+			}
+		}
+
+		err := fn(ctx)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isTransient(err) {
+			return err
+		}
+	}
+	return lastErr
+}
+
+// isTransientHTTPError classifies an HTTP send error as either transient
+// (worth retrying) or permanent (retry would give the same result).
+//
+// Transient:
+//   - Network errors (DNS, TCP, TLS, read timeouts): the error message
+//     doesn't contain "status" since the request never got an HTTP
+//     response back
+//   - 5xx server errors: "webhook returned status 5xx"
+//
+// Permanent:
+//   - 4xx client errors: "webhook returned status 4xx"
+//   - URL validation failures: "invalid webhook URL"
+//   - Request construction: "create request"
+//   - Payload marshaling: "marshal payload"
+//
+// The classification is string-based rather than type-based because the
+// error paths in sendWebhook / sendWebhookToURL wrap the low-level
+// errors into formatted messages, losing the original type. Since all
+// those messages are under our control, string matching is stable.
+func isTransientHTTPError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+
+	// Permanent: URL or payload setup failures — retry would give the
+	// same result.
+	if strings.Contains(msg, "invalid webhook URL") ||
+		strings.Contains(msg, "marshal payload") ||
+		strings.Contains(msg, "create request") {
+		return false
+	}
+
+	// Permanent: 4xx responses. Note that "status 5xx" is transient so
+	// we must check for the explicit 4xx pattern — a naive "status 4"
+	// substring would also match "status 500"'s wraps if we happened
+	// to format them in an odd way, but the current format is
+	// "webhook returned status N" where N is a decimal code.
+	if strings.Contains(msg, "returned status 4") {
+		return false
+	}
+
+	// Everything else — network errors, 5xx, read timeouts — is
+	// transient and worth retrying.
+	return true
+}
+
+// isTransientSMTPError classifies an SMTP send error. SMTP error taxonomy
+// is much less crisp than HTTP, so the default is to retry everything
+// except for the very clearly permanent cases. The cooldown-not-consumed
+// outer loop (PR #34) ensures that even permanent errors are eventually
+// given up on rather than looped forever.
+func isTransientSMTPError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Very few SMTP errors are deterministically permanent at the
+	// Go SDK level. "530 authentication required" is, but the error
+	// message varies by server. For now, retry everything and let
+	// the outer cooldown loop handle persistent failures.
+	return true
+}

--- a/internal/notify/retry_test.go
+++ b/internal/notify/retry_test.go
@@ -1,0 +1,306 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRetryTransient_ReturnsNilOnFirstSuccess verifies the happy path:
+// a function that succeeds on its first attempt returns nil without
+// the retry loop ever sleeping or running a second attempt.
+func TestRetryTransient_ReturnsNilOnFirstSuccess(t *testing.T) {
+	var attempts int32
+	err := retryTransient(context.Background(), 3, func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return nil
+	}, func(error) bool { return true })
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected 1 attempt, got %d", got)
+	}
+}
+
+// TestRetryTransient_StopsImmediatelyOnPermanentError verifies that a
+// permanent error (as classified by the isTransient callback) does not
+// trigger any retries. This prevents wasted work on deterministic
+// failures like invalid URLs or 4xx responses.
+func TestRetryTransient_StopsImmediatelyOnPermanentError(t *testing.T) {
+	var attempts int32
+	permanentErr := errors.New("permanent failure")
+	err := retryTransient(context.Background(), 5, func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return permanentErr
+	}, func(error) bool { return false })
+	if !errors.Is(err, permanentErr) {
+		t.Errorf("expected permanentErr, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected 1 attempt (no retries on permanent error), got %d", got)
+	}
+}
+
+// TestRetryTransient_RetriesUpToMaxOnTransientError verifies that a
+// transient error is retried up to maxAttempts times, and the last
+// error is returned if all attempts fail.
+func TestRetryTransient_RetriesUpToMaxOnTransientError(t *testing.T) {
+	var attempts int32
+	transientErr := errors.New("transient failure")
+	err := retryTransient(context.Background(), 3, func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return transientErr
+	}, func(error) bool { return true })
+	if !errors.Is(err, transientErr) {
+		t.Errorf("expected transientErr, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+}
+
+// TestRetryTransient_SuccessAfterTransientFailures verifies the most
+// valuable case: a function that fails transiently on the first N-1
+// attempts and succeeds on the last one returns nil and reports the
+// correct attempt count.
+func TestRetryTransient_SuccessAfterTransientFailures(t *testing.T) {
+	var attempts int32
+	err := retryTransient(context.Background(), 3, func(_ context.Context) error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			return errors.New("still flaky")
+		}
+		return nil
+	}, func(error) bool { return true })
+	if err != nil {
+		t.Errorf("expected nil on eventual success, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 attempts (2 failures + 1 success), got %d", got)
+	}
+}
+
+// TestRetryTransient_RespectsContextCancellation verifies that context
+// cancellation during the backoff sleep returns the last error
+// immediately rather than waiting out the full backoff. This is
+// critical for tests and for graceful shutdown: a broken endpoint
+// shouldn't keep the daemon alive during teardown.
+func TestRetryTransient_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var attempts int32
+
+	// Cancel the context after the first attempt starts.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := retryTransient(ctx, 5, func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return errors.New("always fails")
+	}, func(error) bool { return true })
+	elapsed := time.Since(start)
+
+	// The first attempt runs immediately, then we sleep for
+	// defaultInitialBackoff (500ms). Cancellation after 50ms should
+	// cut the sleep short, so the total should be well under the
+	// combined backoff time of ~1.5s for 3 attempts.
+	if elapsed > time.Second {
+		t.Errorf("expected early exit on cancel, took %v (>1s)", elapsed)
+	}
+	// We should have made at most 2 attempts (the first one + one
+	// cancelled during backoff).
+	if got := atomic.LoadInt32(&attempts); got > 2 {
+		t.Errorf("expected at most 2 attempts before cancel, got %d", got)
+	}
+	if err == nil {
+		t.Error("expected non-nil error from cancelled retry")
+	}
+}
+
+// TestIsTransientHTTPError verifies the classifier used by sendWebhook
+// and sendWebhookToURL. The classification contract is fragile
+// (string-based on internally-formatted messages) so these tests lock
+// in the expected behavior.
+func TestIsTransientHTTPError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error is not transient",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "invalid webhook URL is permanent",
+			err:  fmt.Errorf("invalid webhook URL: localhost not allowed"),
+			want: false,
+		},
+		{
+			name: "marshal payload is permanent",
+			err:  fmt.Errorf("marshal payload: unsupported type"),
+			want: false,
+		},
+		{
+			name: "create request is permanent",
+			err:  fmt.Errorf("create request: invalid URL"),
+			want: false,
+		},
+		{
+			name: "404 response is permanent",
+			err:  fmt.Errorf("webhook returned status 404"),
+			want: false,
+		},
+		{
+			name: "403 response is permanent",
+			err:  fmt.Errorf("webhook returned status 403"),
+			want: false,
+		},
+		{
+			name: "500 response is transient",
+			err:  fmt.Errorf("webhook returned status 500"),
+			want: true,
+		},
+		{
+			name: "503 response is transient",
+			err:  fmt.Errorf("webhook returned status 503"),
+			want: true,
+		},
+		{
+			name: "network error is transient",
+			err:  fmt.Errorf("send request: dial tcp: i/o timeout"),
+			want: true,
+		},
+		{
+			name: "DNS error is transient",
+			err:  fmt.Errorf("send request: no such host"),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTransientHTTPError(tt.err)
+			if got != tt.want {
+				t.Errorf("isTransientHTTPError(%q) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSendWebhook_RetriesOn5xxAndEventuallySucceeds verifies the full
+// integration from sendWebhook through retryTransient against a real
+// httptest server that fails the first two attempts with 500 and
+// succeeds on the third. If retry is wired correctly, the third
+// attempt's 200 turns the overall send into a success.
+func TestSendWebhook_RetriesOn5xxAndEventuallySucceeds(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	n := New(&Config{
+		WebhookEnabled: true,
+		WebhookURL:     server.URL,
+		CooldownPeriod: time.Hour,
+	})
+
+	alert := Alert{
+		Type:       AlertTypeError,
+		SourceID:   "src1",
+		SourceName: "Test Source",
+		Message:    "test message",
+		Details:    "test details",
+		Timestamp:  time.Now(),
+	}
+
+	err := n.sendWebhook(context.Background(), alert)
+	if err != nil {
+		t.Errorf("expected successful send after retries, got %v", err)
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 3 {
+		t.Errorf("expected 3 attempts (2 failures + 1 success), server saw %d", got)
+	}
+}
+
+// TestSendWebhook_StopsImmediatelyOn4xx verifies that a 404 response
+// does NOT trigger any retries — it's a permanent failure from the
+// classifier's point of view.
+func TestSendWebhook_StopsImmediatelyOn4xx(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	n := New(&Config{
+		WebhookEnabled: true,
+		WebhookURL:     server.URL,
+		CooldownPeriod: time.Hour,
+	})
+
+	alert := Alert{
+		Type:       AlertTypeError,
+		SourceID:   "src1",
+		SourceName: "Test Source",
+		Message:    "test message",
+		Timestamp:  time.Now(),
+	}
+
+	err := n.sendWebhook(context.Background(), alert)
+	if err == nil {
+		t.Error("expected error on 404, got nil")
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Errorf("expected exactly 1 attempt on permanent 4xx, server saw %d", got)
+	}
+}
+
+// TestSendWebhook_RetriesAllAttemptsOn5xx verifies the worst case: all
+// attempts fail with 500, the last error is returned, and the server
+// saw exactly defaultMaxSendAttempts requests.
+func TestSendWebhook_RetriesAllAttemptsOn5xx(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	n := New(&Config{
+		WebhookEnabled: true,
+		WebhookURL:     server.URL,
+		CooldownPeriod: time.Hour,
+	})
+
+	alert := Alert{
+		Type:       AlertTypeError,
+		SourceID:   "src1",
+		SourceName: "Test Source",
+		Message:    "test message",
+		Timestamp:  time.Now(),
+	}
+
+	err := n.sendWebhook(context.Background(), alert)
+	if err == nil {
+		t.Error("expected error after all retries exhausted, got nil")
+	}
+	if got := atomic.LoadInt32(&requestCount); got != int32(defaultMaxSendAttempts) {
+		t.Errorf("expected %d attempts, server saw %d", defaultMaxSendAttempts, got)
+	}
+}


### PR DESCRIPTION
Re-created after the stacked PR #40 was auto-closed when its base branch was deleted on merge. Same commits rebased onto current main. Closes #39.