### PR TITLE
HOTFIX: empty-source + ratio guards on two-way deletion (data-loss fix)

### DIFF
--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -162,6 +162,86 @@ func shouldUpdateSourceFromDest(destETag string, prev *db.SyncedEvent) bool {
 	return prev.DestETag != destETag
 }
 
+// planTwoWayDeletion determines which destination events should be
+// deleted because they were removed from source during a two-way sync.
+// It is the dest-deletion mirror of planOrphanDeletion (one-way) and
+// the symmetric counterpart of planReverseCreate.
+//
+// Three safety rules are enforced:
+//
+//  1. Empty-dest guard: if destination returned 0 events but we have
+//     prior sync records, refuse. Same rationale as the original
+//     shouldSkipTwoWayDeletion check — an empty destination query is
+//     almost certainly a destination failure, not a user action.
+//
+//  2. Empty-source guard: if source returned 0 events but we have
+//     prior sync records, refuse. NEW in #80. Without this guard, a
+//     transient source query failure for one calendar would mass-
+//     delete the entire destination calendar — exactly the
+//     catastrophe that prompted this PR (William lost 748 events
+//     from SOGo when iCloud returned a partial set).
+//
+//  3. Mass-deletion ratio guard: if more than maxDeleteRatio of the
+//     prior records would be deleted in a single cycle, refuse and
+//     surface a warning. Mirrors planOrphanDeletion's ratio check
+//     for the two-way path. Defends against the case where source
+//     returned SOME events but is missing the bulk of them — neither
+//     of the empty-side guards catches this case, and the existing
+//     per-event time-based safety threshold only protects events
+//     that were synced very recently. Critical for the partial-
+//     source-failure scenario.
+//
+// Returns the list of dest UIDs to delete and a non-empty warning if
+// any safety rule was triggered. When a warning is returned, toDelete
+// is nil — the caller must not perform any deletions in that case.
+// (#80)
+func planTwoWayDeletion(
+	sourceEventMap map[string]Event,
+	destEventMap map[string]Event,
+	previouslySyncedMap map[string]*db.SyncedEvent,
+	maxDeleteRatio float64,
+) (toDelete []string, warning string) {
+	// Rule 1: empty destination with prior records → refuse.
+	if len(destEventMap) == 0 && len(previouslySyncedMap) > 0 {
+		return nil, fmt.Sprintf(
+			"destination returned 0 events but %d previously-synced records exist - "+
+				"skipping two-way deletion pass for safety (possible destination query failure)",
+			len(previouslySyncedMap),
+		)
+	}
+	// Rule 2: empty source with prior records → refuse. (#80)
+	if len(sourceEventMap) == 0 && len(previouslySyncedMap) > 0 {
+		return nil, fmt.Sprintf(
+			"source returned 0 events but %d previously-synced records exist - "+
+				"skipping two-way deletion pass for safety (possible source query failure)",
+			len(previouslySyncedMap),
+		)
+	}
+	// Build candidate list: previously-synced UIDs that no longer
+	// exist on source but still exist on destination.
+	candidates := make([]string, 0)
+	for uid := range previouslySyncedMap {
+		_, existsOnSource := sourceEventMap[uid]
+		_, existsOnDest := destEventMap[uid]
+		if !existsOnSource && existsOnDest {
+			candidates = append(candidates, uid)
+		}
+	}
+	// Rule 3: mass-deletion ratio guard. Only applied when there is
+	// prior state to measure against and a threshold is configured.
+	if maxDeleteRatio > 0 && len(previouslySyncedMap) > 0 {
+		ratio := float64(len(candidates)) / float64(len(previouslySyncedMap))
+		if ratio > maxDeleteRatio {
+			return nil, fmt.Sprintf(
+				"two-way deletion pass would delete %d of %d previously-synced events (%.0f%%), "+
+					"exceeds safety threshold %.0f%% - skipping for safety (possible partial source query failure)",
+				len(candidates), len(previouslySyncedMap), ratio*100, maxDeleteRatio*100,
+			)
+		}
+	}
+	return candidates, ""
+}
+
 // planReverseCreate determines which destination events should be uploaded
 // to source as new creates during a two-way sync. It is the mirror of
 // planOrphanDeletion for the reverse direction.
@@ -1115,78 +1195,118 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 	sourceInterval := time.Duration(source.SyncInterval) * time.Second
 	now := time.Now()
 
-	// SAFETY: Skip two-way deletion entirely if destination query
-	// returned empty but we have synced events. Prevents mass
-	// deletion from source when the destination query fails.
-	skipTwoWayDeletion := shouldSkipTwoWayDeletion(syncDirection, len(destEventMap), len(previouslySyncedMap))
-	if skipTwoWayDeletion {
-		log.Printf("WARNING: Destination returned 0 events but we have %d previously synced events - skipping two-way deletions for safety", len(previouslySyncedMap))
-	}
-
-	if syncDirection == db.SyncDirectionTwoWay && !skipTwoWayDeletion && sourceClient != nil {
-		for uid, syncedEvent := range previouslySyncedMap {
-			_, existsOnSource := sourceEventMap[uid]
-			destEvent, existsOnDest := destEventMap[uid]
-
-			if !existsOnSource && existsOnDest {
-				// Event was deleted from source - delete from destination too
-				log.Printf("Event %s deleted from source, deleting from destination", uid)
-				if err := destClient.DeleteEvent(ctx, destEvent.Path); err != nil {
-					result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to delete event from dest: %v", err))
-				} else {
-					result.Deleted++
-					updateProgress()
-				}
-				// Remove from synced_events
-				if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, uid); err != nil {
-					log.Printf("Failed to delete synced event record: %v", err)
-				}
-				delete(destEventMap, uid)
-				continue
+	// Two-way deletion pass. Two independent steps with their own
+	// safety guards:
+	//
+	//   - Dest-deletion: events that were removed from source must be
+	//     removed from destination. Delegated to planTwoWayDeletion,
+	//     which enforces three guards (empty-dest, empty-source, and
+	//     mass-delete ratio). The empty-source and ratio guards are
+	//     new in #80 — without them, a partial source query failure
+	//     for one calendar mass-deletes the matching destination
+	//     events. (William lost 748 events to this exact bug.)
+	//
+	//   - Source-deletion: events that were removed from destination
+	//     must be removed from source. Still inline because each
+	//     candidate has its own per-event safety threshold
+	//     (isWithinSyncSafetyThreshold) protecting recently-synced
+	//     events; ratio-based protection for this direction is
+	//     deferred to a follow-up. The shouldSkipTwoWayDeletion
+	//     guard is still consulted to short-circuit when the dest
+	//     query failed entirely.
+	if syncDirection == db.SyncDirectionTwoWay && sourceClient != nil {
+		// Step 1: dest-deletion via planTwoWayDeletion. The helper's
+		// three guards subsume the previous shouldSkipTwoWayDeletion
+		// check for this direction and add empty-source + ratio
+		// protection on top. (#80)
+		toDeleteFromDest, deletionWarning := planTwoWayDeletion(
+			sourceEventMap,
+			destEventMap,
+			previouslySyncedMap,
+			defaultOrphanDeleteRatioThreshold,
+		)
+		if deletionWarning != "" {
+			log.Printf("WARNING: %s", deletionWarning)
+			result.Warnings = append(result.Warnings, deletionWarning)
+		}
+		// Track which UIDs the dest-deletion pass already handled so
+		// the source-deletion pass below skips them.
+		handledByDestDelete := make(map[string]bool, len(toDeleteFromDest))
+		for _, uid := range toDeleteFromDest {
+			destEvent := destEventMap[uid]
+			log.Printf("Event %s deleted from source, deleting from destination", uid)
+			if err := destClient.DeleteEvent(ctx, destEvent.Path); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to delete event from dest: %v", err))
+			} else {
+				result.Deleted++
+				updateProgress()
 			}
+			// Remove from synced_events
+			if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, uid); err != nil {
+				log.Printf("Failed to delete synced event record: %v", err)
+			}
+			delete(destEventMap, uid)
+			handledByDestDelete[uid] = true
+		}
 
-			sourceEvent, existsOnSource := sourceEventMap[uid]
-			if existsOnSource && !existsOnDest {
-				// SAFETY CHECK: Only delete from source if the event was
-				// FIRST synced before the safety threshold (commit 23e88c1,
-				// Issue #72). Prevents deleting events that just appeared
-				// and haven't had time to fully propagate.
-				//
-				// We deliberately read CreatedAt (sticky, set once at first
-				// sync) rather than UpdatedAt (bumped every cycle via
-				// UpsertSyncedEvent). Reading UpdatedAt was a bug: for
-				// any normally-running sync, UpdatedAt is always within
-				// one sync interval of "now" because the upsert at the
-				// end of every cycle resets it, which made this safety
-				// guard fire unconditionally and silently block every
-				// two-way source-side deletion. CreatedAt preserves the
-				// original intent ("protect brand-new events") without
-				// the "protect everything forever" accident.
-				if isWithinSyncSafetyThreshold(syncedEvent.CreatedAt, sourceInterval, now) {
-					log.Printf("Event %s not on destination but newly synced (CreatedAt=%v) - skipping deletion from source (safety)", uid, syncedEvent.CreatedAt)
+		// Step 2: source-deletion + cleanup. Skip entirely if the
+		// dest query returned empty (would risk mass-deleting from
+		// source); the per-event safety threshold provides the
+		// remaining protection within an individual cycle.
+		skipSourceDeletion := shouldSkipTwoWayDeletion(syncDirection, len(destEventMap), len(previouslySyncedMap))
+		if skipSourceDeletion {
+			log.Printf("WARNING: Destination returned 0 events but we have %d previously synced events - skipping source-side deletions for safety", len(previouslySyncedMap))
+		}
+		if !skipSourceDeletion {
+			for uid, syncedEvent := range previouslySyncedMap {
+				if handledByDestDelete[uid] {
+					continue
+				}
+				sourceEvent, existsOnSource := sourceEventMap[uid]
+				_, existsOnDest := destEventMap[uid]
+
+				if existsOnSource && !existsOnDest {
+					// SAFETY CHECK: Only delete from source if the event was
+					// FIRST synced before the safety threshold (commit 23e88c1,
+					// Issue #72). Prevents deleting events that just appeared
+					// and haven't had time to fully propagate.
+					//
+					// We deliberately read CreatedAt (sticky, set once at first
+					// sync) rather than UpdatedAt (bumped every cycle via
+					// UpsertSyncedEvent). Reading UpdatedAt was a bug: for
+					// any normally-running sync, UpdatedAt is always within
+					// one sync interval of "now" because the upsert at the
+					// end of every cycle resets it, which made this safety
+					// guard fire unconditionally and silently block every
+					// two-way source-side deletion. CreatedAt preserves the
+					// original intent ("protect brand-new events") without
+					// the "protect everything forever" accident.
+					if isWithinSyncSafetyThreshold(syncedEvent.CreatedAt, sourceInterval, now) {
+						log.Printf("Event %s not on destination but newly synced (CreatedAt=%v) - skipping deletion from source (safety)", uid, syncedEvent.CreatedAt)
+						continue
+					}
+
+					// Event was deleted from destination - delete from source too
+					log.Printf("Event %s deleted from destination, deleting from source", uid)
+					if err := sourceClient.DeleteEvent(ctx, sourceEvent.Path); err != nil {
+						result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to delete event from source: %v", err))
+					} else {
+						result.Deleted++
+						updateProgress()
+					}
+					// Remove from synced_events
+					if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, uid); err != nil {
+						log.Printf("Failed to delete synced event record: %v", err)
+					}
+					delete(sourceEventMap, uid)
 					continue
 				}
 
-				// Event was deleted from destination - delete from source too
-				log.Printf("Event %s deleted from destination, deleting from source", uid)
-				if err := sourceClient.DeleteEvent(ctx, sourceEvent.Path); err != nil {
-					result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to delete event from source: %v", err))
-				} else {
-					result.Deleted++
-					updateProgress()
-				}
-				// Remove from synced_events
-				if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, uid); err != nil {
-					log.Printf("Failed to delete synced event record: %v", err)
-				}
-				delete(sourceEventMap, uid)
-				continue
-			}
-
-			if !existsOnSource && !existsOnDest {
-				// Event deleted from both - just clean up the record
-				if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, syncedEvent.EventUID); err != nil {
-					log.Printf("Failed to delete synced event record: %v", err)
+				if !existsOnSource && !existsOnDest {
+					// Event deleted from both - just clean up the record
+					if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, syncedEvent.EventUID); err != nil {
+						log.Printf("Failed to delete synced event record: %v", err)
+					}
 				}
 			}
 		}

--- a/internal/caldav/two_way_deletion_test.go
+++ b/internal/caldav/two_way_deletion_test.go
@@ -1,0 +1,335 @@
+package caldav
+
+import (
+	"testing"
+
+	"github.com/macjediwizard/calbridgesync/internal/db"
+)
+
+// Issue #80 regression suite for planTwoWayDeletion.
+//
+// Background: William lost 748 events from his SOGo destination
+// calendar in a single sync cycle. Root cause: the inline two-way
+// deletion loop only consulted shouldSkipTwoWayDeletion, which checks
+// destEventCount==0 but NOT sourceEventCount. When iCloud returned a
+// partial response for one of his calendars (a few events instead of
+// the expected ~748), every previously-synced UID not in the partial
+// response was treated as "deleted from source" and propagated to
+// the destination.
+//
+// planTwoWayDeletion now enforces three independent guards:
+//
+//   1. Empty-dest guard (was: shouldSkipTwoWayDeletion)
+//   2. Empty-source guard (NEW — the direct fix for William's case)
+//   3. Mass-deletion ratio guard (NEW — protects against partial
+//      source responses that don't trigger the empty-side guards)
+//
+// These tests lock in each guard plus the happy paths that must NOT
+// trigger them.
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+func newPriorMap(uids ...string) map[string]*db.SyncedEvent {
+	m := make(map[string]*db.SyncedEvent, len(uids))
+	for _, uid := range uids {
+		m[uid] = &db.SyncedEvent{EventUID: uid}
+	}
+	return m
+}
+
+func newEventMap(uids ...string) map[string]Event {
+	m := make(map[string]Event, len(uids))
+	for _, uid := range uids {
+		m[uid] = Event{UID: uid, Path: "/cal/" + uid + ".ics"}
+	}
+	return m
+}
+
+// -----------------------------------------------------------------------------
+// Rule 1: empty-dest guard (existing behavior, preserved)
+// -----------------------------------------------------------------------------
+
+// TestPlanTwoWayDeletion_EmptyDestWithPriorRefuses verifies the
+// empty-destination guard. If destination returned 0 events but we
+// have prior records, refuse to delete anything — this is the
+// original shouldSkipTwoWayDeletion check, now subsumed into
+// planTwoWayDeletion. (#80)
+func TestPlanTwoWayDeletion_EmptyDestWithPriorRefuses(t *testing.T) {
+	source := newEventMap("a", "b", "c")
+	dest := newEventMap()
+	prior := newPriorMap("a", "b", "c")
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning == "" {
+		t.Fatal("expected empty-dest guard to fire")
+	}
+	if toDelete != nil {
+		t.Errorf("expected nil delete list when guard fires, got %d", len(toDelete))
+	}
+}
+
+// TestPlanTwoWayDeletion_EmptyDestNoPriorAllowsEmpty verifies the
+// legitimate first-sync scenario for the dest side. Empty dest with
+// zero prior records is not a safety violation — there's nothing to
+// protect. The function should return cleanly with an empty list. (#80)
+func TestPlanTwoWayDeletion_EmptyDestNoPriorAllowsEmpty(t *testing.T) {
+	source := newEventMap("a", "b")
+	dest := newEventMap()
+	prior := newPriorMap()
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("first-sync (no prior records) should not trigger guard: %q", warning)
+	}
+	if len(toDelete) != 0 {
+		t.Errorf("expected empty delete list, got %d", len(toDelete))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Rule 2: empty-source guard (NEW — the William fix)
+// -----------------------------------------------------------------------------
+
+// TestPlanTwoWayDeletion_EmptySourceWithPriorRefuses is the direct
+// regression test for the bug that lost William's 748 events. When
+// the source query returns 0 events but we have prior sync records,
+// the deletion pass MUST refuse — even if the destination has events.
+// Without this guard, every prior UID would be classified as
+// "deleted from source" and propagated to the destination. (#80)
+func TestPlanTwoWayDeletion_EmptySourceWithPriorRefuses(t *testing.T) {
+	source := newEventMap() // empty — simulates iCloud query failure
+	dest := newEventMap("a", "b", "c", "d", "e")
+	prior := newPriorMap("a", "b", "c", "d", "e")
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning == "" {
+		t.Fatal("expected empty-source guard to fire — this is the William #80 regression")
+	}
+	if toDelete != nil {
+		t.Errorf("expected nil delete list when guard fires, got %d", len(toDelete))
+	}
+}
+
+// TestPlanTwoWayDeletion_EmptySourceNoPriorAllowsEmpty verifies that
+// the empty-source guard does not fire when there are no prior
+// records — that is the legitimate "fresh source, no history" case
+// (e.g., a brand-new source that hasn't had its first successful
+// sync yet). Mirror of EmptyDestNoPriorAllowsEmpty. (#80)
+func TestPlanTwoWayDeletion_EmptySourceNoPriorAllowsEmpty(t *testing.T) {
+	source := newEventMap()
+	dest := newEventMap("a", "b")
+	prior := newPriorMap()
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("empty-source with no prior should not trigger guard: %q", warning)
+	}
+	if len(toDelete) != 0 {
+		t.Errorf("expected empty delete list, got %d", len(toDelete))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Rule 3: mass-deletion ratio guard (NEW)
+// -----------------------------------------------------------------------------
+
+// TestPlanTwoWayDeletion_PartialSourceTriggersRatioGuard is the
+// other half of the William regression. When the source returns
+// SOME events but is missing the bulk of them, neither the empty-
+// dest nor the empty-source guard fires — but the ratio guard
+// catches it. With 100 prior records and only 10 still on source,
+// 90 would be deleted (90% of prior > 50% threshold) → refuse. (#80)
+func TestPlanTwoWayDeletion_PartialSourceTriggersRatioGuard(t *testing.T) {
+	// 100 prior records, source returns only 10 of them, dest has
+	// all 100. Without the ratio guard the function would propose
+	// 90 deletes (90% of prior).
+	priorUIDs := make([]string, 100)
+	for i := range priorUIDs {
+		priorUIDs[i] = string(rune('a'+(i%26))) + string(rune('0'+(i/26)))
+	}
+	prior := newPriorMap(priorUIDs...)
+	dest := newEventMap(priorUIDs...)
+	source := newEventMap(priorUIDs[:10]...) // only first 10 still on source
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning == "" {
+		t.Fatal("expected ratio guard to fire on 90% mass-deletion proposal")
+	}
+	if toDelete != nil {
+		t.Errorf("expected nil delete list when ratio guard fires, got %d", len(toDelete))
+	}
+}
+
+// TestPlanTwoWayDeletion_NormalDeletionAllowed verifies the happy
+// path: a single legitimate deletion (well under the ratio
+// threshold) flows through. 10 prior records, 9 still on source,
+// 1 missing → 1 delete (10% of prior, well below 50%). (#80)
+func TestPlanTwoWayDeletion_NormalDeletionAllowed(t *testing.T) {
+	source := newEventMap("a", "b", "c", "d", "e", "f", "g", "h", "i")
+	dest := newEventMap("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+	prior := newPriorMap("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("legitimate single deletion should not trigger any guard: %q", warning)
+	}
+	if len(toDelete) != 1 || toDelete[0] != "j" {
+		t.Errorf("expected exactly one deletion of UID j, got %v", toDelete)
+	}
+}
+
+// TestPlanTwoWayDeletion_RatioDisabledWhenZero verifies that passing
+// maxDeleteRatio=0 disables the ratio check entirely (matching
+// planOrphanDeletion's disable semantics). When the threshold is
+// disabled, even a 100% deletion proposal flows through — useful
+// for tests and for callers that want only the empty-side guards.
+// (#80)
+func TestPlanTwoWayDeletion_RatioDisabledWhenZero(t *testing.T) {
+	source := newEventMap("only-this-one")
+	dest := newEventMap("a", "b", "c", "d", "e", "only-this-one")
+	prior := newPriorMap("a", "b", "c", "d", "e", "only-this-one")
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0)
+
+	if warning != "" {
+		t.Errorf("ratio=0 disables the ratio guard, got warning: %q", warning)
+	}
+	if len(toDelete) != 5 {
+		t.Errorf("expected 5 deletions when ratio is disabled, got %d", len(toDelete))
+	}
+}
+
+// TestPlanTwoWayDeletion_RatioExactlyAtThresholdAllowed verifies the
+// boundary: a deletion ratio exactly equal to the threshold is
+// allowed (the check is strict greater-than). 4 of 8 prior records
+// missing from source = 50% exactly = allowed. (#80)
+func TestPlanTwoWayDeletion_RatioExactlyAtThresholdAllowed(t *testing.T) {
+	source := newEventMap("a", "b", "c", "d")
+	dest := newEventMap("a", "b", "c", "d", "e", "f", "g", "h")
+	prior := newPriorMap("a", "b", "c", "d", "e", "f", "g", "h")
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("ratio exactly at threshold should be allowed, got warning: %q", warning)
+	}
+	if len(toDelete) != 4 {
+		t.Errorf("expected 4 deletions, got %d", len(toDelete))
+	}
+}
+
+// TestPlanTwoWayDeletion_OnlyDeletesIntersectionOfPriorAndDest
+// verifies the ownership semantics: an event must be in
+// previouslySyncedMap (we synced it) AND on dest (still there) AND
+// not on source (gone) to qualify for deletion. Events that exist
+// only on dest without ever being synced are NOT deleted — those
+// belong to the user, not to us. (#80)
+func TestPlanTwoWayDeletion_OnlyDeletesIntersectionOfPriorAndDest(t *testing.T) {
+	source := newEventMap("a")
+	dest := newEventMap("a", "b", "user-only-1", "user-only-2")
+	prior := newPriorMap("a", "b") // user-only-1 and user-only-2 were never synced by us
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("normal deletion should not trigger guard: %q", warning)
+	}
+	if len(toDelete) != 1 || toDelete[0] != "b" {
+		t.Errorf("expected exactly one deletion of UID b (user-only events should be untouched), got %v", toDelete)
+	}
+}
+
+// TestPlanTwoWayDeletion_DoesNotDeleteEventsStillOnSource verifies
+// the basic correctness check: events that exist on BOTH source and
+// dest are not candidates for deletion regardless of any other
+// state. (#80)
+func TestPlanTwoWayDeletion_DoesNotDeleteEventsStillOnSource(t *testing.T) {
+	source := newEventMap("a", "b", "c")
+	dest := newEventMap("a", "b", "c")
+	prior := newPriorMap("a", "b", "c")
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("no deletions case should not trigger guard: %q", warning)
+	}
+	if len(toDelete) != 0 {
+		t.Errorf("expected zero deletions when source has all prior events, got %d", len(toDelete))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Combined / canary tests
+// -----------------------------------------------------------------------------
+
+// TestPlanTwoWayDeletion_GuardOrderEmptyDestBeforeEmptySource
+// documents that the empty-dest guard fires BEFORE the empty-source
+// guard when both conditions hold. The user-visible warning message
+// matters because it points the operator at the right side to debug.
+// (#80)
+func TestPlanTwoWayDeletion_GuardOrderEmptyDestBeforeEmptySource(t *testing.T) {
+	source := newEventMap()
+	dest := newEventMap()
+	prior := newPriorMap("a", "b", "c")
+
+	_, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning == "" {
+		t.Fatal("expected a guard to fire when both sides empty")
+	}
+	// The dest-side guard message should win because Rule 1 is
+	// checked first. This is documented behavior, not a coincidence.
+	if !contains(warning, "destination returned 0 events") {
+		t.Errorf("expected dest-empty warning first, got: %q", warning)
+	}
+}
+
+// TestPlanTwoWayDeletion_WilliamScenarioReproduction reconstructs the
+// actual production failure: 748 prior records, dest has 130 of them
+// (with the rest filtered out by the date window upstream), source
+// returned 0 for one calendar (the partial-failure case). The empty-
+// source guard MUST fire and zero events MUST be deleted. (#80)
+//
+// Without the fix, this would propose 130 deletions (every UID in
+// dest that is also in prior but not in source) — and that's just
+// one calendar. The original bug saw all 748 evaporate over the
+// full sync cycle.
+func TestPlanTwoWayDeletion_WilliamScenarioReproduction(t *testing.T) {
+	priorUIDs := make([]string, 748)
+	for i := range priorUIDs {
+		priorUIDs[i] = "evt-" + string(rune('a'+(i%26))) + string(rune('0'+(i/26)))
+	}
+	prior := newPriorMap(priorUIDs...)
+	// Dest has the first 130 prior UIDs (post-date-filter slice).
+	dest := newEventMap(priorUIDs[:130]...)
+	// Source returned 0 — the iCloud partial-failure that started it.
+	source := newEventMap()
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning == "" {
+		t.Fatal("William scenario MUST trigger the empty-source guard — this is the regression")
+	}
+	if toDelete != nil {
+		t.Errorf("William scenario MUST refuse to delete anything, got %d candidates", len(toDelete))
+	}
+}
+
+// contains is a tiny helper to avoid pulling in strings.Contains
+// just for the canary tests above.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- **Critical hotfix.** Prevents the dest-deletion direction of two-way sync from mass-deleting destination events when the source query returns a partial set. William just lost 748 events from SOGo to this exact bug.
- New pure helper \`planTwoWayDeletion\` enforces three guards: empty-dest (existing), empty-source (NEW — direct fix), mass-deletion ratio > 50% (NEW — catches partial-source).
- Inline two-way deletion loop refactored into two passes (dest-delete via helper, source-delete still inline with its existing per-event safety threshold).
- 12 new unit tests including a direct 748-event reproduction of the William scenario.

## Why
The previous \`shouldSkipTwoWayDeletion\` only checked \`destEventCount==0\` — it had no protection against an empty or partial **source** response. When iCloud returned a partial set for one of William's calendars, the inline loop classified every previously-synced UID not in the response as "deleted from source" and propagated 748 deletes to SOGo.

This shipped to production today as the very next sync cycle after PR #79 deployed. The deletion bug is pre-existing — PR #79 did not cause it. Recent PRs (#76, #78, #79) just removed enough upstream noise to expose it.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (all packages green)
- [x] \`go test -race ./internal/caldav/...\`
- [x] 12 new tests in \`two_way_deletion_test.go\`:
  - Empty-dest guard fires + does not fire (no prior records)
  - Empty-source guard fires (the William fix) + does not fire (no prior records)
  - Mass-deletion ratio guard fires on 90% proposal
  - Normal single deletion (10% of prior) flows through cleanly
  - \`maxDeleteRatio=0\` disables the ratio check
  - Boundary: ratio exactly at threshold is allowed
  - Ownership filter (only deletes events we synced)
  - Direct reproduction: 748 prior records, empty source, dest holds 130 in-window UIDs → must refuse
- [ ] **Post-deploy**: William needs to restore the 748 lost events from iCloud (they should still be there) by triggering a re-sync once this fix is live. The fix prevents future losses; it cannot recover what was already deleted.

## Deployment notes
- Hotfix ships ahead of the per-source Google OAuth refactor (task #39), which is stashed locally pending this merge.
- Recommend deploying immediately and watching the first sync cycle for the new warning messages.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)