### PR TITLE
feat: implement OAuth2 for Google Calendar sources (#70)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,14 @@ MAX_SYNC_INTERVAL=3600
 
 # Cooldown between repeated alerts for the same source (default: 60 minutes)
 # ALERT_COOLDOWN_MINUTES=60
+
+# Google Calendar OAuth2 (optional — enables the Google source type)
+# One-time setup: Google Cloud Console → create project → enable
+# Google Calendar API → Credentials → OAuth client ID (Web app) →
+# add https://calbridgesync.yourdomain.com/auth/oauth/google/callback
+# as an authorized redirect URI. Copy the client id and secret here.
+# GOOGLE_OAUTH_REDIRECT_URL defaults to <BASE_URL>/auth/oauth/google/callback
+# if unset, so usually you only need the client id and secret.
+# GOOGLE_OAUTH_CLIENT_ID=your-google-oauth-client-id.apps.googleusercontent.com
+# GOOGLE_OAUTH_CLIENT_SECRET=your-google-oauth-client-secret
+# GOOGLE_OAUTH_REDIRECT_URL=https://calbridgesync.yourdomain.com/auth/oauth/google/callback

--- a/cmd/calbridgesync/main.go
+++ b/cmd/calbridgesync/main.go
@@ -12,6 +12,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+
 	"github.com/macjediwizard/calbridgesync/internal/auth"
 	"github.com/macjediwizard/calbridgesync/internal/caldav"
 	"github.com/macjediwizard/calbridgesync/internal/config"
@@ -83,8 +86,33 @@ func main() {
 		cfg.Security.OAuthStateMaxAgeSecs,
 	)
 
+	// Build the Google OAuth2 config if credentials are configured.
+	// This is passed through to the sync engine so Google sources can
+	// authenticate via Bearer tokens. nil when the feature is not
+	// configured — in that case, attempting to sync a Google source
+	// will surface a clear error from the engine. (#70)
+	var googleOAuthConfig *oauth2.Config
+	if cfg.GoogleOAuth.Enabled() {
+		googleOAuthConfig = &oauth2.Config{
+			ClientID:     cfg.GoogleOAuth.ClientID,
+			ClientSecret: cfg.GoogleOAuth.ClientSecret,
+			RedirectURL:  cfg.GoogleOAuth.RedirectURL,
+			Endpoint:     google.Endpoint,
+			Scopes: []string{
+				// Full calendar scope is required for CalDAV access.
+				// The narrower .events scope is NOT sufficient because
+				// CalDAV requires PROPFIND on calendar-home-set.
+				"https://www.googleapis.com/auth/calendar",
+				// Needed to fetch the user's primary email during the
+				// OAuth callback so we can build the per-calendar URL.
+				"https://www.googleapis.com/auth/userinfo.email",
+			},
+		}
+		log.Printf("Google OAuth2 enabled (redirect=%s)", cfg.GoogleOAuth.RedirectURL)
+	}
+
 	// Initialize sync engine
-	syncEngine := caldav.NewSyncEngine(database, encryptor)
+	syncEngine := caldav.NewSyncEngine(database, encryptor, googleOAuthConfig)
 
 	// Initialize notifier for alerts
 	notifyCfg := &notify.Config{

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/bytedance/sonic v1.14.0 h1:/OfKt8HFw0kh2rj8N0F6C/qPGRESq0BbaNZgcNXXzQQ=
 github.com/bytedance/sonic v1.14.0/go.mod h1:WoEbx8WTcFJfzCe0hbmyTGrfjt8PzNEBdxlNUO24NhA=
 github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -10,10 +11,35 @@ import (
 )
 
 const (
-	sessionName     = "calbridgesync_session"
-	oauthStateName  = "calbridgesync_oauth_state"
-	csrfTokenLength = 32
+	sessionName             = "calbridgesync_session"
+	oauthStateName          = "calbridgesync_oauth_state"
+	googlePendingSourceName = "calbridgesync_google_pending" // #70
+	csrfTokenLength         = 32
+	// pendingSourceMaxAge is how long a pending Google source can sit
+	// in its cookie between form submit and OAuth callback. Long
+	// enough for the user to go through Google's consent screen,
+	// short enough that a stale cookie doesn't pile up. (#70)
+	pendingSourceMaxAge = 900 // 15 minutes
 )
+
+// PendingGoogleSource holds the form data for a Google source that is
+// mid-OAuth. It's stashed in a short-lived session cookie between the
+// "prepare" API call and the OAuth callback, then read and cleared by
+// the callback when it creates the real Source row. DestPassword is
+// already encrypted via the application's AES-256-GCM Encryptor
+// before it lands in this struct — the session cookie does NOT carry
+// a plaintext password. (#70)
+type PendingGoogleSource struct {
+	State            string `json:"state"`
+	Name             string `json:"name"`
+	SyncInterval     int    `json:"sync_interval"`
+	SyncDaysPast     int    `json:"sync_days_past"`
+	SyncDirection    string `json:"sync_direction"`
+	ConflictStrategy string `json:"conflict_strategy"`
+	DestURL          string `json:"dest_url"`
+	DestUsername     string `json:"dest_username"`
+	DestPasswordEnc  string `json:"dest_password_enc"` // already encrypted
+}
 
 var (
 	ErrSessionNotFound = errors.New("session not found")
@@ -31,9 +57,9 @@ type SessionData struct {
 
 // SessionManager manages user sessions.
 type SessionManager struct {
-	store             *sessions.CookieStore
-	secure            bool
-	oauthStateMaxAge  int // OAuth state timeout in seconds
+	store            *sessions.CookieStore
+	secure           bool
+	oauthStateMaxAge int // OAuth state timeout in seconds
 }
 
 // NewSessionManager creates a new session manager.
@@ -171,6 +197,59 @@ func (sm *SessionManager) GetOAuthState(w http.ResponseWriter, r *http.Request) 
 	}
 
 	return state, nil
+}
+
+// SetPendingGoogleSource stores a pending Google source form in a
+// short-lived session cookie. Used between the "prepare" API call
+// (which validates the form) and the OAuth callback (which reads it
+// back and creates the real Source row after Google returns the
+// refresh token). (#70)
+func (sm *SessionManager) SetPendingGoogleSource(w http.ResponseWriter, r *http.Request, data *PendingGoogleSource) error {
+	session, err := sm.store.Get(r, googlePendingSourceName)
+	if err != nil {
+		session, err = sm.store.New(r, googlePendingSourceName)
+		if err != nil {
+			return err
+		}
+	}
+
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	session.Values["pending"] = string(encoded)
+	session.Options.MaxAge = pendingSourceMaxAge
+
+	return session.Save(r, w)
+}
+
+// GetPendingGoogleSource retrieves and clears the pending Google
+// source. The clear-on-read semantics mean a pending source can only
+// be consumed once — replaying the OAuth callback will fail. (#70)
+func (sm *SessionManager) GetPendingGoogleSource(w http.ResponseWriter, r *http.Request) (*PendingGoogleSource, error) {
+	session, err := sm.store.Get(r, googlePendingSourceName)
+	if err != nil {
+		return nil, err
+	}
+
+	encoded, ok := session.Values["pending"].(string)
+	if !ok || encoded == "" {
+		return nil, ErrInvalidSession
+	}
+
+	var data PendingGoogleSource
+	if err := json.Unmarshal([]byte(encoded), &data); err != nil {
+		return nil, err
+	}
+
+	// Clear the cookie after reading
+	session.Options.MaxAge = -1
+	if err := session.Save(r, w); err != nil {
+		return nil, err
+	}
+
+	return &data, nil
 }
 
 // GenerateState generates a random state string for OAuth.

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -802,7 +802,7 @@ func TestSanitizeLogDetails(t *testing.T) {
 
 func TestNewSyncEngine(t *testing.T) {
 	t.Run("creates sync engine with nil dependencies", func(t *testing.T) {
-		engine := NewSyncEngine(nil, nil)
+		engine := NewSyncEngine(nil, nil, nil)
 
 		if engine == nil {
 			t.Fatal("expected non-nil engine")
@@ -1347,7 +1347,7 @@ func TestSanitizeLogDetailsEdgeCases(t *testing.T) {
 
 func TestSyncEngineTestConnection(t *testing.T) {
 	t.Run("returns error for invalid URL", func(t *testing.T) {
-		engine := NewSyncEngine(nil, nil)
+		engine := NewSyncEngine(nil, nil, nil)
 
 		err := engine.TestConnection(context.Background(), "", "user", "pass")
 		if err == nil {

--- a/internal/caldav/oauth_client.go
+++ b/internal/caldav/oauth_client.go
@@ -1,0 +1,83 @@
+package caldav
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/emersion/go-webdav/caldav"
+	"golang.org/x/oauth2"
+)
+
+// NewOAuthClient creates a CalDAV Client that authenticates using
+// OAuth2 Bearer tokens instead of HTTP Basic Auth. It is used for
+// source types where the server requires OAuth2 — currently only
+// Google Calendar (#70).
+//
+// The caller provides an oauth2.Config (with ClientID/ClientSecret
+// and the provider endpoint already set) and an *oauth2.Token that
+// holds a non-empty RefreshToken. Access tokens are refreshed
+// automatically by oauth2.Transport when they expire; the caller does
+// NOT need to check expiry.
+//
+// ctx is stored inside the returned TokenSource and used for token
+// refreshes, so it must remain valid for the lifetime of the Client.
+// Pass context.Background() for long-lived use (the sync engine).
+func NewOAuthClient(ctx context.Context, baseURL string, oauthConfig *oauth2.Config, token *oauth2.Token) (*Client, error) {
+	if baseURL == "" {
+		return nil, fmt.Errorf("%w: base URL is required", ErrConnectionFailed)
+	}
+	if oauthConfig == nil {
+		return nil, fmt.Errorf("%w: oauth config is required", ErrConnectionFailed)
+	}
+	if token == nil || token.RefreshToken == "" {
+		return nil, fmt.Errorf("%w: refresh token is required", ErrAuthFailed)
+	}
+
+	// Base transport — matches NewClient's TLS/timeouts exactly so
+	// OAuth requests and non-OAuth requests behave identically at the
+	// network layer. Any change to TLS/timeout policy here MUST be
+	// mirrored in NewClient (and vice versa).
+	baseTransport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: minTLSVersion,
+		},
+		MaxIdleConns:        10,
+		IdleConnTimeout:     30 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+
+	// oauth2.Transport wraps baseTransport and injects the bearer
+	// token into every request. When the access token expires, the
+	// underlying ReuseTokenSource calls oauthConfig.TokenSource(ctx,
+	// token).Token() which performs a refresh against the provider's
+	// TokenURL (google.Endpoint.TokenURL for Google).
+	tokenSource := oauthConfig.TokenSource(ctx, token)
+	oauthTransport := &oauth2.Transport{
+		Base:   baseTransport,
+		Source: tokenSource,
+	}
+
+	httpClient := &http.Client{
+		Timeout:   defaultTimeout,
+		Transport: oauthTransport,
+	}
+
+	// caldav.NewClient accepts anything that implements webdav.HTTPClient,
+	// and *http.Client satisfies that interface via its Do method. We
+	// pass the oauth-wrapped client directly — no basic-auth wrapper.
+	caldavClient, err := caldav.NewClient(httpClient, baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to create CalDAV client: %w", ErrConnectionFailed, err)
+	}
+
+	return &Client{
+		baseURL:      baseURL,
+		username:     "", // OAuth clients don't carry a username/password
+		password:     "",
+		httpClient:   httpClient,
+		caldavClient: caldavClient,
+	}, nil
+}

--- a/internal/caldav/oauth_client_test.go
+++ b/internal/caldav/oauth_client_test.go
@@ -1,0 +1,178 @@
+package caldav
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// TestNewOAuthClient_RejectsEmptyBaseURL verifies the same empty-URL
+// guard as NewClient. (#70)
+func TestNewOAuthClient_RejectsEmptyBaseURL(t *testing.T) {
+	cfg := &oauth2.Config{ClientID: "x", ClientSecret: "y", Endpoint: oauth2.Endpoint{TokenURL: "https://example.com/token"}}
+	token := &oauth2.Token{RefreshToken: "refresh"}
+
+	_, err := NewOAuthClient(context.Background(), "", cfg, token)
+	if err == nil {
+		t.Fatal("expected error for empty base URL")
+	}
+	if !errors.Is(err, ErrConnectionFailed) {
+		t.Errorf("expected ErrConnectionFailed, got %v", err)
+	}
+}
+
+// TestNewOAuthClient_RejectsNilConfig verifies that a nil oauth2.Config
+// is rejected before we try to build anything. (#70)
+func TestNewOAuthClient_RejectsNilConfig(t *testing.T) {
+	token := &oauth2.Token{RefreshToken: "refresh"}
+	_, err := NewOAuthClient(context.Background(), "https://example.com/", nil, token)
+	if err == nil {
+		t.Fatal("expected error for nil oauth config")
+	}
+	if !errors.Is(err, ErrConnectionFailed) {
+		t.Errorf("expected ErrConnectionFailed, got %v", err)
+	}
+}
+
+// TestNewOAuthClient_RejectsMissingRefreshToken verifies that callers
+// cannot create a client without a refresh token. A refresh token is
+// the only way the client can recover from access token expiry, so
+// creating a client without one is a programming error that should
+// fail loudly instead of silently producing a 401-later client. (#70)
+func TestNewOAuthClient_RejectsMissingRefreshToken(t *testing.T) {
+	cfg := &oauth2.Config{ClientID: "x", ClientSecret: "y", Endpoint: oauth2.Endpoint{TokenURL: "https://example.com/token"}}
+
+	_, err := NewOAuthClient(context.Background(), "https://example.com/", cfg, nil)
+	if err == nil {
+		t.Fatal("expected error for nil token")
+	}
+	if !errors.Is(err, ErrAuthFailed) {
+		t.Errorf("expected ErrAuthFailed for nil token, got %v", err)
+	}
+
+	_, err = NewOAuthClient(context.Background(), "https://example.com/", cfg, &oauth2.Token{})
+	if err == nil {
+		t.Fatal("expected error for empty refresh token")
+	}
+	if !errors.Is(err, ErrAuthFailed) {
+		t.Errorf("expected ErrAuthFailed for empty refresh token, got %v", err)
+	}
+}
+
+// TestOAuthClient_InjectsBearerToken verifies the core of the OAuth
+// path: the CalDAV HTTP requests carry an Authorization: Bearer
+// header derived from the configured TokenSource. We stand up a
+// mock CalDAV server that inspects the header and a mock OAuth2
+// token endpoint that returns a canned access token. (#70)
+func TestOAuthClient_InjectsBearerToken(t *testing.T) {
+	var caldavAuthHeader atomic.Value
+	caldavServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		caldavAuthHeader.Store(r.Header.Get("Authorization"))
+		// Return a 401 so the client's subsequent call path is
+		// irrelevant to this test — we only care that the header
+		// was set correctly on the outgoing request.
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer caldavServer.Close()
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test-access-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	cfg := &oauth2.Config{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  tokenServer.URL + "/auth",
+			TokenURL: tokenServer.URL + "/token",
+		},
+	}
+	// Token with an expired access token — the Transport must
+	// refresh it via tokenServer before making any CalDAV call.
+	token := &oauth2.Token{
+		AccessToken:  "stale",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().Add(-1 * time.Hour),
+	}
+
+	client, err := NewOAuthClient(context.Background(), caldavServer.URL+"/", cfg, token)
+	if err != nil {
+		t.Fatalf("NewOAuthClient returned error: %v", err)
+	}
+
+	// TestConnection will fail (server returns 401) — we don't care
+	// about the return value, only the header seen by the server.
+	_ = client.TestConnection(context.Background())
+
+	headerValue, _ := caldavAuthHeader.Load().(string)
+	if headerValue == "" {
+		t.Fatal("CalDAV server never saw an Authorization header")
+	}
+	if !strings.HasPrefix(headerValue, "Bearer ") {
+		t.Errorf("expected Bearer token, got %q", headerValue)
+	}
+	if !strings.Contains(headerValue, "test-access-token") {
+		t.Errorf("expected Bearer header to carry refreshed token, got %q", headerValue)
+	}
+}
+
+// TestOAuthClient_RefreshHitsTokenEndpoint verifies that an expired
+// access token triggers a refresh against the configured TokenURL
+// with the stored refresh token. This is the happy-path scenario
+// for long-running Google sources that sit idle between syncs. (#70)
+func TestOAuthClient_RefreshHitsTokenEndpoint(t *testing.T) {
+	var tokenHits atomic.Int32
+	var receivedRefreshToken atomic.Value
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenHits.Add(1)
+		// oauth2 package sends the refresh token as form body
+		if err := r.ParseForm(); err == nil {
+			receivedRefreshToken.Store(r.Form.Get("refresh_token"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	caldavServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer caldavServer.Close()
+
+	cfg := &oauth2.Config{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		Endpoint: oauth2.Endpoint{
+			TokenURL: tokenServer.URL,
+		},
+	}
+	token := &oauth2.Token{
+		AccessToken:  "stale",
+		RefreshToken: "the-refresh-token",
+		Expiry:       time.Now().Add(-1 * time.Hour),
+	}
+
+	client, err := NewOAuthClient(context.Background(), caldavServer.URL+"/", cfg, token)
+	if err != nil {
+		t.Fatalf("NewOAuthClient returned error: %v", err)
+	}
+
+	_ = client.TestConnection(context.Background())
+
+	if got := tokenHits.Load(); got == 0 {
+		t.Fatal("token endpoint was never hit — refresh did not occur")
+	}
+	if got, _ := receivedRefreshToken.Load().(string); got != "the-refresh-token" {
+		t.Errorf("expected refresh token %q, got %q", "the-refresh-token", got)
+	}
+}

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/oauth2"
+
 	"github.com/macjediwizard/calbridgesync/internal/activity"
 	"github.com/macjediwizard/calbridgesync/internal/crypto"
 	"github.com/macjediwizard/calbridgesync/internal/db"
@@ -294,14 +296,23 @@ type SyncEngine struct {
 	db        *db.DB
 	encryptor *crypto.Encryptor
 	tracker   *activity.Tracker
+	// googleOAuth is the OAuth2 configuration used when syncing
+	// source_type == google. Nil if the feature is not configured on
+	// this instance; SyncSource will then surface a clear error
+	// instead of silently falling back to Basic Auth (which Google
+	// would reject anyway). (#70)
+	googleOAuth *oauth2.Config
 }
 
-// NewSyncEngine creates a new sync engine.
-func NewSyncEngine(database *db.DB, encryptor *crypto.Encryptor) *SyncEngine {
+// NewSyncEngine creates a new sync engine. googleOAuth is optional
+// and should be nil unless Google OAuth2 credentials have been
+// configured via GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET.
+func NewSyncEngine(database *db.DB, encryptor *crypto.Encryptor, googleOAuth *oauth2.Config) *SyncEngine {
 	return &SyncEngine{
-		db:        database,
-		encryptor: encryptor,
-		tracker:   activity.NewTracker(),
+		db:          database,
+		encryptor:   encryptor,
+		tracker:     activity.NewTracker(),
+		googleOAuth: googleOAuth,
 	}
 }
 
@@ -331,13 +342,22 @@ func (se *SyncEngine) SyncSource(ctx context.Context, source *db.Source) *SyncRe
 	}
 
 	// Decrypt credentials - NEVER log these
-	sourcePassword, err := se.encryptor.Decrypt(source.SourcePassword)
-	if err != nil {
-		result.Message = "Failed to decrypt source credentials"
-		result.Errors = append(result.Errors, err.Error())
-		result.Duration = time.Since(start)
-		se.finishSync(source.ID, result)
-		return result
+	// For Google OAuth sources, SourcePassword is empty and we decrypt
+	// the refresh token instead. For all other source types, we use
+	// the standard Basic Auth path.
+	isGoogleOAuth := source.SourceType == db.SourceTypeGoogle && source.OAuthRefreshToken != ""
+
+	var sourcePassword string
+	if !isGoogleOAuth {
+		decPassword, decErr := se.encryptor.Decrypt(source.SourcePassword)
+		if decErr != nil {
+			result.Message = "Failed to decrypt source credentials"
+			result.Errors = append(result.Errors, decErr.Error())
+			result.Duration = time.Since(start)
+			se.finishSync(source.ID, result)
+			return result
+		}
+		sourcePassword = decPassword
 	}
 
 	destPassword, err := se.encryptor.Decrypt(source.DestPassword)
@@ -349,8 +369,42 @@ func (se *SyncEngine) SyncSource(ctx context.Context, source *db.Source) *SyncRe
 		return result
 	}
 
-	// Create source client
-	sourceClient, err := NewClient(source.SourceURL, source.SourceUsername, sourcePassword)
+	// Create source client — branch on source type (#70).
+	// Google sources use OAuth2 Bearer auth; everything else uses
+	// Basic Auth. A Google source without an OAuth config on the
+	// server or without a stored refresh token is a hard failure —
+	// we must not silently fall back to Basic Auth because Google
+	// will reject it with 401, which would look like bad credentials
+	// even though the real fix is to finish configuring OAuth.
+	var sourceClient *Client
+	if source.SourceType == db.SourceTypeGoogle {
+		if se.googleOAuth == nil {
+			result.Message = "Google OAuth is not configured on this server (GOOGLE_OAUTH_CLIENT_ID missing)"
+			result.Errors = append(result.Errors, result.Message)
+			result.Duration = time.Since(start)
+			se.finishSync(source.ID, result)
+			return result
+		}
+		if source.OAuthRefreshToken == "" {
+			result.Message = "Google source is missing its OAuth refresh token — reconnect via the web UI"
+			result.Errors = append(result.Errors, result.Message)
+			result.Duration = time.Since(start)
+			se.finishSync(source.ID, result)
+			return result
+		}
+		refreshToken, decErr := se.encryptor.Decrypt(source.OAuthRefreshToken)
+		if decErr != nil {
+			result.Message = "Failed to decrypt Google OAuth refresh token"
+			result.Errors = append(result.Errors, decErr.Error())
+			result.Duration = time.Since(start)
+			se.finishSync(source.ID, result)
+			return result
+		}
+		token := &oauth2.Token{RefreshToken: refreshToken}
+		sourceClient, err = NewOAuthClient(ctx, source.SourceURL, se.googleOAuth, token)
+	} else {
+		sourceClient, err = NewClient(source.SourceURL, source.SourceUsername, sourcePassword)
+	}
 	if err != nil {
 		result.Message = "Failed to connect to source"
 		result.Errors = append(result.Errors, err.Error())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,23 @@ type Config struct {
 	RateLimiting RateLimitConfig
 	Sync         SyncConfig
 	Alerts       AlertConfig
+	GoogleOAuth  GoogleOAuthConfig
+}
+
+// GoogleOAuthConfig holds the OAuth2 credentials for Google Calendar
+// source_type. These are optional: if ClientID or ClientSecret is unset,
+// the feature is disabled and the web UI surfaces a clear error instead
+// of letting the user start a flow that would 401 at the end. (#70)
+type GoogleOAuthConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+}
+
+// Enabled returns true if both client ID and secret are configured.
+// Call this before routing users into the Google OAuth flow.
+func (g GoogleOAuthConfig) Enabled() bool {
+	return g.ClientID != "" && g.ClientSecret != ""
 }
 
 // AlertConfig holds alerting configuration.
@@ -257,6 +274,19 @@ func Load() (*Config, error) {
 			ErrInvalidConfig, initialBackoffMS)
 	}
 	cfg.Alerts.InitialBackoffMS = initialBackoffMS
+
+	// Google OAuth2 configuration (optional; feature is disabled when
+	// ClientID/ClientSecret are unset). (#70)
+	cfg.GoogleOAuth.ClientID = getEnv("GOOGLE_OAUTH_CLIENT_ID", "")
+	cfg.GoogleOAuth.ClientSecret = getEnv("GOOGLE_OAUTH_CLIENT_SECRET", "")
+	cfg.GoogleOAuth.RedirectURL = getEnv("GOOGLE_OAUTH_REDIRECT_URL", "")
+	// If redirect URL is not explicitly set but base URL is, default to
+	// <BASE_URL>/auth/oauth/google/callback. This matches the route
+	// registered in internal/web/routes.go and means operators usually
+	// only need to set the client id and secret.
+	if cfg.GoogleOAuth.RedirectURL == "" && cfg.Server.BaseURL != "" && cfg.GoogleOAuth.ClientID != "" {
+		cfg.GoogleOAuth.RedirectURL = strings.TrimRight(cfg.Server.BaseURL, "/") + "/auth/oauth/google/callback"
+	}
 
 	// Check for missing required configuration
 	missing := cfg.getMissingRequired()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -785,3 +785,48 @@ func TestConfigStructs(t *testing.T) {
 		}
 	})
 }
+
+// TestGoogleOAuthConfig_Enabled verifies the feature-gate helper. (#70)
+// Enabled() must return true only when BOTH client id and secret are
+// set; a half-configured state must be reported as disabled so we
+// don't start a flow that would fail at the token exchange step.
+func TestGoogleOAuthConfig_Enabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    GoogleOAuthConfig
+		wantOk bool
+	}{
+		{
+			name:   "both unset",
+			cfg:    GoogleOAuthConfig{},
+			wantOk: false,
+		},
+		{
+			name:   "only client id",
+			cfg:    GoogleOAuthConfig{ClientID: "x"},
+			wantOk: false,
+		},
+		{
+			name:   "only client secret",
+			cfg:    GoogleOAuthConfig{ClientSecret: "y"},
+			wantOk: false,
+		},
+		{
+			name:   "both set",
+			cfg:    GoogleOAuthConfig{ClientID: "x", ClientSecret: "y"},
+			wantOk: true,
+		},
+		{
+			name:   "redirect url alone is not enough",
+			cfg:    GoogleOAuthConfig{RedirectURL: "https://example.com/cb"},
+			wantOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.Enabled(); got != tt.wantOk {
+				t.Errorf("Enabled() = %v, want %v", got, tt.wantOk)
+			}
+		})
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -40,10 +40,10 @@ func New(dbPath string) (*DB, error) {
 	// Configure connection pool limits to prevent resource exhaustion
 	// SQLite handles concurrency differently than other databases, but these
 	// limits still help prevent file descriptor exhaustion and memory issues
-	conn.SetMaxOpenConns(25)       // Maximum number of open connections
-	conn.SetMaxIdleConns(5)        // Maximum idle connections in pool
-	conn.SetConnMaxLifetime(0)     // Connections are reused forever
-	conn.SetConnMaxIdleTime(0)     // Idle connections are kept forever
+	conn.SetMaxOpenConns(25)   // Maximum number of open connections
+	conn.SetMaxIdleConns(5)    // Maximum idle connections in pool
+	conn.SetConnMaxLifetime(0) // Connections are reused forever
+	conn.SetConnMaxIdleTime(0) // Idle connections are kept forever
 
 	// Configure SQLite for optimal performance and security
 	pragmas := []string{
@@ -224,6 +224,12 @@ func (db *DB) migrate() error {
 
 		// Migration: Add sync_days_past column to sources (default 30 days)
 		`ALTER TABLE sources ADD COLUMN sync_days_past INTEGER NOT NULL DEFAULT 30`,
+
+		// Migration (#70): Add oauth_refresh_token column for Google
+		// Calendar sources. Stored encrypted via the application's
+		// AES-256-GCM Encryptor, same as source_password. Nullable
+		// because non-Google sources never populate it.
+		`ALTER TABLE sources ADD COLUMN oauth_refresh_token TEXT`,
 	}
 
 	for _, migration := range migrations {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -170,13 +170,17 @@ type UserAlertPreferences struct {
 
 // Source represents a calendar source configuration.
 type Source struct {
-	ID                string           `json:"id"`
-	UserID            string           `json:"user_id"`
-	Name              string           `json:"name"`
-	SourceType        SourceType       `json:"source_type"`
-	SourceURL         string           `json:"source_url"`
-	SourceUsername    string           `json:"source_username"`
-	SourcePassword    string           `json:"-"` // Never include in JSON
+	ID             string     `json:"id"`
+	UserID         string     `json:"user_id"`
+	Name           string     `json:"name"`
+	SourceType     SourceType `json:"source_type"`
+	SourceURL      string     `json:"source_url"`
+	SourceUsername string     `json:"source_username"`
+	SourcePassword string     `json:"-"` // Never include in JSON
+	// OAuthRefreshToken holds the encrypted Google OAuth2 refresh
+	// token for source_type == google. Empty for all other source
+	// types. Never exposed via JSON. (#70)
+	OAuthRefreshToken string           `json:"-"`
 	DestURL           string           `json:"dest_url"`
 	DestUsername      string           `json:"dest_username"`
 	DestPassword      string           `json:"-"` // Never include in JSON

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -97,11 +97,20 @@ func (db *DB) CreateSource(source *Source) error {
 		selectedCalendarsJSON = &s
 	}
 
+	// OAuth refresh token is stored in its own column; callers populate
+	// it directly on the Source struct before calling CreateSource
+	// (encrypted upstream by the API handler, same as passwords).
+	var oauthRefreshToken *string
+	if source.OAuthRefreshToken != "" {
+		t := source.OAuthRefreshToken
+		oauthRefreshToken = &t
+	}
+
 	query := `INSERT INTO sources (
 		id, user_id, name, source_type, source_url, source_username, source_password,
 		dest_url, dest_username, dest_password, sync_interval, sync_days_past, sync_direction, conflict_strategy,
-		selected_calendars, enabled, last_sync_status, created_at, updated_at
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		selected_calendars, enabled, last_sync_status, oauth_refresh_token, created_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	_, err := db.conn.Exec(query,
 		source.ID, source.UserID, source.Name, source.SourceType,
@@ -109,7 +118,7 @@ func (db *DB) CreateSource(source *Source) error {
 		source.DestURL, source.DestUsername, source.DestPassword,
 		source.SyncInterval, source.SyncDaysPast, source.SyncDirection, source.ConflictStrategy,
 		selectedCalendarsJSON, source.Enabled,
-		source.LastSyncStatus, source.CreatedAt, source.UpdatedAt,
+		source.LastSyncStatus, oauthRefreshToken, source.CreatedAt, source.UpdatedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create source: %w", err)
@@ -118,12 +127,17 @@ func (db *DB) CreateSource(source *Source) error {
 	return nil
 }
 
+// sourceSelectColumns is the canonical SELECT column list for sources,
+// kept in one place so every query + scan function stays in lockstep.
+// (#70) added oauth_refresh_token at the end so the positional scans
+// only needed a single new field.
+const sourceSelectColumns = `id, user_id, name, source_type, source_url, source_username, source_password,
+	dest_url, dest_username, dest_password, sync_interval, sync_days_past, sync_direction, conflict_strategy,
+	selected_calendars, enabled, last_sync_at, last_sync_status, last_sync_message, created_at, updated_at, oauth_refresh_token`
+
 // GetSourceByID returns a source by its ID.
 func (db *DB) GetSourceByID(id string) (*Source, error) {
-	query := `SELECT id, user_id, name, source_type, source_url, source_username, source_password,
-		dest_url, dest_username, dest_password, sync_interval, sync_days_past, sync_direction, conflict_strategy,
-		selected_calendars, enabled, last_sync_at, last_sync_status, last_sync_message, created_at, updated_at
-		FROM sources WHERE id = ?`
+	query := `SELECT ` + sourceSelectColumns + ` FROM sources WHERE id = ?`
 
 	row := db.conn.QueryRow(query, id)
 	return scanSource(row)
@@ -132,10 +146,7 @@ func (db *DB) GetSourceByID(id string) (*Source, error) {
 // GetSourceByIDForUser returns a source by its ID only if it belongs to the user.
 // This prevents timing attacks by combining auth check with the query.
 func (db *DB) GetSourceByIDForUser(id, userID string) (*Source, error) {
-	query := `SELECT id, user_id, name, source_type, source_url, source_username, source_password,
-		dest_url, dest_username, dest_password, sync_interval, sync_days_past, sync_direction, conflict_strategy,
-		selected_calendars, enabled, last_sync_at, last_sync_status, last_sync_message, created_at, updated_at
-		FROM sources WHERE id = ? AND user_id = ?`
+	query := `SELECT ` + sourceSelectColumns + ` FROM sources WHERE id = ? AND user_id = ?`
 
 	row := db.conn.QueryRow(query, id, userID)
 	return scanSource(row)
@@ -143,10 +154,7 @@ func (db *DB) GetSourceByIDForUser(id, userID string) (*Source, error) {
 
 // GetSourcesByUserID returns all sources for a user.
 func (db *DB) GetSourcesByUserID(userID string) ([]*Source, error) {
-	query := `SELECT id, user_id, name, source_type, source_url, source_username, source_password,
-		dest_url, dest_username, dest_password, sync_interval, sync_days_past, sync_direction, conflict_strategy,
-		selected_calendars, enabled, last_sync_at, last_sync_status, last_sync_message, created_at, updated_at
-		FROM sources WHERE user_id = ? ORDER BY name`
+	query := `SELECT ` + sourceSelectColumns + ` FROM sources WHERE user_id = ? ORDER BY name`
 
 	rows, err := db.conn.Query(query, userID)
 	if err != nil {
@@ -172,10 +180,7 @@ func (db *DB) GetSourcesByUserID(userID string) ([]*Source, error) {
 
 // GetEnabledSources returns all enabled sources.
 func (db *DB) GetEnabledSources() ([]*Source, error) {
-	query := `SELECT id, user_id, name, source_type, source_url, source_username, source_password,
-		dest_url, dest_username, dest_password, sync_interval, sync_days_past, sync_direction, conflict_strategy,
-		selected_calendars, enabled, last_sync_at, last_sync_status, last_sync_message, created_at, updated_at
-		FROM sources WHERE enabled = 1`
+	query := `SELECT ` + sourceSelectColumns + ` FROM sources WHERE enabled = 1`
 
 	rows, err := db.conn.Query(query)
 	if err != nil {
@@ -219,16 +224,28 @@ func (db *DB) UpdateSource(source *Source) error {
 		selectedCalendarsJSON = &s
 	}
 
+	// Only write oauth_refresh_token if the caller populated it.
+	// An empty string on UpdateSource must NOT clobber an existing
+	// refresh token — that would silently break a working Google
+	// source. Use UpdateSourceOAuthRefreshToken to change it explicitly.
+	var oauthRefreshToken *string
+	if source.OAuthRefreshToken != "" {
+		t := source.OAuthRefreshToken
+		oauthRefreshToken = &t
+	}
+
 	query := `UPDATE sources SET
 		name = ?, source_type = ?, source_url = ?, source_username = ?, source_password = ?,
 		dest_url = ?, dest_username = ?, dest_password = ?, sync_interval = ?, sync_days_past = ?,
-		sync_direction = ?, conflict_strategy = ?, selected_calendars = ?, enabled = ?, updated_at = ?
+		sync_direction = ?, conflict_strategy = ?, selected_calendars = ?, enabled = ?,
+		oauth_refresh_token = COALESCE(?, oauth_refresh_token), updated_at = ?
 		WHERE id = ?`
 
 	result, err := db.conn.Exec(query,
 		source.Name, source.SourceType, source.SourceURL, source.SourceUsername, source.SourcePassword,
 		source.DestURL, source.DestUsername, source.DestPassword, source.SyncInterval, source.SyncDaysPast,
-		source.SyncDirection, source.ConflictStrategy, selectedCalendarsJSON, source.Enabled, source.UpdatedAt, source.ID,
+		source.SyncDirection, source.ConflictStrategy, selectedCalendarsJSON, source.Enabled,
+		oauthRefreshToken, source.UpdatedAt, source.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update source: %w", err)
@@ -473,6 +490,7 @@ func scanSource(row *sql.Row) (*Source, error) {
 	var lastSyncMessage sql.NullString
 	var syncDirection sql.NullString
 	var selectedCalendarsJSON sql.NullString
+	var oauthRefreshToken sql.NullString
 
 	err := row.Scan(
 		&source.ID, &source.UserID, &source.Name, &source.SourceType,
@@ -481,7 +499,7 @@ func scanSource(row *sql.Row) (*Source, error) {
 		&source.SyncInterval, &source.SyncDaysPast, &syncDirection, &source.ConflictStrategy,
 		&selectedCalendarsJSON, &source.Enabled,
 		&lastSyncAt, &source.LastSyncStatus, &lastSyncMessage,
-		&source.CreatedAt, &source.UpdatedAt,
+		&source.CreatedAt, &source.UpdatedAt, &oauthRefreshToken,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -497,6 +515,9 @@ func scanSource(row *sql.Row) (*Source, error) {
 	source.SyncDirection = SyncDirection(syncDirection.String)
 	if source.SyncDirection == "" {
 		source.SyncDirection = SyncDirectionOneWay
+	}
+	if oauthRefreshToken.Valid {
+		source.OAuthRefreshToken = oauthRefreshToken.String
 	}
 
 	// Decode selected_calendars from JSON (backward compatible)
@@ -514,6 +535,7 @@ func scanSourceFromRows(rows *sql.Rows) (*Source, error) {
 	var lastSyncMessage sql.NullString
 	var syncDirection sql.NullString
 	var selectedCalendarsJSON sql.NullString
+	var oauthRefreshToken sql.NullString
 
 	err := rows.Scan(
 		&source.ID, &source.UserID, &source.Name, &source.SourceType,
@@ -522,7 +544,7 @@ func scanSourceFromRows(rows *sql.Rows) (*Source, error) {
 		&source.SyncInterval, &source.SyncDaysPast, &syncDirection, &source.ConflictStrategy,
 		&selectedCalendarsJSON, &source.Enabled,
 		&lastSyncAt, &source.LastSyncStatus, &lastSyncMessage,
-		&source.CreatedAt, &source.UpdatedAt,
+		&source.CreatedAt, &source.UpdatedAt, &oauthRefreshToken,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan source: %w", err)
@@ -535,6 +557,9 @@ func scanSourceFromRows(rows *sql.Rows) (*Source, error) {
 	source.SyncDirection = SyncDirection(syncDirection.String)
 	if source.SyncDirection == "" {
 		source.SyncDirection = SyncDirectionOneWay
+	}
+	if oauthRefreshToken.Valid {
+		source.OAuthRefreshToken = oauthRefreshToken.String
 	}
 
 	// Decode selected_calendars from JSON (backward compatible)

--- a/internal/web/oauth_google.go
+++ b/internal/web/oauth_google.go
@@ -1,0 +1,432 @@
+package web
+
+// OAuth2 flow for Google Calendar source_type. (#70)
+//
+// Flow:
+//  1. User picks "Google" in the add-source form (React SPA).
+//  2. React POSTs the form (sans source credentials) to
+//     POST /api/sources/google/prepare, which validates the form,
+//     encrypts the dest password, stashes it in a short-lived
+//     session cookie, and returns {redirect_url}.
+//  3. React does window.location.href = redirect_url, landing on
+//     GET /auth/oauth/google/start.
+//  4. /start generates an OAuth state, stores it in the OAuth state
+//     cookie, and redirects to Google's consent screen with the
+//     calendar + userinfo.email scopes and access_type=offline so
+//     Google returns a refresh_token.
+//  5. Google redirects back to GET /auth/oauth/google/callback with
+//     code + state.
+//  6. /callback validates the state, exchanges the code for a token,
+//     fetches the user's primary Google email, reads the pending
+//     form from the session cookie, encrypts the refresh token,
+//     creates the real Source row (SourceURL is built from the
+//     email), and redirects to /sources.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+
+	"github.com/macjediwizard/calbridgesync/internal/auth"
+	"github.com/macjediwizard/calbridgesync/internal/db"
+)
+
+// googleOAuthStatePrefix namespaces the OAuth state cookie so a Google
+// OAuth state can never be confused with an OIDC login state, even
+// though they share the same underlying cookie.
+const googleOAuthStatePrefix = "google:"
+
+// googleUserinfoURL is the Google API endpoint used to fetch the
+// authenticated user's primary email after OAuth consent. Scoped by
+// "https://www.googleapis.com/auth/userinfo.email".
+const googleUserinfoURL = "https://www.googleapis.com/oauth2/v2/userinfo"
+
+// googleUserinfo is the subset of Google's /userinfo response that
+// we care about.
+type googleUserinfo struct {
+	Email         string `json:"email"`
+	VerifiedEmail bool   `json:"verified_email"`
+	Name          string `json:"name"`
+}
+
+// googleOAuthConfig builds the oauth2.Config from handler config.
+// Returns nil if the feature is disabled on this instance (no client
+// id or secret set).
+func (h *Handlers) googleOAuthConfig() *oauth2.Config {
+	if !h.cfg.GoogleOAuth.Enabled() {
+		return nil
+	}
+	return &oauth2.Config{
+		ClientID:     h.cfg.GoogleOAuth.ClientID,
+		ClientSecret: h.cfg.GoogleOAuth.ClientSecret,
+		RedirectURL:  h.cfg.GoogleOAuth.RedirectURL,
+		Endpoint:     google.Endpoint,
+		Scopes: []string{
+			"https://www.googleapis.com/auth/calendar",
+			"https://www.googleapis.com/auth/userinfo.email",
+		},
+	}
+}
+
+// APIPrepareGoogleSourceRequest is the payload the React SPA sends to
+// kick off a Google OAuth source. It contains only the fields the user
+// sets in the form — source_url/username/password are intentionally
+// omitted because they're filled in after OAuth completes.
+type APIPrepareGoogleSourceRequest struct {
+	Name             string `json:"name"`
+	SyncInterval     int    `json:"sync_interval"`
+	SyncDaysPast     int    `json:"sync_days_past"`
+	SyncDirection    string `json:"sync_direction"`
+	ConflictStrategy string `json:"conflict_strategy"`
+	DestURL          string `json:"dest_url"`
+	DestUsername     string `json:"dest_username"`
+	DestPassword     string `json:"dest_password"`
+}
+
+// APIPrepareGoogleSourceResponse tells the SPA where to send the user
+// next (Google's consent page, via our /start handler).
+type APIPrepareGoogleSourceResponse struct {
+	RedirectURL string `json:"redirect_url"`
+}
+
+// APIPrepareGoogleSource is called by the React SPA when the user
+// submits the add-source form with source_type=google. It:
+//
+//  1. Verifies Google OAuth is configured on this instance.
+//  2. Validates the destination fields (source fields are not
+//     required — those come from Google).
+//  3. Tests the destination connection so we fail fast if SOGo
+//     credentials are wrong.
+//  4. Encrypts the dest password.
+//  5. Generates an OAuth state and stashes it plus the form data in
+//     a short-lived session cookie.
+//  6. Returns the Google consent URL for the SPA to navigate to.
+func (h *Handlers) APIPrepareGoogleSource(c *gin.Context) {
+	session := auth.GetCurrentUser(c)
+	if session == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	cfg := h.googleOAuthConfig()
+	if cfg == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "Google OAuth is not configured on this server. Set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET.",
+		})
+		return
+	}
+
+	var req APIPrepareGoogleSourceRequest
+	if err := json.NewDecoder(c.Request.Body).Decode(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	// Validate required destination fields. Source fields are filled
+	// in from the OAuth response, not from the form.
+	if req.Name == "" || req.DestURL == "" || req.DestUsername == "" || req.DestPassword == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Name and destination URL/username/password are required",
+		})
+		return
+	}
+
+	// Reuse the standard input validator. Source username/URL are
+	// passed as empty because they aren't filled in yet.
+	if validationErr := validateSourceInput(
+		req.Name, string(db.SourceTypeGoogle), req.SyncDirection, req.ConflictStrategy,
+		"", req.DestURL, "", req.DestUsername,
+	); validationErr != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": validationErr})
+		return
+	}
+
+	if len(req.DestPassword) > maxPasswordLength {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Destination password is too long"})
+		return
+	}
+
+	// Test destination before sending the user off to Google — if
+	// SOGo credentials are wrong, we want to catch it now, not
+	// after they've clicked through consent.
+	if err := h.syncEngine.TestConnection(c.Request.Context(), req.DestURL, req.DestUsername, req.DestPassword); err != nil {
+		log.Printf("Google source prepare: destination connection test failed for %s: %v", req.DestURL, err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Failed to connect to destination: " + categorizeConnectionError(err),
+		})
+		return
+	}
+
+	encDestPwd, err := h.encryptor.Encrypt(req.DestPassword)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to encrypt credentials"})
+		return
+	}
+
+	state, err := auth.GenerateState()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate state"})
+		return
+	}
+
+	// Stash state + form data in separate cookies. We keep them
+	// separate so a stale pending-source cookie from a previous flow
+	// can't interfere with the OAuth state CSRF check.
+	if err := h.session.SetOAuthState(c.Writer, c.Request, googleOAuthStatePrefix+state); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save OAuth state"})
+		return
+	}
+
+	pending := &auth.PendingGoogleSource{
+		State:            state,
+		Name:             req.Name,
+		SyncInterval:     req.SyncInterval,
+		SyncDaysPast:     req.SyncDaysPast,
+		SyncDirection:    req.SyncDirection,
+		ConflictStrategy: req.ConflictStrategy,
+		DestURL:          req.DestURL,
+		DestUsername:     req.DestUsername,
+		DestPasswordEnc:  encDestPwd,
+	}
+	if err := h.session.SetPendingGoogleSource(c.Writer, c.Request, pending); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save pending source"})
+		return
+	}
+
+	// access_type=offline tells Google to return a refresh_token.
+	// prompt=consent forces the consent screen to appear on every
+	// re-authorization, which also forces a fresh refresh_token.
+	// Without prompt=consent, Google may return no refresh_token on
+	// re-authorization, which breaks the sync engine.
+	redirectURL := cfg.AuthCodeURL(
+		state,
+		oauth2.AccessTypeOffline,
+		oauth2.SetAuthURLParam("prompt", "consent"),
+	)
+
+	c.JSON(http.StatusOK, APIPrepareGoogleSourceResponse{RedirectURL: redirectURL})
+}
+
+// GoogleOAuthStart is a convenience redirect that exists so operators
+// can kick off the flow from the URL bar for debugging. In the
+// normal flow, the SPA navigates directly to Google using the URL
+// returned by APIPrepareGoogleSource, but this handler exists as a
+// second entry point for the consent screen.
+//
+// It REQUIRES that a pending source already exist in the session —
+// if the user navigates here directly without going through the
+// prepare endpoint first, they'll be bounced back to /sources/add
+// with an error.
+func (h *Handlers) GoogleOAuthStart(c *gin.Context) {
+	cfg := h.googleOAuthConfig()
+	if cfg == nil {
+		c.Redirect(http.StatusFound, "/sources/add?error=google_not_configured")
+		return
+	}
+
+	// We can't easily peek at the pending cookie without clearing
+	// it, so the start endpoint just redirects to /sources/add with
+	// an error if there's no valid prior prepare call. The normal
+	// path is the SPA calling the AuthCodeURL returned by prepare,
+	// which skips this handler entirely.
+	c.Redirect(http.StatusFound, "/sources/add?error=start_via_prepare")
+}
+
+// GoogleOAuthCallback handles the redirect from Google after the user
+// approves (or denies) the consent request. It validates state,
+// exchanges the code for tokens, fetches the user's primary email,
+// reads the pending form data from the session, creates the real
+// Source row, and redirects back to /sources.
+func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
+	cfg := h.googleOAuthConfig()
+	if cfg == nil {
+		c.Redirect(http.StatusFound, "/sources/add?error=google_not_configured")
+		return
+	}
+
+	// Validate state BEFORE anything else — this is the CSRF check.
+	// GetOAuthState atomically reads and clears the state cookie.
+	queryState := c.Query("state")
+	savedState, err := h.session.GetOAuthState(c.Writer, c.Request)
+	if err != nil || savedState == "" || savedState != googleOAuthStatePrefix+queryState {
+		log.Printf("Google OAuth callback: state mismatch (saved=%q query=%q err=%v)", savedState, queryState, err)
+		c.Redirect(http.StatusFound, "/sources/add?error=invalid_state")
+		return
+	}
+
+	// Google can report its own error (user denied consent, etc.)
+	if errParam := c.Query("error"); errParam != "" {
+		log.Printf("Google OAuth callback: Google reported error: %s", errParam)
+		// Clear any stashed pending source so we don't leave it
+		// lying around to interfere with a retry.
+		_, _ = h.session.GetPendingGoogleSource(c.Writer, c.Request)
+		c.Redirect(http.StatusFound, "/sources/add?error=google_denied")
+		return
+	}
+
+	code := c.Query("code")
+	if code == "" {
+		_, _ = h.session.GetPendingGoogleSource(c.Writer, c.Request)
+		c.Redirect(http.StatusFound, "/sources/add?error=missing_code")
+		return
+	}
+
+	// Exchange the authorization code for an access + refresh token.
+	// This hits https://oauth2.googleapis.com/token with the client
+	// secret; it MUST happen server-side, never in the browser.
+	token, err := cfg.Exchange(c.Request.Context(), code)
+	if err != nil {
+		log.Printf("Google OAuth callback: code exchange failed: %v", err)
+		_, _ = h.session.GetPendingGoogleSource(c.Writer, c.Request)
+		c.Redirect(http.StatusFound, "/sources/add?error=exchange_failed")
+		return
+	}
+
+	if token.RefreshToken == "" {
+		// If a user re-authorizes an existing client, Google may
+		// omit the refresh_token. prompt=consent on the auth URL
+		// should force a new one, but if it's still missing we
+		// can't proceed — a source without a refresh token can't
+		// sync past the first access token expiry.
+		log.Printf("Google OAuth callback: Google did not return a refresh token")
+		_, _ = h.session.GetPendingGoogleSource(c.Writer, c.Request)
+		c.Redirect(http.StatusFound, "/sources/add?error=no_refresh_token")
+		return
+	}
+
+	// Fetch the user's primary email. We need it to build the
+	// per-calendar CalDAV URL because Google's CalDAV endpoints are
+	// keyed by email, not by a discovery principal.
+	email, err := fetchGoogleUserEmail(c.Request.Context(), cfg, token)
+	if err != nil {
+		log.Printf("Google OAuth callback: failed to fetch user email: %v", err)
+		_, _ = h.session.GetPendingGoogleSource(c.Writer, c.Request)
+		c.Redirect(http.StatusFound, "/sources/add?error=userinfo_failed")
+		return
+	}
+
+	// Read back the pending form data. GetPendingGoogleSource also
+	// clears the cookie.
+	pending, err := h.session.GetPendingGoogleSource(c.Writer, c.Request)
+	if err != nil {
+		log.Printf("Google OAuth callback: no pending source in session: %v", err)
+		c.Redirect(http.StatusFound, "/sources/add?error=pending_expired")
+		return
+	}
+
+	// Cross-check: the state in the pending source cookie must
+	// match the state we just validated. This is belt-and-braces on
+	// top of the state cookie CSRF check.
+	if pending.State != queryState {
+		log.Printf("Google OAuth callback: pending state mismatch (pending=%q query=%q)", pending.State, queryState)
+		c.Redirect(http.StatusFound, "/sources/add?error=state_mismatch")
+		return
+	}
+
+	session := auth.GetCurrentUser(c)
+	if session == nil {
+		c.Redirect(http.StatusFound, "/auth/login")
+		return
+	}
+
+	// Build the Google CalDAV URL for the user's primary calendar.
+	// Google's documented format is:
+	//   https://apidata.googleusercontent.com/caldav/v2/<email>/user
+	// for principal discovery. The sync engine's FindCurrentUserPrincipal
+	// call is happy with this as the base URL.
+	sourceURL := fmt.Sprintf("https://apidata.googleusercontent.com/caldav/v2/%s/user", email)
+
+	encRefreshToken, err := h.encryptor.Encrypt(token.RefreshToken)
+	if err != nil {
+		log.Printf("Google OAuth callback: failed to encrypt refresh token: %v", err)
+		c.Redirect(http.StatusFound, "/sources/add?error=encrypt_failed")
+		return
+	}
+
+	// Defaults for the sync interval + days past — same clamping as
+	// APICreateSource.
+	syncInterval := pending.SyncInterval
+	if syncInterval < h.cfg.Sync.MinInterval || syncInterval > h.cfg.Sync.MaxInterval {
+		syncInterval = h.cfg.Sync.MinInterval
+	}
+	syncDaysPast := pending.SyncDaysPast
+	if syncDaysPast <= 0 {
+		syncDaysPast = 30
+	}
+	syncDirection := db.SyncDirection(pending.SyncDirection)
+	if !syncDirection.IsValid() {
+		syncDirection = db.SyncDirectionOneWay
+	}
+	conflictStrategy := db.ConflictStrategy(pending.ConflictStrategy)
+	if !conflictStrategy.IsValid() {
+		conflictStrategy = db.ConflictSourceWins
+	}
+
+	source := &db.Source{
+		UserID:            session.UserID,
+		Name:              pending.Name,
+		SourceType:        db.SourceTypeGoogle,
+		SourceURL:         sourceURL,
+		SourceUsername:    email, // Informational only; OAuth doesn't use it
+		SourcePassword:    "",    // Intentionally empty for OAuth sources
+		OAuthRefreshToken: encRefreshToken,
+		DestURL:           pending.DestURL,
+		DestUsername:      pending.DestUsername,
+		DestPassword:      pending.DestPasswordEnc,
+		SyncInterval:      syncInterval,
+		SyncDaysPast:      syncDaysPast,
+		SyncDirection:     syncDirection,
+		ConflictStrategy:  conflictStrategy,
+		Enabled:           true,
+	}
+
+	if err := h.db.CreateSource(source); err != nil {
+		log.Printf("Google OAuth callback: failed to create source: %v", err)
+		c.Redirect(http.StatusFound, "/sources/add?error=create_failed")
+		return
+	}
+
+	h.scheduler.AddJob(source.ID, time.Duration(source.SyncInterval)*time.Second)
+	log.Printf("Google OAuth callback: created source %s for %s", source.ID, email)
+
+	// Full-page navigation back to the SPA, which will load /sources
+	// and show the new source.
+	c.Redirect(http.StatusFound, "/sources?google_oauth=success")
+}
+
+// fetchGoogleUserEmail makes a GET /userinfo call against Google using
+// the access token we just obtained and returns the user's primary
+// email. Separated into its own function to keep the callback handler
+// readable and to make it easy to mock in tests.
+func fetchGoogleUserEmail(ctx context.Context, cfg *oauth2.Config, token *oauth2.Token) (string, error) {
+	client := cfg.Client(ctx, token)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, googleUserinfoURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("userinfo returned HTTP %d", resp.StatusCode)
+	}
+
+	var info googleUserinfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return "", err
+	}
+	if info.Email == "" {
+		return "", fmt.Errorf("userinfo did not include an email")
+	}
+	return info.Email, nil
+}

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -33,6 +33,14 @@ func SetupRoutes(r *gin.Engine, h *Handlers, sm *auth.SessionManager) {
 		authGroup.POST("/login", h.Login)
 		authGroup.GET("/callback", h.Callback)
 		authGroup.POST("/logout", h.Logout)
+
+		// Google Calendar OAuth2 source flow (#70). /start is a
+		// debugging entry point; the real path is the SPA calling
+		// POST /api/sources/google/prepare and then navigating
+		// directly to the returned URL. /callback is the redirect
+		// URI registered in Google Cloud Console.
+		authGroup.GET("/oauth/google/start", h.GoogleOAuthStart)
+		authGroup.GET("/oauth/google/callback", h.GoogleOAuthCallback)
 	}
 
 	// General API routes - 30 req/s handles typical SPA usage (page loads fetch multiple endpoints)
@@ -78,9 +86,10 @@ func SetupRoutes(r *gin.Engine, h *Handlers, sm *auth.SessionManager) {
 	expensiveAPI.Use(ValidateOrigin())
 	expensiveAPI.Use(RequireJSONContentType())
 	{
-		expensiveAPI.POST("/sources", h.APICreateSource)                      // Tests connections to CalDAV servers
-		expensiveAPI.POST("/calendars/discover", h.APIDiscoverCalendars)      // Discovers calendars via network
-		expensiveAPI.POST("/settings/alerts/test-webhook", h.APITestWebhook)  // Tests webhook via network
+		expensiveAPI.POST("/sources", h.APICreateSource)                       // Tests connections to CalDAV servers
+		expensiveAPI.POST("/sources/google/prepare", h.APIPrepareGoogleSource) // Tests dest + stashes pending Google source (#70)
+		expensiveAPI.POST("/calendars/discover", h.APIDiscoverCalendars)       // Discovers calendars via network
+		expensiveAPI.POST("/settings/alerts/test-webhook", h.APITestWebhook)   // Tests webhook via network
 	}
 
 	// Serve React app static files

--- a/web/src/pages/SourceAdd.tsx
+++ b/web/src/pages/SourceAdd.tsx
@@ -1,10 +1,29 @@
-import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
-import { createSource, discoverCalendars } from '../services/api';
+import { useEffect, useState } from 'react';
+import { useNavigate, Link, useSearchParams } from 'react-router-dom';
+import { createSource, discoverCalendars, prepareGoogleSource } from '../services/api';
 import type { SourceFormData, Calendar } from '../types';
+
+// Human-readable mapping for the error query params the backend
+// Google OAuth callback redirects back with when something goes
+// wrong. Keep this in sync with internal/web/oauth_google.go. (#70)
+const GOOGLE_OAUTH_ERRORS: Record<string, string> = {
+  google_not_configured: 'Google OAuth is not configured on this server. Ask your admin to set GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET.',
+  invalid_state: 'OAuth state mismatch. Please start the flow again.',
+  google_denied: 'You denied the Google consent request.',
+  missing_code: 'Google did not return an authorization code.',
+  exchange_failed: 'Failed to exchange the authorization code with Google.',
+  no_refresh_token: 'Google did not return a refresh token. Revoke access at https://myaccount.google.com/permissions and try again.',
+  userinfo_failed: 'Could not fetch your Google account info.',
+  pending_expired: 'The OAuth flow timed out. Please start again.',
+  state_mismatch: 'OAuth state mismatch (pending). Please start again.',
+  encrypt_failed: 'Internal error encrypting the refresh token.',
+  create_failed: 'Failed to create the source after successful OAuth.',
+  start_via_prepare: 'Start the Google OAuth flow by submitting the form first.',
+};
 
 export default function SourceAdd() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [discovering, setDiscovering] = useState(false);
@@ -25,6 +44,18 @@ export default function SourceAdd() {
     conflict_strategy: 'source_wins',
     selected_calendars: [],
   });
+
+  // Surface Google OAuth errors returned by the backend callback as a
+  // query param. The callback uses ?error=<code> because it's doing a
+  // full-page redirect, not an API response. (#70)
+  useEffect(() => {
+    const errCode = searchParams.get('error');
+    if (errCode && GOOGLE_OAUTH_ERRORS[errCode]) {
+      setError(GOOGLE_OAUTH_ERRORS[errCode]);
+      // Pre-select Google so the user lands back on the right form state
+      setForm(prev => ({ ...prev, source_type: 'google' }));
+    }
+  }, [searchParams]);
 
   const handleDiscoverCalendars = async () => {
     if (!form.source_url || !form.source_username || !form.source_password) {
@@ -80,6 +111,10 @@ export default function SourceAdd() {
   };
 
   const isICS = form.source_type === 'ics';
+  // Google sources authenticate via OAuth2 (#70). Source URL/username/
+  // password fields are hidden because they come from Google after
+  // the user approves consent, not from the form.
+  const isGoogleOAuth = form.source_type === 'google';
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
@@ -104,6 +139,23 @@ export default function SourceAdd() {
     setError(null);
 
     try {
+      if (isGoogleOAuth) {
+        // Google sources take a different path: hand the form to the
+        // prepare endpoint, then redirect to Google's consent screen.
+        // The backend callback creates the source and redirects back. (#70)
+        const { redirect_url } = await prepareGoogleSource({
+          name: form.name,
+          sync_interval: form.sync_interval,
+          sync_days_past: form.sync_days_past,
+          sync_direction: form.sync_direction,
+          conflict_strategy: form.conflict_strategy,
+          dest_url: form.dest_url,
+          dest_username: form.dest_username,
+          dest_password: form.dest_password,
+        });
+        window.location.href = redirect_url;
+        return;
+      }
       await createSource(form);
       navigate('/sources');
     } catch (err: unknown) {
@@ -226,57 +278,75 @@ export default function SourceAdd() {
               {/* Source Server */}
               <div className="space-y-4">
                 <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wide border-b border-zinc-800 pb-2">
-                  {isICS ? 'ICS Feed' : 'Source Server'}
+                  {isICS ? 'ICS Feed' : isGoogleOAuth ? 'Google Account' : 'Source Server'}
                 </h3>
-                <div>
-                  <label htmlFor="source_url" className="block text-sm font-medium text-gray-300 mb-1">
-                    {isICS ? 'ICS Feed URL' : 'CalDAV URL'}
-                  </label>
-                  <input
-                    type="url"
-                    name="source_url"
-                    id="source_url"
-                    value={form.source_url}
-                    onChange={handleChange}
-                    required
-                    placeholder={isICS ? 'https://example.com/calendar.ics' : 'https://caldav.example.com/calendars/user/'}
-                    className="w-full"
-                  />
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div>
-                    <label htmlFor="source_username" className="block text-sm font-medium text-gray-300 mb-1">
-                      Username {isICS && <span className="text-gray-500">(optional)</span>}
-                    </label>
-                    <input
-                      type="text"
-                      name="source_username"
-                      id="source_username"
-                      value={form.source_username}
-                      onChange={handleChange}
-                      required={!isICS}
-                      placeholder="user@example.com"
-                      className="w-full"
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="source_password" className="block text-sm font-medium text-gray-300 mb-1">
-                      Password {isICS && <span className="text-gray-500">(optional)</span>}
-                    </label>
-                    <input
-                      type="password"
-                      name="source_password"
-                      id="source_password"
-                      value={form.source_password}
-                      onChange={handleChange}
-                      required={!isICS}
-                      className="w-full"
-                    />
-                  </div>
-                </div>
 
-                {/* Calendar Discovery (not for ICS) */}
-                {!isICS && <div className="pt-2">
+                {isGoogleOAuth ? (
+                  /* Google sources use OAuth2 — no URL/username/password fields. (#70) */
+                  <div className="p-4 rounded border border-zinc-700 bg-black/30 space-y-3">
+                    <p className="text-sm text-white">
+                      Google Calendar requires OAuth2. When you click <span className="font-semibold">Connect Google Account & Save</span>, you'll be redirected to Google to sign in and approve calendar access.
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      calbridgesync will store a refresh token so it can sync on your behalf. You can revoke access at any time at <a href="https://myaccount.google.com/permissions" className="text-red-400 underline" target="_blank" rel="noreferrer">myaccount.google.com/permissions</a>.
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      Your admin must have configured <code className="text-red-400">GOOGLE_OAUTH_CLIENT_ID</code> and <code className="text-red-400">GOOGLE_OAUTH_CLIENT_SECRET</code> on this server for this to work.
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    <div>
+                      <label htmlFor="source_url" className="block text-sm font-medium text-gray-300 mb-1">
+                        {isICS ? 'ICS Feed URL' : 'CalDAV URL'}
+                      </label>
+                      <input
+                        type="url"
+                        name="source_url"
+                        id="source_url"
+                        value={form.source_url}
+                        onChange={handleChange}
+                        required
+                        placeholder={isICS ? 'https://example.com/calendar.ics' : 'https://caldav.example.com/calendars/user/'}
+                        className="w-full"
+                      />
+                    </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      <div>
+                        <label htmlFor="source_username" className="block text-sm font-medium text-gray-300 mb-1">
+                          Username {isICS && <span className="text-gray-500">(optional)</span>}
+                        </label>
+                        <input
+                          type="text"
+                          name="source_username"
+                          id="source_username"
+                          value={form.source_username}
+                          onChange={handleChange}
+                          required={!isICS}
+                          placeholder="user@example.com"
+                          className="w-full"
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="source_password" className="block text-sm font-medium text-gray-300 mb-1">
+                          Password {isICS && <span className="text-gray-500">(optional)</span>}
+                        </label>
+                        <input
+                          type="password"
+                          name="source_password"
+                          id="source_password"
+                          value={form.source_password}
+                          onChange={handleChange}
+                          required={!isICS}
+                          className="w-full"
+                        />
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                {/* Calendar Discovery (not for ICS or Google OAuth) */}
+                {!isICS && !isGoogleOAuth && <div className="pt-2">
                   <button
                     type="button"
                     onClick={handleDiscoverCalendars}
@@ -395,7 +465,13 @@ export default function SourceAdd() {
                   disabled={loading}
                   className="px-4 py-2 rounded bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors disabled:opacity-50"
                 >
-                  {loading ? 'Adding...' : 'Add Source'}
+                  {loading
+                    ? isGoogleOAuth
+                      ? 'Redirecting to Google...'
+                      : 'Adding...'
+                    : isGoogleOAuth
+                    ? 'Connect Google Account & Save'
+                    : 'Add Source'}
                 </button>
               </div>
             </form>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -45,6 +45,33 @@ export const createSource = async (data: SourceFormData): Promise<Source> => {
   return response.data;
 };
 
+// Google OAuth2 source preparation (#70).
+// Called when the user picks source_type=google in the add-source
+// form. The backend validates the form, tests the destination,
+// stashes the encrypted form in a session cookie, and returns a URL
+// to redirect to Google's consent screen. After the user approves at
+// Google, the backend callback creates the real source and
+// redirects back to /sources.
+export interface PrepareGoogleSourceRequest {
+  name: string;
+  sync_interval: number;
+  sync_days_past: number;
+  sync_direction: string;
+  conflict_strategy: string;
+  dest_url: string;
+  dest_username: string;
+  dest_password: string;
+}
+
+export interface PrepareGoogleSourceResponse {
+  redirect_url: string;
+}
+
+export const prepareGoogleSource = async (data: PrepareGoogleSourceRequest): Promise<PrepareGoogleSourceResponse> => {
+  const response = await api.post('/sources/google/prepare', data);
+  return response.data;
+};
+
 export const updateSource = async (id: string, data: Partial<SourceFormData>): Promise<Source> => {
   const response = await api.put(`/sources/${id}`, data);
   return response.data;


### PR DESCRIPTION
## Summary

Implements the OAuth2 backend for Google Calendar sources so users can actually connect their Google accounts. Closes #70.

The `google` source type has been defined in the codebase for a while with a preset URL and a `"(requires OAuth)"` note in its description, but the backend only ever implemented HTTP Basic Auth. Google deprecated Basic Auth for `/caldav/v2/*` — it now returns **HTTP 401 Unauthorized** for any `Authorization: Basic` header regardless of the credential, so the Google source type in the dropdown was effectively dead.

This PR finishes the feature end-to-end.

## What changed

### Backend

- **Schema:** `ALTER TABLE sources ADD COLUMN oauth_refresh_token TEXT` (migration #17 in `internal/db/db.go`). Encrypted at rest with the same AES-256-GCM Encryptor used for passwords.
- **Source struct / CRUD:** new `OAuthRefreshToken` field; `CreateSource`, `UpdateSource`, `scanSource`, `scanSourceFromRows` all updated. A shared `sourceSelectColumns` constant keeps SELECTs in lockstep with scans so a future column add only touches one place. `UpdateSource` uses `COALESCE(?, oauth_refresh_token)` so an empty refresh token on the Source struct doesn't clobber an existing stored token.
- **Config:** new `GoogleOAuthConfig` with `Enabled()` helper gated on both `CLIENT_ID` and `CLIENT_SECRET`. New env vars `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `GOOGLE_OAUTH_REDIRECT_URL`. Redirect URL auto-defaults to `<BASE_URL>/auth/oauth/google/callback` if unset.
- **CalDAV OAuth2 client:** new `internal/caldav/oauth_client.go` with `NewOAuthClient(ctx, baseURL, oauthConfig, token)`. Wraps `oauth2.Transport` for automatic Bearer header injection and auto-refresh against `google.Endpoint.TokenURL`. Rejects nil config / empty refresh token at construction time so failures are loud, not silent.
- **Sync dispatch:** `sync.go` branches on `source.SourceType == db.SourceTypeGoogle`. If the server has no OAuth config or the row has no refresh token, the sync fails with a clear error instead of falling back to Basic Auth. No other source type is affected.
- **OAuth flow handlers:** new `internal/web/oauth_google.go` with three handlers:
  - `APIPrepareGoogleSource` — validates form, tests destination connection, encrypts dest password, generates OAuth state, stashes pending form + state in a short-lived session cookie, returns the Google consent URL for the SPA to navigate to.
  - `GoogleOAuthStart` — debugging entry point.
  - `GoogleOAuthCallback` — validates state (CSRF), exchanges code, fetches user email from `/userinfo`, reads pending form from session, encrypts refresh token, creates the `Source` row, schedules the sync job, redirects to `/sources`.
- **Session:** new `SetPendingGoogleSource` / `GetPendingGoogleSource` helpers with clear-on-read semantics and a 15-minute TTL.
- **Routes:** new `GET /auth/oauth/google/{start,callback}` under the existing strict auth rate limiter; new `POST /api/sources/google/prepare` under the expensive-operation rate limiter (it makes an outbound CalDAV test to verify the destination before handing the user off to Google).

### Frontend

- New `prepareGoogleSource` API client in `web/src/services/api.ts`.
- `SourceAdd.tsx` detects `source_type=google` and hides the source URL/username/password fields, showing an OAuth explanation card instead. Submit button becomes **"Connect Google Account & Save"** and routes through the prepare endpoint to `window.location.href = <google consent URL>`. After Google redirects to the backend callback and the source is created, the browser lands back on `/sources?google_oauth=success`.
- `SourceAdd` surfaces human-readable errors for every `?error=<code>` the backend callback can redirect with (`google_not_configured`, `invalid_state`, `google_denied`, `missing_code`, `exchange_failed`, `no_refresh_token`, `userinfo_failed`, `pending_expired`, `state_mismatch`, `encrypt_failed`, `create_failed`).

### Tests

- `oauth_client_test.go` (new):
  - Empty URL / nil config / missing refresh token are rejected at construction.
  - Mock CalDAV server + mock token endpoint verify the `Authorization: Bearer <token>` header is injected on outgoing requests.
  - Refresh flow verifies the stored `refresh_token` is POSTed to the configured `TokenURL` when the access token is expired.
- `config_test.go`: table-driven `Enabled()` test covering all half-configured states.
- Existing `NewSyncEngine(nil, nil)` call sites updated to the new 3-arg signature.

### Deploy steps (for William, one-time setup)

1. https://console.cloud.google.com/ → create or pick a project
2. **APIs & Services → Library** → search "Google Calendar API" → **Enable**
3. **APIs & Services → Credentials** → Create Credentials → **OAuth client ID** → Application type: **Web application**
4. Authorized redirect URI: `https://<your-calbridgesync-host>/auth/oauth/google/callback`
5. Copy the Client ID and Client Secret
6. Set env vars in Komodo:
   - `GOOGLE_OAUTH_CLIENT_ID=<client id>`
   - `GOOGLE_OAUTH_CLIENT_SECRET=<client secret>`
   - `GOOGLE_OAUTH_REDIRECT_URL=https://<your-host>/auth/oauth/google/callback` (optional — auto-computed from `BASE_URL`)
7. Redeploy calbridgesync
8. Log into the UI → Add Source → pick **Google** → fill in Name + destination SOGo fields → click **Connect Google Account & Save** → approve at Google

### Not in scope for this PR

- Refresh-token expiry / "needs reauth" UI (future issue)
- Per-calendar discovery via Google Calendar REST API (the CalDAV principal discovery at `/caldav/v2/<email>/user` works fine with Bearer auth)
- Integration tests against real Google (needs live credentials; manual smoke test only)

## Verification

- [x] `go test ./...` green (all 11 packages)
- [x] `go test -race ./...` green
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `npx tsc --noEmit` clean
- [x] `vite build` successful

## Test plan

- [ ] Set `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` in Komodo, redeploy
- [ ] Verify logs show `Google OAuth2 enabled (redirect=...)` on startup
- [ ] Verify existing iCloud (Evan) and ICS (Charles) sources still sync without issues
- [ ] Add a Google source via the UI, go through the consent flow, confirm a new source appears with `source_type=google` and an encrypted `oauth_refresh_token`
- [ ] Manually trigger a sync on the new Google source, confirm events flow from Google → SOGo
- [ ] Wait for an access-token expiry (~1 hour) and confirm the next sync succeeds via the refresh flow
- [ ] Try adding a Google source with `GOOGLE_OAUTH_CLIENT_ID` unset — should show a clear "not configured" error
- [ ] Try revoking the app at https://myaccount.google.com/permissions and confirm the next sync surfaces a useful error

## Context

Discovered 2026-04-10 while William was trying to add his Google Calendar as a source to replace SyncGene (the real culprit behind his iCloud calendar corruption earlier that day). Without OAuth2 support, calbridgesync cannot replace SyncGene's Google↔iCloud sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
