### PR TITLE
test: extract and characterize fullSync two-way safety guards (#68)

### DIFF
--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -31,6 +31,48 @@ func isForbiddenError(err error) bool {
 	return strings.Contains(errStr, "403") || strings.Contains(errStr, "Forbidden")
 }
 
+// shouldSkipTwoWayDeletion returns true if the two-way deletion pass
+// should be skipped entirely for this sync cycle. This is the guard
+// introduced in commit b772c56 (and extended by PR #22) against mass
+// deletion when the destination query returned empty but we have
+// prior sync records.
+//
+// The rationale: if we previously synced N events and the destination
+// suddenly says it has zero, that's almost certainly a destination
+// query failure (network hiccup, bad auth, server bug), NOT a user
+// who just deleted N events in rapid succession. Deleting the
+// corresponding events from the source based on that empty query
+// would be a disaster.
+//
+// Extracted as a pure helper in Issue #68 so it can be unit-tested
+// directly. Behavior is byte-for-byte identical to the previous
+// inline implementation.
+func shouldSkipTwoWayDeletion(direction db.SyncDirection, destEventCount, previouslySyncedCount int) bool {
+	return direction == db.SyncDirectionTwoWay &&
+		destEventCount == 0 &&
+		previouslySyncedCount > 0
+}
+
+// isWithinSyncSafetyThreshold returns true if the given
+// "last synced at" timestamp is within the safety window — meaning
+// the event was synced recently enough that we should NOT delete it
+// from the source yet, even if it appears to be missing from the
+// destination.
+//
+// This is the guard introduced in commit 23e88c1. The rationale: if
+// an event was just synced to the destination but hasn't propagated
+// yet (destination eventual consistency, caching, indexing delay),
+// a naive "event missing from destination → delete from source"
+// reaction would cause data loss. The threshold is one full sync
+// interval plus the slack needed for the destination to catch up.
+//
+// Extracted as a pure helper in Issue #68 for testability.
+// Behavior is byte-for-byte identical to the previous inline check.
+func isWithinSyncSafetyThreshold(syncedAt time.Time, sourceSyncInterval time.Duration, now time.Time) bool {
+	threshold := now.Add(-sourceSyncInterval)
+	return syncedAt.After(threshold)
+}
+
 // getSyncDirectionForCalendar returns the effective sync direction for a calendar.
 // It checks per-calendar settings first, then falls back to the source default.
 func getSyncDirectionForCalendar(source *db.Source, calendarPath string) db.SyncDirection {
@@ -762,17 +804,19 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 	// Update status to show processing phase
 	updateStatus(fmt.Sprintf("processing %d events", len(sourceEvents)))
 
-	// Handle deletions first (for two-way sync)
-	// SAFETY: Only delete from source if the event was synced at least one sync cycle ago
-	// This prevents deleting events that failed to sync to destination
-	syncSafetyThreshold := time.Now().Add(-time.Duration(source.SyncInterval) * time.Second)
+	// Handle deletions first (for two-way sync). Both safety guards
+	// below are extracted as pure helpers (Issue #68) so they can be
+	// unit-tested directly — see shouldSkipTwoWayDeletion and
+	// isWithinSyncSafetyThreshold in this file.
+	sourceInterval := time.Duration(source.SyncInterval) * time.Second
+	now := time.Now()
 
-	// SAFETY: Skip two-way deletion if destination query returned empty but we have synced events
-	// This prevents mass deletion from source when destination query fails
-	skipTwoWayDeletion := false
-	if syncDirection == db.SyncDirectionTwoWay && len(destEventMap) == 0 && len(previouslySyncedMap) > 0 {
+	// SAFETY: Skip two-way deletion entirely if destination query
+	// returned empty but we have synced events. Prevents mass
+	// deletion from source when the destination query fails.
+	skipTwoWayDeletion := shouldSkipTwoWayDeletion(syncDirection, len(destEventMap), len(previouslySyncedMap))
+	if skipTwoWayDeletion {
 		log.Printf("WARNING: Destination returned 0 events but we have %d previously synced events - skipping two-way deletions for safety", len(previouslySyncedMap))
-		skipTwoWayDeletion = true
 	}
 
 	if syncDirection == db.SyncDirectionTwoWay && !skipTwoWayDeletion && sourceClient != nil {
@@ -799,9 +843,11 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 
 			sourceEvent, existsOnSource := sourceEventMap[uid]
 			if existsOnSource && !existsOnDest {
-				// SAFETY CHECK: Only delete from source if the event was synced before the safety threshold
-				// This prevents deleting events that never synced successfully to destination
-				if syncedEvent.UpdatedAt.After(syncSafetyThreshold) {
+				// SAFETY CHECK: Only delete from source if the event was
+				// synced before the safety threshold (commit 23e88c1).
+				// Prevents deleting events that failed to sync to
+				// destination or haven't propagated yet.
+				if isWithinSyncSafetyThreshold(syncedEvent.UpdatedAt, sourceInterval, now) {
 					log.Printf("Event %s not on destination but synced recently - skipping deletion from source (safety)", uid)
 					continue
 				}

--- a/internal/caldav/two_way_safety_test.go
+++ b/internal/caldav/two_way_safety_test.go
@@ -1,0 +1,136 @@
+package caldav
+
+import (
+	"testing"
+	"time"
+
+	"github.com/macjediwizard/calbridgesync/internal/db"
+)
+
+// TestShouldSkipTwoWayDeletion_NormalCase verifies the happy path:
+// a two-way sync with destination events and previously synced
+// events does NOT skip deletion. This is the normal operating mode.
+func TestShouldSkipTwoWayDeletion_NormalCase(t *testing.T) {
+	if shouldSkipTwoWayDeletion(db.SyncDirectionTwoWay, 50, 50) {
+		t.Error("normal case should not skip two-way deletion")
+	}
+}
+
+// TestShouldSkipTwoWayDeletion_DestEmptyWithPriorSync verifies the
+// critical safety case: two-way sync, destination query returned
+// empty, previously synced events exist. MUST skip deletion.
+// Regression test for commit b772c56 and PR #22 extension.
+func TestShouldSkipTwoWayDeletion_DestEmptyWithPriorSync(t *testing.T) {
+	if !shouldSkipTwoWayDeletion(db.SyncDirectionTwoWay, 0, 50) {
+		t.Fatal("destination empty + prior sync records MUST skip deletion to prevent mass data loss")
+	}
+}
+
+// TestShouldSkipTwoWayDeletion_OneWayNotAffected verifies that the
+// guard only applies to two-way sync. A one-way sync with an empty
+// destination is a legitimate "clean start" scenario, not a safety
+// violation.
+func TestShouldSkipTwoWayDeletion_OneWayNotAffected(t *testing.T) {
+	if shouldSkipTwoWayDeletion(db.SyncDirectionOneWay, 0, 50) {
+		t.Error("one-way sync should never be affected by the two-way deletion guard")
+	}
+}
+
+// TestShouldSkipTwoWayDeletion_EmptyDestNoPrior verifies the
+// legitimate first-sync scenario: two-way sync, empty destination,
+// zero prior sync records. Nothing to protect, so don't skip — this
+// allows the normal sync flow to populate the destination.
+func TestShouldSkipTwoWayDeletion_EmptyDestNoPrior(t *testing.T) {
+	if shouldSkipTwoWayDeletion(db.SyncDirectionTwoWay, 0, 0) {
+		t.Error("legitimate first-sync (empty dest, no prior records) should not be blocked")
+	}
+}
+
+// TestShouldSkipTwoWayDeletion_DestPopulatedNoPrior verifies that a
+// fresh two-way sync against a destination that already has events
+// (e.g., user manually added events, or migration from another tool)
+// does not skip deletion — there are no prior records to protect.
+func TestShouldSkipTwoWayDeletion_DestPopulatedNoPrior(t *testing.T) {
+	if shouldSkipTwoWayDeletion(db.SyncDirectionTwoWay, 10, 0) {
+		t.Error("populated destination with no prior records should not trigger the guard")
+	}
+}
+
+// TestIsWithinSyncSafetyThreshold_RecentlySynced verifies the core
+// case: an event synced within the last sync interval is "too
+// recent to delete from source" — the destination may not have
+// finished propagating yet.
+func TestIsWithinSyncSafetyThreshold_RecentlySynced(t *testing.T) {
+	now := time.Now()
+	interval := 5 * time.Minute
+	// Synced 2 minutes ago — well inside the 5-minute window
+	syncedAt := now.Add(-2 * time.Minute)
+
+	if !isWithinSyncSafetyThreshold(syncedAt, interval, now) {
+		t.Error("event synced 2 min ago should be within 5 min safety threshold")
+	}
+}
+
+// TestIsWithinSyncSafetyThreshold_OldSync verifies that an event
+// synced before the safety window is eligible for deletion.
+func TestIsWithinSyncSafetyThreshold_OldSync(t *testing.T) {
+	now := time.Now()
+	interval := 5 * time.Minute
+	// Synced 10 minutes ago — outside the 5-minute window
+	syncedAt := now.Add(-10 * time.Minute)
+
+	if isWithinSyncSafetyThreshold(syncedAt, interval, now) {
+		t.Error("event synced 10 min ago should be outside 5 min safety threshold")
+	}
+}
+
+// TestIsWithinSyncSafetyThreshold_ExactBoundary verifies the
+// boundary condition. The threshold uses strict After(), so an
+// event synced exactly at the threshold is considered OUT of the
+// window (eligible for deletion).
+func TestIsWithinSyncSafetyThreshold_ExactBoundary(t *testing.T) {
+	now := time.Now()
+	interval := 5 * time.Minute
+	// Exactly at the threshold: now - interval
+	syncedAt := now.Add(-interval)
+
+	if isWithinSyncSafetyThreshold(syncedAt, interval, now) {
+		t.Error("event synced exactly at threshold should be OUT of window (strict After)")
+	}
+}
+
+// TestIsWithinSyncSafetyThreshold_LongInterval verifies the guard
+// scales with the source's configured sync interval. A source with
+// a 1-hour interval gives events a longer grace period.
+func TestIsWithinSyncSafetyThreshold_LongInterval(t *testing.T) {
+	now := time.Now()
+	interval := 1 * time.Hour
+
+	// 30 minutes ago — within a 1-hour window
+	recentSync := now.Add(-30 * time.Minute)
+	if !isWithinSyncSafetyThreshold(recentSync, interval, now) {
+		t.Error("30min-old sync should be within 1h threshold")
+	}
+
+	// 2 hours ago — outside a 1-hour window
+	oldSync := now.Add(-2 * time.Hour)
+	if isWithinSyncSafetyThreshold(oldSync, interval, now) {
+		t.Error("2h-old sync should be outside 1h threshold")
+	}
+}
+
+// TestIsWithinSyncSafetyThreshold_FutureSyncedAt verifies the edge
+// case where syncedAt is somehow in the future (clock skew, bad
+// clock on the source, corrupted timestamp). A future timestamp is
+// trivially "within the threshold" and should block deletion, which
+// is the safe default.
+func TestIsWithinSyncSafetyThreshold_FutureSyncedAt(t *testing.T) {
+	now := time.Now()
+	interval := 5 * time.Minute
+	// 10 seconds in the future — from clock skew
+	syncedAt := now.Add(10 * time.Second)
+
+	if !isWithinSyncSafetyThreshold(syncedAt, interval, now) {
+		t.Error("future syncedAt should trivially be 'within' threshold (safe default)")
+	}
+}


### PR DESCRIPTION
Closes #68.