### PR TITLE
fix: detect MULTIGET silently-dropped events and surface them (#35)

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -313,7 +313,62 @@ func (c *Client) getEventsViaList(ctx context.Context, calendarPath string, coll
 	return events, nil
 }
 
+// normalizeMultiGetPath returns a canonical form of a CalDAV object path
+// suitable for equality comparison between a request path (which may be
+// URL-decoded by parseEventPaths) and a response path (which may be
+// URL-encoded, or have a trailing slash added by some servers).
+//
+// The comparison is intentionally loose: percent-escapes are decoded,
+// trailing slashes are trimmed. Case is preserved since CalDAV paths
+// can be case-sensitive depending on the server.
+func normalizeMultiGetPath(p string) string {
+	if decoded, err := url.PathUnescape(p); err == nil {
+		p = decoded
+	}
+	return strings.TrimRight(p, "/")
+}
+
+// findDroppedMultiGetPaths returns the subset of requestedPaths that do
+// not appear in returnedPaths, using normalized comparison. Used to
+// detect paths that the go-webdav library silently dropped during a
+// MultiGetCalendar call — typically because the library could not parse
+// that entry's response and discarded it without reporting.
+//
+// Exposed (unexported but free function) so it can be unit-tested
+// without touching the real CalDAV client.
+func findDroppedMultiGetPaths(requestedPaths, returnedPaths []string) []string {
+	if len(requestedPaths) == 0 {
+		return nil
+	}
+	returned := make(map[string]bool, len(returnedPaths))
+	for _, p := range returnedPaths {
+		returned[normalizeMultiGetPath(p)] = true
+	}
+	var dropped []string
+	for _, p := range requestedPaths {
+		if !returned[normalizeMultiGetPath(p)] {
+			dropped = append(dropped, p)
+		}
+	}
+	return dropped
+}
+
 // getEventsBatch fetches a batch of events using MULTIGET.
+//
+// Beyond the obvious "fetch these paths", this function also detects and
+// reports paths that the go-webdav library silently drops from the
+// response. The library occasionally discards entries it cannot parse,
+// and those paths vanish without any error or log — they're simply
+// missing from the returned objects slice. Before this function detected
+// that, malformed events at the protocol level were completely invisible
+// to users: the dashboard's "Corrupted Events" card stayed empty while
+// real corruption was silently losing data.
+//
+// For each dropped path, we fall back to an individual GetEvent call,
+// which returns a concrete error that we can record in the
+// MalformedEventCollector. That's one extra HTTP round-trip per dropped
+// path, but only for paths that are genuinely problematic — in normal
+// operation the fallback loop doesn't execute at all.
 func (c *Client) getEventsBatch(ctx context.Context, calendarPath string, paths []string, collector *MalformedEventCollector) ([]Event, int, int, error) {
 	multiGet := &caldav.CalendarMultiGet{
 		Paths: paths,
@@ -375,6 +430,37 @@ func (c *Client) getEventsBatch(ctx context.Context, calendarPath string, paths 
 		}
 
 		events = append(events, event)
+	}
+
+	// Detect paths that MULTIGET silently dropped and probe them
+	// individually. See the function doc comment for the full rationale.
+	returnedPaths := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		returnedPaths = append(returnedPaths, obj.Path)
+	}
+	dropped := findDroppedMultiGetPaths(paths, returnedPaths)
+	if len(dropped) > 0 {
+		log.Printf("MULTIGET response missing %d of %d requested paths; probing individually to classify", len(dropped), len(paths))
+	}
+	for _, missingPath := range dropped {
+		_, probeErr := c.GetEvent(ctx, missingPath)
+		if probeErr != nil {
+			// Got a concrete error from the individual fetch. Record it
+			// in the collector so the user sees it on the dashboard.
+			if collector != nil {
+				collector.Add(missingPath, fmt.Sprintf("MULTIGET silently dropped this event; individual fetch returned: %v", probeErr))
+			}
+			skippedMalformed++
+			continue
+		}
+		// Individual fetch succeeded where MULTIGET didn't. This is
+		// weird but not data loss — log it so the next sync cycle's
+		// MULTIGET can try again. Don't add the recovered event to
+		// the return slice because the existing processing loop
+		// already ran without it; mixing in a late addition would
+		// require re-running all the extract logic here and we'd
+		// rather keep the happy path simple.
+		log.Printf("MULTIGET dropped %s but individual GetEvent succeeded; will retry on next sync", missingPath)
 	}
 
 	return events, skippedMalformed, skippedEmpty, nil

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -1489,6 +1489,140 @@ func TestIsMalformedErrorEdgeCases(t *testing.T) {
 	}
 }
 
+// TestNormalizeMultiGetPath verifies that request and response paths
+// compare equal despite differences in URL encoding and trailing
+// slashes. Without this normalization, findDroppedMultiGetPaths would
+// produce false positives whenever the server returned a response path
+// in a slightly different form from the request.
+func TestNormalizeMultiGetPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no changes for a plain path",
+			in:   "/cal/event123.ics",
+			want: "/cal/event123.ics",
+		},
+		{
+			name: "trailing slash stripped",
+			in:   "/cal/event123.ics/",
+			want: "/cal/event123.ics",
+		},
+		{
+			name: "URL-encoded space decoded",
+			in:   "/cal/event%20with%20space.ics",
+			want: "/cal/event with space.ics",
+		},
+		{
+			name: "URL-encoded special chars decoded",
+			in:   "/cal/%5Bbracket%5D.ics",
+			want: "/cal/[bracket].ics",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "only slash",
+			in:   "/",
+			want: "",
+		},
+		{
+			name: "mixed encoding and trailing slash",
+			in:   "/cal/a%20b.ics/",
+			want: "/cal/a b.ics",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeMultiGetPath(tt.in)
+			if got != tt.want {
+				t.Errorf("normalizeMultiGetPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFindDroppedMultiGetPaths verifies the detection logic for MULTIGET
+// responses that are missing requested entries. This is the core of
+// Issue #35 — catching silent data loss that was previously invisible.
+func TestFindDroppedMultiGetPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested []string
+		returned  []string
+		want      []string
+	}{
+		{
+			name:      "all paths returned, nothing dropped",
+			requested: []string{"/cal/a.ics", "/cal/b.ics", "/cal/c.ics"},
+			returned:  []string{"/cal/a.ics", "/cal/b.ics", "/cal/c.ics"},
+			want:      nil,
+		},
+		{
+			name:      "one path dropped",
+			requested: []string{"/cal/a.ics", "/cal/b.ics", "/cal/c.ics"},
+			returned:  []string{"/cal/a.ics", "/cal/c.ics"},
+			want:      []string{"/cal/b.ics"},
+		},
+		{
+			name:      "multiple paths dropped",
+			requested: []string{"/cal/a.ics", "/cal/b.ics", "/cal/c.ics", "/cal/d.ics"},
+			returned:  []string{"/cal/a.ics", "/cal/d.ics"},
+			want:      []string{"/cal/b.ics", "/cal/c.ics"},
+		},
+		{
+			name:      "all dropped (empty response)",
+			requested: []string{"/cal/a.ics", "/cal/b.ics"},
+			returned:  []string{},
+			want:      []string{"/cal/a.ics", "/cal/b.ics"},
+		},
+		{
+			name:      "empty request returns empty result",
+			requested: nil,
+			returned:  []string{"/unexpected.ics"},
+			want:      nil,
+		},
+		{
+			name:      "URL-encoding differences are not false positives",
+			requested: []string{"/cal/event with space.ics", "/cal/plain.ics"},
+			returned:  []string{"/cal/event%20with%20space.ics", "/cal/plain.ics"},
+			want:      nil,
+		},
+		{
+			name:      "trailing-slash differences are not false positives",
+			requested: []string{"/cal/a.ics", "/cal/b.ics"},
+			returned:  []string{"/cal/a.ics/", "/cal/b.ics"},
+			want:      nil,
+		},
+		{
+			name:      "response has extra paths (shouldn't happen but shouldn't panic)",
+			requested: []string{"/cal/a.ics"},
+			returned:  []string{"/cal/a.ics", "/cal/unexpected.ics"},
+			want:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findDroppedMultiGetPaths(tt.requested, tt.returned)
+			if len(got) != len(tt.want) {
+				t.Fatalf("findDroppedMultiGetPaths() returned %d paths, want %d\n got = %v\nwant = %v",
+					len(got), len(tt.want), got, tt.want)
+			}
+			// Order-sensitive comparison: findDroppedMultiGetPaths iterates
+			// requested in order, so the result preserves that order.
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("findDroppedMultiGetPaths()[%d] = %q, want %q", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestMalformedEventCollectorMultipleOperations(t *testing.T) {
 	t.Run("handles large number of events", func(t *testing.T) {
 		collector := NewMalformedEventCollector()


### PR DESCRIPTION
Re-created after auto-close. Closes #35.