### PR TITLE
fix: add liveness watchdog for scheduler goroutines (#43)

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -20,7 +20,40 @@ const (
 	healthLogInterval = 5 * time.Minute   // Interval for scheduler health logging
 	staleMultiplier   = 2                 // Source is stale if last sync > staleMultiplier * interval
 	startupStagger    = 30 * time.Second  // Delay between starting each source's first sync
+
+	// Liveness watchdog constants (Issue #43). The watchdog detects
+	// routines that have crashed (caught by PR #38 panic recovery but
+	// whose goroutine then exited) OR that have hung (infinite loop,
+	// deadlock, stuck CalDAV call).
+	watchdogInterval = 1 * time.Minute
+
+	// Per-routine stale thresholds. A routine whose last heartbeat is
+	// older than its threshold is considered dead/hung by the watchdog.
+	// Thresholds are set to ~2x the routine's tick interval plus slack
+	// so normal ticking doesn't trigger false positives.
+	watchdogStaleDetectionThreshold = 3 * time.Minute  // tick = 1 min
+	watchdogCleanupThreshold        = 26 * time.Hour   // tick = 24 hr
+	watchdogHealthLogThreshold      = 12 * time.Minute // tick = 5 min
+	watchdogWatchdogSelfThreshold   = 3 * time.Minute  // tick = 1 min, covers watchdog itself
+	watchdogJobSlack                = 60 * time.Second // added to 2x job interval for per-job heartbeat threshold
 )
+
+// Routine name constants for the liveness heartbeat map. Using constants
+// instead of string literals so typos are compile errors and the watchdog
+// check knows every name it's supposed to track.
+const (
+	routineStaleDetection = "scheduler.staleDetectionRoutine"
+	routineCleanup        = "scheduler.cleanupRoutine"
+	routineHealthLog      = "scheduler.healthLogRoutine"
+	routineWatchdog       = "scheduler.watchdogRoutine"
+)
+
+// routineJobName returns the heartbeat key for a per-job sync loop.
+// Each source has its own heartbeat slot keyed by source ID so the
+// watchdog can identify exactly which job's loop has stopped.
+func routineJobName(sourceID string) string {
+	return "scheduler.runJob." + sourceID
+}
 
 // Job represents a scheduled sync job.
 type Job struct {
@@ -44,6 +77,14 @@ type Scheduler struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
 	started   bool
+
+	// heartbeats tracks the last time each long-running goroutine made
+	// progress (Issue #43). The watchdog reads this map periodically
+	// and flags routines whose last heartbeat is older than their
+	// configured threshold. Separate mutex from mu to avoid contention
+	// on the hot path of job lookups.
+	heartbeatsMu sync.RWMutex
+	heartbeats   map[string]time.Time
 }
 
 // New creates a new scheduler.
@@ -57,6 +98,7 @@ func New(database *db.DB, syncEngine *caldav.SyncEngine, notifier *notify.Notifi
 		syncLocks:  make(map[string]*sync.Mutex),
 		ctx:        ctx,
 		cancel:     cancel,
+		heartbeats: make(map[string]time.Time),
 	}
 }
 
@@ -102,8 +144,140 @@ func (s *Scheduler) Start() error {
 	s.wg.Add(1)
 	go s.staleDetectionRoutine()
 
+	// Start liveness watchdog goroutine (Issue #43). Runs AFTER the
+	// routines it monitors so their heartbeats have time to populate.
+	s.wg.Add(1)
+	go s.watchdogRoutine()
+
 	log.Printf("Scheduler started with %d jobs", len(sources))
 	return nil
+}
+
+// heartbeat records that the named routine has made progress. Called
+// at the top of each tick iteration of long-running routines so the
+// watchdog can detect routines that have crashed or hung.
+func (s *Scheduler) heartbeat(name string) {
+	s.heartbeatsMu.Lock()
+	s.heartbeats[name] = time.Now()
+	s.heartbeatsMu.Unlock()
+}
+
+// lastHeartbeat returns the timestamp of the last heartbeat for the
+// named routine, or the zero time if the routine has never beat.
+// Exported only via tests (lower-case name).
+func (s *Scheduler) lastHeartbeat(name string) time.Time {
+	s.heartbeatsMu.RLock()
+	defer s.heartbeatsMu.RUnlock()
+	return s.heartbeats[name]
+}
+
+// expectedHeartbeatThreshold returns the max age for a routine's heartbeat
+// before it is considered dead/hung by the watchdog. Per-job sync loops
+// use 2x their configured interval plus a slack constant; other routines
+// use their own constants.
+func (s *Scheduler) expectedHeartbeatThreshold(name string) time.Duration {
+	switch name {
+	case routineStaleDetection:
+		return watchdogStaleDetectionThreshold
+	case routineCleanup:
+		return watchdogCleanupThreshold
+	case routineHealthLog:
+		return watchdogHealthLogThreshold
+	case routineWatchdog:
+		return watchdogWatchdogSelfThreshold
+	}
+	// Per-job sync loops: look up the job's interval.
+	if strings.HasPrefix(name, "scheduler.runJob.") {
+		sourceID := strings.TrimPrefix(name, "scheduler.runJob.")
+		s.mu.RLock()
+		job, ok := s.jobs[sourceID]
+		s.mu.RUnlock()
+		if ok {
+			return 2*job.interval + watchdogJobSlack
+		}
+	}
+	// Unknown routine — conservative default
+	return 5 * time.Minute
+}
+
+// watchdogRoutine periodically checks that long-running scheduler
+// goroutines are still ticking. If a routine's last heartbeat is older
+// than its configured threshold, the watchdog logs a warning and
+// (if a notifier is configured) fires a failure alert so the operator
+// knows the daemon's background work has degraded.
+//
+// This closes the observability gap that PR #38's panic recovery
+// cannot cover: a routine that panics is caught and its goroutine
+// exits cleanly, but the scheduler keeps running with one fewer
+// routine. Without this watchdog, a crashed staleDetectionRoutine
+// would cause stale detection to silently stop working indefinitely.
+//
+// The watchdog also catches the non-panic failure mode: a routine
+// that is stuck in an infinite loop, deadlocked on a mutex, or
+// blocked on a misbehaving CalDAV call that never returns.
+func (s *Scheduler) watchdogRoutine() {
+	defer s.wg.Done()
+	defer recoverPanic(routineWatchdog)
+
+	ticker := time.NewTicker(watchdogInterval)
+	defer ticker.Stop()
+
+	// Beat once at startup so checkLiveness doesn't immediately
+	// flag the watchdog itself as stale on the very first tick.
+	s.heartbeat(routineWatchdog)
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-ticker.C:
+			s.heartbeat(routineWatchdog)
+			s.checkLiveness()
+		}
+	}
+}
+
+// checkLiveness scans the heartbeat map and emits a warning + alert
+// for any routine whose last heartbeat is older than its configured
+// threshold. Only tracked routines (those present in the heartbeats
+// map) are checked — routines that never registered a heartbeat are
+// assumed to not exist yet (e.g., the scheduler just started and the
+// routine hasn't run its first tick).
+func (s *Scheduler) checkLiveness() {
+	now := time.Now()
+
+	s.heartbeatsMu.RLock()
+	// Copy the entries so we don't hold the lock across the alert call.
+	snapshot := make(map[string]time.Time, len(s.heartbeats))
+	for k, v := range s.heartbeats {
+		snapshot[k] = v
+	}
+	s.heartbeatsMu.RUnlock()
+
+	for name, lastBeat := range snapshot {
+		threshold := s.expectedHeartbeatThreshold(name)
+		age := now.Sub(lastBeat)
+		if age <= threshold {
+			continue
+		}
+
+		log.Printf("[WATCHDOG] routine %q last heartbeat %v ago (threshold %v) — may be crashed or hung",
+			name, age.Round(time.Second), threshold)
+
+		// Fire an alert so the operator sees this in their alert
+		// channel. Uses SendStaleAlert (the only notifier API
+		// available on main) with a synthetic sourceID derived from
+		// the routine name so the notifier's per-source cooldown
+		// applies per routine, not across all watchdog events.
+		//
+		// NOTE: after PR #24 (SendSyncFailureAlertWithPrefs) merges,
+		// this could switch to the failure-alert path for cleaner
+		// alert-type separation. Follow-up issue.
+		if s.notifier != nil && s.notifier.IsEnabled() {
+			watchdogSourceID := "watchdog:" + name
+			s.notifier.SendStaleAlert(s.ctx, watchdogSourceID, name, "", age, threshold)
+		}
+	}
 }
 
 // Stop gracefully shuts down all jobs.
@@ -271,6 +445,11 @@ func (s *Scheduler) GetJobCount() int {
 func (s *Scheduler) runJob(job *Job) {
 	defer s.wg.Done()
 	defer recoverPanic("scheduler.runJob")
+	defer s.clearJobHeartbeat(job.sourceID)
+
+	// Initial heartbeat so the watchdog sees the job as alive even
+	// if the first executeSync takes longer than the interval.
+	s.heartbeat(routineJobName(job.sourceID))
 
 	// Run immediately on start
 	s.executeSync(job.sourceID)
@@ -283,6 +462,7 @@ func (s *Scheduler) runJob(job *Job) {
 		case <-job.stopCh:
 			return
 		case <-job.ticker.C:
+			s.heartbeat(routineJobName(job.sourceID))
 			s.executeSync(job.sourceID)
 			s.updateNextSyncAt(job.sourceID)
 		}
@@ -294,6 +474,9 @@ func (s *Scheduler) runJob(job *Job) {
 func (s *Scheduler) runJobFromTicker(job *Job) {
 	defer s.wg.Done()
 	defer recoverPanic("scheduler.runJobFromTicker")
+	defer s.clearJobHeartbeat(job.sourceID)
+
+	s.heartbeat(routineJobName(job.sourceID))
 
 	for {
 		select {
@@ -302,6 +485,7 @@ func (s *Scheduler) runJobFromTicker(job *Job) {
 		case <-job.stopCh:
 			return
 		case <-job.ticker.C:
+			s.heartbeat(routineJobName(job.sourceID))
 			s.executeSync(job.sourceID)
 			s.updateNextSyncAt(job.sourceID)
 		}
@@ -312,6 +496,9 @@ func (s *Scheduler) runJobFromTicker(job *Job) {
 func (s *Scheduler) runJobWithDelay(job *Job, initialDelay time.Duration) {
 	defer s.wg.Done()
 	defer recoverPanic("scheduler.runJobWithDelay")
+	defer s.clearJobHeartbeat(job.sourceID)
+
+	s.heartbeat(routineJobName(job.sourceID))
 
 	// Wait for initial delay before first sync
 	if initialDelay > 0 {
@@ -326,6 +513,7 @@ func (s *Scheduler) runJobWithDelay(job *Job, initialDelay time.Duration) {
 	}
 
 	// Run first sync
+	s.heartbeat(routineJobName(job.sourceID))
 	s.executeSync(job.sourceID)
 	s.updateNextSyncAt(job.sourceID)
 
@@ -337,10 +525,21 @@ func (s *Scheduler) runJobWithDelay(job *Job, initialDelay time.Duration) {
 		case <-job.stopCh:
 			return
 		case <-job.ticker.C:
+			s.heartbeat(routineJobName(job.sourceID))
 			s.executeSync(job.sourceID)
 			s.updateNextSyncAt(job.sourceID)
 		}
 	}
+}
+
+// clearJobHeartbeat removes the heartbeat entry for a job when its
+// goroutine exits (via stopCh close or ctx cancel). Without this, a
+// legitimately-stopped job would leave a stale heartbeat and the
+// watchdog would eventually flag it as dead and fire a false alert.
+func (s *Scheduler) clearJobHeartbeat(sourceID string) {
+	s.heartbeatsMu.Lock()
+	defer s.heartbeatsMu.Unlock()
+	delete(s.heartbeats, routineJobName(sourceID))
 }
 
 // updateNextSyncAt updates the next sync time for a job after execution.
@@ -502,11 +701,14 @@ func (s *Scheduler) cleanupRoutine() {
 	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 
+	s.heartbeat(routineCleanup)
+
 	for {
 		select {
 		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
+			s.heartbeat(routineCleanup)
 			s.cleanupOldLogs()
 		}
 	}
@@ -533,11 +735,14 @@ func (s *Scheduler) healthLogRoutine() {
 	ticker := time.NewTicker(healthLogInterval)
 	defer ticker.Stop()
 
+	s.heartbeat(routineHealthLog)
+
 	for {
 		select {
 		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
+			s.heartbeat(routineHealthLog)
 			s.logHealth()
 		}
 	}
@@ -561,11 +766,16 @@ func (s *Scheduler) staleDetectionRoutine() {
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 
+	// Initial heartbeat so the watchdog doesn't flag us as stale
+	// before our first tick fires.
+	s.heartbeat(routineStaleDetection)
+
 	for {
 		select {
 		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
+			s.heartbeat(routineStaleDetection)
 			s.checkStaleSources()
 		}
 	}

--- a/internal/scheduler/watchdog_test.go
+++ b/internal/scheduler/watchdog_test.go
@@ -1,0 +1,213 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+)
+
+// TestHeartbeat_RecordsTimestamp verifies the core heartbeat map
+// contract: calling heartbeat(name) stores a timestamp approximately
+// equal to time.Now(), retrievable via lastHeartbeat(name).
+func TestHeartbeat_RecordsTimestamp(t *testing.T) {
+	s := New(nil, nil, nil)
+	defer s.cancel()
+
+	before := time.Now()
+	s.heartbeat("test.routine")
+	after := time.Now()
+
+	recorded := s.lastHeartbeat("test.routine")
+	if recorded.Before(before) || recorded.After(after) {
+		t.Errorf("heartbeat timestamp %v not in [%v, %v]", recorded, before, after)
+	}
+}
+
+// TestHeartbeat_UnknownRoutineReturnsZero verifies that
+// lastHeartbeat returns the zero time for a routine that has never
+// registered a heartbeat. The zero time is used downstream to
+// distinguish "no data" from "very old data".
+func TestHeartbeat_UnknownRoutineReturnsZero(t *testing.T) {
+	s := New(nil, nil, nil)
+	defer s.cancel()
+
+	last := s.lastHeartbeat("never.beat")
+	if !last.IsZero() {
+		t.Errorf("expected zero time for unknown routine, got %v", last)
+	}
+}
+
+// TestExpectedHeartbeatThreshold_BuiltinRoutines verifies the
+// threshold lookup for the known long-running routines.
+func TestExpectedHeartbeatThreshold_BuiltinRoutines(t *testing.T) {
+	s := New(nil, nil, nil)
+	defer s.cancel()
+
+	tests := []struct {
+		name string
+		want time.Duration
+	}{
+		{routineStaleDetection, watchdogStaleDetectionThreshold},
+		{routineCleanup, watchdogCleanupThreshold},
+		{routineHealthLog, watchdogHealthLogThreshold},
+		{routineWatchdog, watchdogWatchdogSelfThreshold},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.expectedHeartbeatThreshold(tt.name)
+			if got != tt.want {
+				t.Errorf("expectedHeartbeatThreshold(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExpectedHeartbeatThreshold_PerJobUsesJobInterval verifies that
+// the threshold for a per-job sync loop is computed from the job's
+// configured interval. This prevents a job with a 10-hour interval
+// from being flagged as stale just because its heartbeat is older
+// than the default 3-minute stale-detection threshold.
+func TestExpectedHeartbeatThreshold_PerJobUsesJobInterval(t *testing.T) {
+	s := New(nil, nil, nil)
+	defer s.cancel()
+
+	// Inject a job with a known interval.
+	interval := 10 * time.Minute
+	s.mu.Lock()
+	s.jobs["src1"] = &Job{
+		sourceID: "src1",
+		interval: interval,
+	}
+	s.mu.Unlock()
+
+	got := s.expectedHeartbeatThreshold(routineJobName("src1"))
+	want := 2*interval + watchdogJobSlack
+	if got != want {
+		t.Errorf("per-job threshold = %v, want %v", got, want)
+	}
+}
+
+// TestExpectedHeartbeatThreshold_UnknownJobFallsBackToDefault
+// verifies that looking up a job that isn't in the scheduler's jobs
+// map returns a safe conservative default instead of zero. Zero
+// would cause every heartbeat to immediately look stale.
+func TestExpectedHeartbeatThreshold_UnknownJobFallsBackToDefault(t *testing.T) {
+	s := New(nil, nil, nil)
+	defer s.cancel()
+
+	got := s.expectedHeartbeatThreshold("scheduler.runJob.unknown")
+	if got <= 0 {
+		t.Errorf("expected positive default threshold, got %v", got)
+	}
+}
+
+// TestCheckLiveness_NoEntriesDoesNotPanic verifies the empty-state
+// edge case. If no routine has heartbeat yet (e.g., scheduler just
+// started and first ticks haven't fired), checkLiveness should be a
+// no-op.
+func TestCheckLiveness_NoEntriesDoesNotPanic(t *testing.T) {
+	s := New(nil, nil, nil)
+	defer s.cancel()
+
+	// Should return without panic
+	s.checkLiveness()
+}
+
+// TestCheckLiveness_FreshHeartbeatsNotFlagged verifies the happy
+// path: when all heartbeats are recent, checkLiveness logs nothing
+// and fires no alert. We verify indirectly by confirming no stale
+// heartbeats remain in an alert-bearing state.
+func TestCheckLiveness_FreshHeartbeatsNotFlagged(t *testing.T) {
+	s := New(nil, nil, nil)
+	defer s.cancel()
+
+	s.heartbeat(routineStaleDetection)
+	s.heartbeat(routineCleanup)
+	s.heartbeat(routineHealthLog)
+
+	// checkLiveness walks the map and emits warnings for stale
+	// entries. With all fresh entries, the scan should complete
+	// quickly and fire no alerts. We can't directly observe the
+	// absence of a log line, but we can confirm the function
+	// doesn't hang or panic.
+	s.checkLiveness()
+}
+
+// TestCheckLiveness_StaleHeartbeatIsDetected verifies that a
+// heartbeat older than its threshold is detected. We manipulate the
+// heartbeat map directly to install a timestamp far in the past.
+// Without a mockable notifier we can't observe the alert firing
+// from this test level, but we can verify the stale-detection
+// logic runs without error and leaves the heartbeat map unchanged
+// (checkLiveness only reads, doesn't write).
+func TestCheckLiveness_StaleHeartbeatIsDetected(t *testing.T) {
+	s := New(nil, nil, nil)
+	defer s.cancel()
+
+	// Install a stale heartbeat: older than the stale-detection
+	// routine's threshold.
+	stale := time.Now().Add(-2 * watchdogStaleDetectionThreshold)
+	s.heartbeatsMu.Lock()
+	s.heartbeats[routineStaleDetection] = stale
+	s.heartbeatsMu.Unlock()
+
+	// Should log a [WATCHDOG] warning but not panic. No notifier
+	// is configured, so the alert-firing branch is skipped.
+	s.checkLiveness()
+
+	// Heartbeat must still be in the map (checkLiveness is read-only).
+	if !s.lastHeartbeat(routineStaleDetection).Equal(stale) {
+		t.Error("checkLiveness unexpectedly mutated the heartbeat map")
+	}
+}
+
+// TestClearJobHeartbeat_RemovesEntry verifies that when a job
+// goroutine exits (via stopCh close or ctx cancel), its heartbeat
+// entry is removed from the map. Without this, a legitimately
+// stopped job would leave a stale heartbeat and the watchdog would
+// eventually flag it as dead and fire a false alert.
+func TestClearJobHeartbeat_RemovesEntry(t *testing.T) {
+	s := New(nil, nil, nil)
+	defer s.cancel()
+
+	sourceID := "src-to-remove"
+	name := routineJobName(sourceID)
+
+	s.heartbeat(name)
+	if s.lastHeartbeat(name).IsZero() {
+		t.Fatal("heartbeat should be recorded")
+	}
+
+	s.clearJobHeartbeat(sourceID)
+	if !s.lastHeartbeat(name).IsZero() {
+		t.Error("clearJobHeartbeat should remove the entry")
+	}
+}
+
+// TestRoutineJobNameRoundTrip verifies the naming convention used
+// by routineJobName so that expectedHeartbeatThreshold's "scheduler.runJob."
+// prefix check works correctly for any source ID.
+func TestRoutineJobNameRoundTrip(t *testing.T) {
+	tests := []string{
+		"simple-id",
+		"uuid-1234-5678",
+		"id.with.dots",
+		"",
+	}
+	for _, sourceID := range tests {
+		t.Run(sourceID, func(t *testing.T) {
+			name := routineJobName(sourceID)
+			if name == "" {
+				t.Errorf("routineJobName(%q) returned empty", sourceID)
+			}
+			// Must be recognizable by the expectedHeartbeatThreshold
+			// prefix check. Empty sourceID is a weird edge case but
+			// shouldn't produce a false match on the per-job branch
+			// without a corresponding job entry.
+			if len(sourceID) > 0 {
+				if got := name; got != "scheduler.runJob."+sourceID {
+					t.Errorf("routineJobName(%q) = %q, want %q", sourceID, got, "scheduler.runJob."+sourceID)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Re-created after auto-close. Closes #43.