### PR TITLE
fix: raise reverse create hard cap from 100 to 5000 (#77)

### DIFF
--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -222,14 +222,27 @@ const defaultOrphanDeleteRatioThreshold = 0.5
 // defaultReverseCreateHardCap is the maximum number of new destination-only
 // events the two-way reverse create pass will upload to source in a single
 // cycle. Mirror of defaultOrphanDeleteRatioThreshold for the reverse
-// direction — uploading hundreds of events to iCloud in one cycle triggers
-// rate limiting, blocks subsequent syncs, and is almost always the sign of a
-// first-sync scenario that the operator should be explicitly aware of
-// (rather than silently push). When exceeded, planReverseCreate returns a
-// warning and an empty list — the caller must not perform any uploads.
-// 100 is low enough to catch runaway first-syncs but high enough to let
-// normal day-to-day sync (a few new events per cycle) through. (#74)
-const defaultReverseCreateHardCap = 100
+// direction — serves as a blast-radius limit against truly runaway uploads
+// (a misconfigured source, a bug in the ownership filter, corrupted state,
+// etc.). When exceeded, planReverseCreate returns a warning and an empty
+// list — the caller must not perform any uploads in that cycle, and the
+// operator sees the warning in the sync log.
+//
+// The cap is per-calendar — each selected calendar gets its own budget.
+//
+// Initial value was 100 (#74), which turned out to be too aggressive for
+// legitimate first-sync scenarios. William's iCloud source had a calendar
+// with 748 real dest-only events that needed to flow to iCloud, and the
+// 100 cap blocked the entire pass every cycle. Raised to 5000 in #77 —
+// still catches clearly-insane mass upload scenarios (e.g., 50k events
+// from a runaway bug) but lets ordinary first-syncs and bulk imports
+// through in one cycle.
+//
+// If you're hitting this cap with legitimate data, either increase the
+// value here, lower sync_days_past on the source to shrink the window,
+// or break the work across multiple smaller source calendars. A future
+// PR will move this to a per-source setting in the DB. (#77)
+const defaultReverseCreateHardCap = 5000
 
 // extractUIDFromEventPath returns the event UID embedded in a CalDAV object
 // path. By PutEvent convention (client.go:602), events are written as


### PR DESCRIPTION
## Summary

One-const change. Raises `defaultReverseCreateHardCap` from **100** to **5000** in `internal/caldav/sync.go`.

Closes #77.

## Why

PR #74's cap of 100 was based on an estimate of what "normal" per-cycle uploads would look like. William's actual first-sync data shows otherwise:

- iCloud calendar "Family" (`bb65d062-...`): 0 events on source, 878 events on SOGo destination
- After 30-day date filter: 748 legitimate candidates to flow SOGo → iCloud  
- Every cycle: `WARNING: two-way reverse create pass would upload 748 new events to source (cap=100) - skipping pass for safety`
- Zero events ever flowed up, even across many cycles

All 748 are real, user-owned events that William wants on iCloud. The cap exists as a blast-radius limit against runaway uploads (misconfigured source, ownership-filter bug, corrupted state) — it's a **second line of defense**. The **first line of defense** is `planReverseCreate`'s empty-source guard (rule 2: `len(sourceEventMap) == 0 && len(previouslySyncedMap) > 0 → refuse all`), which already catches the "transient source failure" case without needing a tight numeric cap.

5000 is still strict enough to catch clearly-insane scenarios (50k events from an ownership-filter bug, 10k events from a corrupted previouslySyncedMap) but lets legitimate first-syncs and bulk imports through in one cycle.

## Not in this PR

A proper fix would make the cap a **per-source setting in the DB** (tunable per calendar from the edit source UI) with an **instance-level env var default**. That requires:

- Schema migration for a new column
- Source struct + CRUD updates  
- React frontend additions
- Tests

All worth doing, but out of scope for this quick unblock. Tracked separately.

## Tests

No test changes needed. `planReverseCreate`'s hard-cap tests pass the cap value directly as a parameter, independent of the default constant:

- `TestPlanReverseCreate_HardCapExceededRefusesAll` — passes `100` explicitly, still works
- `TestPlanReverseCreate_HardCapOfZeroDisabled` — passes `0` explicitly, still works
- `TestPlanReverseCreate_CapExactlyAtCandidateCountAllowed` — passes `5` explicitly, still works

All 11 packages green with race detector.

## Verification

- [x] `go test ./...` green
- [x] `go test -race ./...` green
- [x] `go vet ./...` clean
- [x] `go build ./...` clean

## Deploy and expected behavior

After deploy, the next sync cycle for William's iCloud source should:
- Actually upload the 748 events to iCloud's "Family" calendar
- Complete in ~12 minutes (rate-limited by iCloud's ~1 PUT/sec) the first time
- Subsequent cycles will be fast (all 748 are then in `previouslySyncedMap`)
- Any future source with more than 5000 new dest-only events still trips the cap and surfaces a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
