### PR TITLE
fix(caldav): stop infinite re-PUT loop from cross-server ETag compare

### DIFF
--- a/internal/caldav/etag_loop_test.go
+++ b/internal/caldav/etag_loop_test.go
@@ -1,0 +1,248 @@
+package caldav
+
+import (
+	"testing"
+
+	"github.com/macjediwizard/calbridgesync/internal/db"
+)
+
+// Issue #79 regression suite for the forward/reverse update ETag
+// comparison helpers.
+//
+// Background: the old code compared sourceEvent.ETag against
+// destEvent.ETag directly at sync.go:1168 and :1313. Those ETags come
+// from different CalDAV servers (iCloud vs SOGo, etc.) and are
+// opaque, server-minted strings — they will never match for the same
+// underlying event. Result: every cycle PUT every event back to the
+// destination, SOGo assigned new dest ETags, next cycle saw the same
+// mismatch, and we got an infinite re-PUT loop running ~748 PUTs per
+// 15-minute cycle on production. These tests lock in the fix.
+
+// -----------------------------------------------------------------------------
+// shouldUpdateDestFromSource — forward path helper
+// -----------------------------------------------------------------------------
+
+// TestShouldUpdateDestFromSource_NilPrevAllowsUpdate: if there is no
+// prior sync record at all, the caller is about to fall into the
+// "create" branch anyway. Defensive default for the update branch is
+// to allow the update. (#79)
+func TestShouldUpdateDestFromSource_NilPrevAllowsUpdate(t *testing.T) {
+	if !shouldUpdateDestFromSource("any-etag", nil) {
+		t.Error("nil prev should default to updating (defensive)")
+	}
+}
+
+// TestShouldUpdateDestFromSource_EmptyStoredETagSkips: legacy records
+// that existed before ETag tracking was wired in will have an empty
+// SourceETag. Do NOT re-PUT the whole calendar on first deploy — skip
+// and let the current cycle's upsert populate the ETag. The next
+// cycle will have a real stored value to compare. (#79)
+func TestShouldUpdateDestFromSource_EmptyStoredETagSkips(t *testing.T) {
+	prev := &db.SyncedEvent{SourceETag: ""}
+	if shouldUpdateDestFromSource("current-etag", prev) {
+		t.Error("empty stored source ETag should skip the PUT (legacy record migration)")
+	}
+}
+
+// TestShouldUpdateDestFromSource_MatchingETagSkips: the happy steady-
+// state case. Source ETag matches the stored one, meaning the source
+// has not changed since last sync. Skip the PUT. This is the path
+// that stops the loop. (#79)
+func TestShouldUpdateDestFromSource_MatchingETagSkips(t *testing.T) {
+	prev := &db.SyncedEvent{SourceETag: "stable-etag"}
+	if shouldUpdateDestFromSource("stable-etag", prev) {
+		t.Error("matching source ETag should skip the PUT")
+	}
+}
+
+// TestShouldUpdateDestFromSource_DiffersTriggersUpdate: the real
+// update case. Source ETag has changed since last sync — PUT to
+// propagate the change to dest. (#79)
+func TestShouldUpdateDestFromSource_DiffersTriggersUpdate(t *testing.T) {
+	prev := &db.SyncedEvent{SourceETag: "old-etag"}
+	if !shouldUpdateDestFromSource("new-etag", prev) {
+		t.Error("changed source ETag must trigger the PUT")
+	}
+}
+
+// TestShouldUpdateDestFromSource_DoesNotCompareAgainstDestETag: the
+// canary. This is the exact bug from #79 — the old code compared
+// sourceEvent.ETag against destEvent.ETag. A helper that accepts a
+// destETag parameter could only be used correctly against the stored
+// SOURCE etag. The test locks in that the helper only reads
+// prev.SourceETag. (#79)
+func TestShouldUpdateDestFromSource_DoesNotCompareAgainstDestETag(t *testing.T) {
+	// Stored source ETag matches current source ETag — should skip
+	// regardless of what prev.DestETag happens to be.
+	prev := &db.SyncedEvent{
+		SourceETag: "source-v1",
+		DestETag:   "dest-v99-totally-different-value",
+	}
+	if shouldUpdateDestFromSource("source-v1", prev) {
+		t.Error("helper must compare only against SourceETag, not DestETag — #79 regression")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// shouldUpdateSourceFromDest — reverse dest_wins path helper
+// -----------------------------------------------------------------------------
+
+// TestShouldUpdateSourceFromDest_NilPrevSkips: unlike the forward
+// path, the reverse dest_wins path should NOT treat "no prior record"
+// as "go ahead and update." A dest event with no synced_events row
+// has not been recorded on our side yet, so we cannot know what the
+// last-propagated dest ETag was. Skip and wait for the first full
+// cycle to store one. (#79)
+func TestShouldUpdateSourceFromDest_NilPrevSkips(t *testing.T) {
+	if shouldUpdateSourceFromDest("any-etag", nil) {
+		t.Error("nil prev should NOT trigger a reverse update")
+	}
+}
+
+// TestShouldUpdateSourceFromDest_EmptyStoredETagSkips: same legacy-
+// record migration rule as the forward path. Don't mass-PUT back to
+// source on first deploy; just start tracking. (#79)
+func TestShouldUpdateSourceFromDest_EmptyStoredETagSkips(t *testing.T) {
+	prev := &db.SyncedEvent{DestETag: ""}
+	if shouldUpdateSourceFromDest("current-etag", prev) {
+		t.Error("empty stored dest ETag should skip the reverse PUT")
+	}
+}
+
+// TestShouldUpdateSourceFromDest_MatchingETagSkips: steady-state
+// reverse path. Dest ETag matches the stored one — nothing changed
+// on dest since last sync. (#79)
+func TestShouldUpdateSourceFromDest_MatchingETagSkips(t *testing.T) {
+	prev := &db.SyncedEvent{DestETag: "stable-etag"}
+	if shouldUpdateSourceFromDest("stable-etag", prev) {
+		t.Error("matching dest ETag should skip the reverse PUT")
+	}
+}
+
+// TestShouldUpdateSourceFromDest_DiffersTriggersUpdate: legitimate
+// dest_wins propagation. User edited the event on dest; push it back
+// to source. (#79)
+func TestShouldUpdateSourceFromDest_DiffersTriggersUpdate(t *testing.T) {
+	prev := &db.SyncedEvent{DestETag: "old-etag"}
+	if !shouldUpdateSourceFromDest("new-etag", prev) {
+		t.Error("changed dest ETag must trigger the reverse PUT")
+	}
+}
+
+// TestShouldUpdateSourceFromDest_DoesNotCompareAgainstSourceETag: the
+// symmetric canary for #79. The helper must only read prev.DestETag.
+func TestShouldUpdateSourceFromDest_DoesNotCompareAgainstSourceETag(t *testing.T) {
+	prev := &db.SyncedEvent{
+		SourceETag: "source-v99-totally-different-value",
+		DestETag:   "dest-v1",
+	}
+	if shouldUpdateSourceFromDest("dest-v1", prev) {
+		t.Error("helper must compare only against DestETag, not SourceETag — #79 regression")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Symmetry + contract canaries
+// -----------------------------------------------------------------------------
+
+// TestEtagHelpers_SymmetricLegacyBehavior verifies both helpers apply
+// the same "legacy record migration" rule: if the side we track has
+// an empty stored ETag, skip. The two helpers diverge only on the
+// nil-prev case (forward defaults to true, reverse defaults to
+// false) — this test documents that asymmetry so future refactors
+// don't accidentally unify them. (#79)
+func TestEtagHelpers_SymmetricLegacyBehavior(t *testing.T) {
+	// Both side's empty-etag case: skip.
+	forwardLegacy := &db.SyncedEvent{SourceETag: ""}
+	reverseLegacy := &db.SyncedEvent{DestETag: ""}
+	if shouldUpdateDestFromSource("x", forwardLegacy) {
+		t.Error("forward legacy case should skip")
+	}
+	if shouldUpdateSourceFromDest("x", reverseLegacy) {
+		t.Error("reverse legacy case should skip")
+	}
+
+	// Intentional asymmetry: nil prev.
+	if !shouldUpdateDestFromSource("x", nil) {
+		t.Error("forward nil-prev defaults to true (defensive; caller is supposed to use create branch)")
+	}
+	if shouldUpdateSourceFromDest("x", nil) {
+		t.Error("reverse nil-prev defaults to false (no history → do not guess)")
+	}
+}
+
+// TestEtagHelpers_BothSidesUnchangedTable covers the combinatorial
+// space with a single table. Each entry is a named scenario with
+// the inputs and the expected output for each helper. (#79)
+func TestEtagHelpers_BothSidesUnchangedTable(t *testing.T) {
+	cases := []struct {
+		name             string
+		currentETag      string
+		prev             *db.SyncedEvent
+		expectForwardPUT bool
+		expectReversePUT bool
+	}{
+		{
+			name:             "nil prev",
+			currentETag:      "any",
+			prev:             nil,
+			expectForwardPUT: true,  // defensive default
+			expectReversePUT: false, // no history
+		},
+		{
+			name:             "empty stored etag (legacy record)",
+			currentETag:      "any",
+			prev:             &db.SyncedEvent{},
+			expectForwardPUT: false,
+			expectReversePUT: false,
+		},
+		{
+			name:             "matching source etag, empty dest etag",
+			currentETag:      "source-1",
+			prev:             &db.SyncedEvent{SourceETag: "source-1"},
+			expectForwardPUT: false,
+			expectReversePUT: false, // dest side is empty, reverse skips
+		},
+		{
+			name:             "differing source etag",
+			currentETag:      "source-2",
+			prev:             &db.SyncedEvent{SourceETag: "source-1"},
+			expectForwardPUT: true,
+			expectReversePUT: false, // dest side has no data
+		},
+		{
+			name:             "matching dest etag, empty source etag",
+			currentETag:      "dest-1",
+			prev:             &db.SyncedEvent{DestETag: "dest-1"},
+			expectForwardPUT: false, // source side is empty, forward skips
+			expectReversePUT: false,
+		},
+		{
+			name:             "differing dest etag",
+			currentETag:      "dest-2",
+			prev:             &db.SyncedEvent{DestETag: "dest-1"},
+			expectForwardPUT: false,
+			expectReversePUT: true,
+		},
+		{
+			name:             "both sides populated, both match (steady state)",
+			currentETag:      "x",
+			prev:             &db.SyncedEvent{SourceETag: "x", DestETag: "x"},
+			expectForwardPUT: false,
+			expectReversePUT: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotForward := shouldUpdateDestFromSource(tc.currentETag, tc.prev)
+			gotReverse := shouldUpdateSourceFromDest(tc.currentETag, tc.prev)
+			if gotForward != tc.expectForwardPUT {
+				t.Errorf("shouldUpdateDestFromSource: got %v, want %v", gotForward, tc.expectForwardPUT)
+			}
+			if gotReverse != tc.expectReversePUT {
+				t.Errorf("shouldUpdateSourceFromDest: got %v, want %v", gotReverse, tc.expectReversePUT)
+			}
+		})
+	}
+}

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -104,6 +104,64 @@ func shouldSkipTwoWayCreate(direction db.SyncDirection, sourceEventCount, previo
 		previouslySyncedCount > 0
 }
 
+// syncETagEntry tracks the last-observed source and destination ETags
+// for a single event UID during a sync pass. Collected as the sync
+// iterates through events, then written to the synced_events table in
+// the final upsert loop so the NEXT cycle can detect whether either
+// side has actually changed since this sync.
+//
+// The ETags are opaque, server-generated strings — a CalDAV ETag from
+// iCloud and a CalDAV ETag from SOGo for the SAME underlying event
+// will never match each other. They are only meaningful when compared
+// against a previously-stored value from the SAME server. That is why
+// we store both sides independently. (#79)
+type syncETagEntry struct {
+	sourceETag string
+	destETag   string
+}
+
+// shouldUpdateDestFromSource decides whether to PUT a source event onto
+// the destination during the forward update branch of the sync loop.
+//
+// Correctness depends on comparing against the LAST-KNOWN source ETag
+// from previouslySyncedMap, not against the destination's current ETag
+// — cross-server ETag comparison is meaningless (every server mints
+// its own opaque string), which is the bug that produced the infinite
+// re-PUT loop in #79.
+//
+// Three cases:
+//
+//   - prev == nil: the caller already handled "no prior record" via
+//     the create branch. Defensive default — allow the update.
+//   - prev.SourceETag == "": legacy record from before ETag tracking
+//     was wired in. Don't re-PUT the whole calendar on first deploy;
+//     skip and let this cycle's upsert start tracking ETags from the
+//     current source state. If the source genuinely changed in the
+//     meantime, we accept a one-cycle propagation delay in exchange
+//     for not thundering-herd the destination on rollout.
+//   - prev.SourceETag != "": a real ETag we can compare. PUT iff the
+//     current source ETag differs from the stored one.
+func shouldUpdateDestFromSource(sourceETag string, prev *db.SyncedEvent) bool {
+	if prev == nil {
+		return true
+	}
+	if prev.SourceETag == "" {
+		return false
+	}
+	return prev.SourceETag != sourceETag
+}
+
+// shouldUpdateSourceFromDest is the symmetric helper for the reverse
+// dest_wins update pass. See shouldUpdateDestFromSource for the full
+// rationale — the only difference is we compare destETag against the
+// last-known DEST ETag from prev. (#79)
+func shouldUpdateSourceFromDest(destETag string, prev *db.SyncedEvent) bool {
+	if prev == nil || prev.DestETag == "" {
+		return false
+	}
+	return prev.DestETag != destETag
+}
+
 // planReverseCreate determines which destination events should be uploaded
 // to source as new creates during a two-way sync. It is the mirror of
 // planOrphanDeletion for the reverse direction.
@@ -760,11 +818,17 @@ func (se *SyncEngine) syncCalendar(ctx context.Context, source *db.Source, sourc
 						// successfully parses the calendar data; if the
 						// event had no UID it cannot reach this branch
 						// (PutEvent returns nil early without writing).
+						//
+						// Populate SourceETag from the source item we
+						// just read (stored in item.ETag) so the next
+						// cycle of the main sync path can skip the PUT
+						// when the source has not changed. (#79)
 						if event.UID != "" {
 							syncedEvent := &db.SyncedEvent{
 								SourceID:     source.ID,
 								CalendarHref: calendar.Path,
 								EventUID:     event.UID,
+								SourceETag:   item.ETag,
 							}
 							if err := se.db.UpsertSyncedEvent(syncedEvent); err != nil {
 								log.Printf("Failed to upsert synced event record for %s: %v", event.UID, err)
@@ -1034,8 +1098,12 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 
 	skippedDupes := 0
 
-	// Track UIDs that exist in current sync (for updating synced_events table)
-	currentUIDs := make(map[string]bool)
+	// Track UIDs that exist in current sync (for updating synced_events
+	// table). Values hold the observed source and destination ETags so
+	// the next cycle can detect whether either side has changed without
+	// doing the cross-server ETag comparison that caused the re-PUT
+	// loop in #79.
+	currentUIDs := make(map[string]syncETagEntry)
 
 	// Update status to show processing phase
 	updateStatus(fmt.Sprintf("processing %d events", len(sourceEvents)))
@@ -1161,12 +1229,22 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 				if dedupeKey != "|" {
 					destDedupeMap[dedupeKey] = true
 				}
-				currentUIDs[sourceEvent.UID] = true
+				// Record the source ETag so the next cycle can skip
+				// the PUT if the source has not changed. No dest ETag
+				// yet — PutEvent does not return one on create; the
+				// next cycle will read it from PROPFIND and populate
+				// the dest side at that point. (#79)
+				currentUIDs[sourceEvent.UID] = syncETagEntry{sourceETag: sourceEvent.ETag}
 			}
 			result.EventsProcessed++
 			updateProgress()
-		} else if sourceEvent.ETag != destEvent.ETag {
-			// Update existing event
+		} else if shouldUpdateDestFromSource(sourceEvent.ETag, previouslySyncedMap[sourceEvent.UID]) {
+			// Source ETag has changed since the last recorded sync
+			// (or this is a first-time update with tracked ETags).
+			// Only then do we actually PUT. Comparing sourceEvent.ETag
+			// against destEvent.ETag directly is WRONG — they come
+			// from different servers and will never match, which was
+			// the cause of the infinite re-PUT loop fixed in #79.
 			sourceEvent.Path = destEvent.Path
 			if err := destClient.PutEvent(ctx, destCalendarPath, &sourceEvent); err != nil {
 				if errors.Is(err, ErrEventSkipped) {
@@ -1180,13 +1258,32 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 				}
 			} else {
 				result.Updated++
-				currentUIDs[sourceEvent.UID] = true
+				// Record both ETags: source from the server we just
+				// read, dest from the server we just wrote. Note the
+				// dest ETag here is the OLD one — we don't have the
+				// new one from PutEvent's response. The next read
+				// cycle will refresh it. That is fine: the forward
+				// path compares against the SOURCE ETag, and the
+				// reverse dest_wins path that reads DestETag will
+				// either see this stale value (correctly triggering
+				// an update back to source on the first cycle where
+				// it runs) or the refreshed value. (#79)
+				currentUIDs[sourceEvent.UID] = syncETagEntry{
+					sourceETag: sourceEvent.ETag,
+					destETag:   destEvent.ETag,
+				}
 			}
 			result.EventsProcessed++
 			updateProgress()
 		} else {
-			// Event unchanged, still track it
-			currentUIDs[sourceEvent.UID] = true
+			// Event unchanged (source ETag matches stored prior ETag),
+			// still track it so the synced_events upsert at end of
+			// pass keeps it alive. Record both ETags from this cycle
+			// so the next cycle has fresh reference points. (#79)
+			currentUIDs[sourceEvent.UID] = syncETagEntry{
+				sourceETag: sourceEvent.ETag,
+				destETag:   destEvent.ETag,
+			}
 			result.EventsProcessed++
 			updateProgress()
 		}
@@ -1242,8 +1339,14 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 		// in planReverseCreate skips this dest event instead of
 		// proposing another upload. This stops the infinite-retry
 		// loop for content duplicates. (#78)
+		//
+		// Only destETag is meaningful here: the source side is a
+		// different UID, so we cannot store a source ETag against
+		// this UID. (#79)
 		for i := range contentDupes {
-			currentUIDs[contentDupes[i].UID] = true
+			currentUIDs[contentDupes[i].UID] = syncETagEntry{
+				destETag: contentDupes[i].ETag,
+			}
 		}
 		if len(contentDupes) > 0 {
 			log.Printf("Two-way sync: %d destination events already exist on source by content (Summary+StartTime) under different UIDs - recorded as synced to prevent retry", len(contentDupes))
@@ -1273,8 +1376,15 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 					// pass stops us from retrying the upload on every
 					// subsequent cycle (which would otherwise produce
 					// the same 409/412 warning indefinitely). (#74)
+					//
+					// Only destETag is known here (the dest event we
+					// read before attempting the upload). The source
+					// side exists but we do not know its current ETag
+					// on the source server. (#79)
 					skippedAlreadyExists++
-					currentUIDs[destEvent.UID] = true
+					currentUIDs[destEvent.UID] = syncETagEntry{
+						destETag: destEvent.ETag,
+					}
 				case isForbiddenError(err):
 					// Source calendar is read-only (iCloud subscribed
 					// calendars, shared read-only, etc). Count as a
@@ -1289,17 +1399,28 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 				// upsert at the end of this calendar's pass records
 				// it. Without this, the next cycle would see the
 				// same event as "not in previouslySyncedMap" and
-				// try to re-upload it.
-				currentUIDs[destEvent.UID] = true
+				// try to re-upload it. Record the dest ETag we read
+				// from before the upload; the source ETag we just
+				// wrote is not returned by PutEvent and will be
+				// populated from a read on the next cycle. (#79)
+				currentUIDs[destEvent.UID] = syncETagEntry{
+					destETag: destEvent.ETag,
+				}
 			}
 			updateProgress()
 		}
 
-		// Case 3: dest_wins update pass. Unchanged from pre-#72 behavior.
-		// Walks destEvents (not just candidates) because the update
-		// branch fires on UID match with ETag mismatch — that's a
-		// different filter than "dest-only" and can't reuse the
-		// candidate list.
+		// Case 3: dest_wins update pass. Walks destEvents (not just
+		// candidates) because the update branch fires on "dest ETag
+		// changed since last sync" — that's a different filter than
+		// "dest-only" and can't reuse the candidate list.
+		//
+		// The old code compared destEvent.ETag against sourceEvent.ETag
+		// directly, which was the same cross-server ETag bug fixed in
+		// the forward path by #79. We now compare destEvent.ETag
+		// against the last-known dest ETag in previouslySyncedMap via
+		// shouldUpdateSourceFromDest — the symmetric twin of the
+		// forward helper.
 		if source.ConflictStrategy == db.ConflictDestWins {
 			for _, destEvent := range destEvents {
 				if destEvent.UID == "" {
@@ -1310,7 +1431,7 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 					// Case 1 already handled this.
 					continue
 				}
-				if destEvent.ETag == sourceEvent.ETag {
+				if !shouldUpdateSourceFromDest(destEvent.ETag, previouslySyncedMap[destEvent.UID]) {
 					continue
 				}
 				destEvent.Path = sourceEvent.Path
@@ -1327,6 +1448,14 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 					}
 				} else {
 					result.Updated++
+					// Record the dest ETag we just propagated back
+					// to source so the next cycle can detect another
+					// dest-side change. We don't know the new source
+					// ETag PutEvent just created — next read cycle
+					// will populate it. (#79)
+					currentUIDs[destEvent.UID] = syncETagEntry{
+						destETag: destEvent.ETag,
+					}
 				}
 				updateProgress()
 			}
@@ -1376,12 +1505,17 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 		log.Printf("Removed %d duplicate events from destination", result.DuplicatesRemoved)
 	}
 
-	// Update synced_events table with current state
-	for uid := range currentUIDs {
+	// Update synced_events table with current state. Each entry's
+	// sourceETag and destETag are what the next cycle will compare
+	// against to decide whether either side has changed — that is
+	// the fix for the infinite re-PUT loop in #79.
+	for uid, etags := range currentUIDs {
 		syncedEvent := &db.SyncedEvent{
 			SourceID:     source.ID,
 			CalendarHref: calendar.Path,
 			EventUID:     uid,
+			SourceETag:   etags.sourceETag,
+			DestETag:     etags.destETag,
 		}
 		if err := se.db.UpsertSyncedEvent(syncedEvent); err != nil {
 			log.Printf("Failed to upsert synced event: %v", err)


### PR DESCRIPTION
## Summary
- The forward update branch was comparing `sourceEvent.ETag` against `destEvent.ETag` — two opaque, server-minted strings from two different CalDAV servers that never match. Every cycle re-PUT every event (748/cycle for William, 115 for Evan, 62 for Charles).
- Same bug on the reverse dest_wins update path.
- Fix: compare against the last-known ETag from `synced_events` via two new pure helpers (`shouldUpdateDestFromSource`, `shouldUpdateSourceFromDest`). The `source_etag` / `dest_etag` columns already existed; the sync code just never populated them.
- Empty stored ETag is treated as "legacy record, skip PUT and start tracking" so first deploy does not trigger a one-time PUT stampede.
- `currentUIDs` changed from `map[string]bool` to `map[string]syncETagEntry` so every write site records the ETags it observed; the final `UpsertSyncedEvent` loop passes them through.

## Why
Production logs confirmed the loop across all three users on every cycle. At 15 minute cadence that is ~72k pointless PUTs to SOGo per day for William's calendar alone, plus similar for the others. The cross-server ETag comparison was silently broken in a way that only appeared as "sync is noisy" rather than "sync is incorrect."

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages green)
- [x] `go test -race ./internal/caldav/...`
- [x] 12 new unit tests in `etag_loop_test.go` covering nil prev, legacy empty-etag records, matching/differing ETags, a regression canary that the helpers only read their own side's stored ETag, and a table test of the full combinatorial space.
- [ ] Post-deploy: first cycle should show ~0 updates for calendars with legacy records (ETags populated for next cycle). Steady-state `updated` count should drop from ~(dest total) to ~0.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)