### PR TITLE
HOTFIX #2: source-side deletion ratio guard (data-loss recovery cascade)

### DIFF
--- a/internal/caldav/source_deletion_test.go
+++ b/internal/caldav/source_deletion_test.go
@@ -1,0 +1,293 @@
+package caldav
+
+import (
+	"testing"
+
+	"github.com/macjediwizard/calbridgesync/internal/db"
+)
+
+// Issue #82 regression suite for planTwoWaySourceDeletion.
+//
+// Background: PR #80 added empty-source + ratio guards to the dest-
+// deletion direction (planTwoWayDeletion) but explicitly deferred the
+// source-deletion direction "to a follow-up." That follow-up
+// deferred too long: with the dest calendar mid-recovery from the
+// previous mass-delete bug, the unguarded source-deletion pass saw
+// 360+ prior UIDs as "missing from dest" and deleted them from
+// iCloud at ~360 events/cycle. This file is the regression suite
+// for the symmetric guard.
+
+// -----------------------------------------------------------------------------
+// Empty-source guard
+// -----------------------------------------------------------------------------
+
+// TestPlanTwoWaySourceDeletion_EmptySourceWithPriorRefuses verifies
+// that an empty source query short-circuits the source-deletion pass
+// (same rationale as the dest-side empty-source guard in #80). (#82)
+func TestPlanTwoWaySourceDeletion_EmptySourceWithPriorRefuses(t *testing.T) {
+	source := newEventMap() // empty
+	dest := newEventMap("a", "b", "c")
+	prior := newPriorMap("a", "b", "c")
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning == "" {
+		t.Fatal("expected empty-source guard to fire")
+	}
+	if toDelete != nil {
+		t.Errorf("expected nil delete list when guard fires, got %d", len(toDelete))
+	}
+}
+
+// TestPlanTwoWaySourceDeletion_EmptySourceNoPriorAllowsEmpty verifies
+// that empty source with NO prior records is the legitimate first-
+// sync case and must not trigger the guard. (#82)
+func TestPlanTwoWaySourceDeletion_EmptySourceNoPriorAllowsEmpty(t *testing.T) {
+	source := newEventMap()
+	dest := newEventMap("a", "b")
+	prior := newPriorMap()
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("first-sync (no prior records) should not trigger guard: %q", warning)
+	}
+	if len(toDelete) != 0 {
+		t.Errorf("expected empty delete list, got %d", len(toDelete))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Empty-dest guard
+// -----------------------------------------------------------------------------
+
+// TestPlanTwoWaySourceDeletion_EmptyDestWithPriorRefuses verifies the
+// guard against destination query failures. If destination returns
+// 0 events and we have prior records, the unguarded code would
+// delete every prior UID from source. (#82)
+func TestPlanTwoWaySourceDeletion_EmptyDestWithPriorRefuses(t *testing.T) {
+	source := newEventMap("a", "b", "c", "d")
+	dest := newEventMap()
+	prior := newPriorMap("a", "b", "c", "d")
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning == "" {
+		t.Fatal("expected empty-dest guard to fire")
+	}
+	if toDelete != nil {
+		t.Errorf("expected nil delete list when guard fires, got %d", len(toDelete))
+	}
+}
+
+// TestPlanTwoWaySourceDeletion_EmptyDestNoPriorAllowsEmpty verifies
+// the legitimate fresh-dest case. (#82)
+func TestPlanTwoWaySourceDeletion_EmptyDestNoPriorAllowsEmpty(t *testing.T) {
+	source := newEventMap("a", "b")
+	dest := newEventMap()
+	prior := newPriorMap()
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("empty-dest with no prior should not trigger guard: %q", warning)
+	}
+	if len(toDelete) != 0 {
+		t.Errorf("expected empty delete list, got %d", len(toDelete))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Mass-deletion ratio guard
+// -----------------------------------------------------------------------------
+
+// TestPlanTwoWaySourceDeletion_RecoveryScenarioTriggersRatioGuard is
+// the direct reproduction of the William #82 cascade. The dest
+// calendar is mid-recovery: the previous mass-delete event removed
+// most of the dest events, this cycle's forward sync has only
+// re-created a fraction of them, and the source-delete pass would
+// otherwise propagate the still-missing UIDs as deletes from source.
+//
+// 100 prior records, source has all 100, dest has only 10 (the rest
+// are pending recovery) → would propose 90 deletes (90% of prior)
+// → ratio guard fires. (#82)
+func TestPlanTwoWaySourceDeletion_RecoveryScenarioTriggersRatioGuard(t *testing.T) {
+	priorUIDs := make([]string, 100)
+	for i := range priorUIDs {
+		priorUIDs[i] = string(rune('a'+(i%26))) + string(rune('0'+(i/26)))
+	}
+	prior := newPriorMap(priorUIDs...)
+	source := newEventMap(priorUIDs...)    // source still has everything
+	dest := newEventMap(priorUIDs[:10]...) // dest only has the first 10 (mid-recovery)
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning == "" {
+		t.Fatal("expected ratio guard to fire on 90% mass-deletion proposal — this is the William #82 regression")
+	}
+	if toDelete != nil {
+		t.Errorf("expected nil delete list when ratio guard fires, got %d", len(toDelete))
+	}
+}
+
+// TestPlanTwoWaySourceDeletion_NormalDeletionAllowed verifies the
+// happy path: a single legitimate user-initiated deletion (well
+// under the ratio threshold) flows through. (#82)
+func TestPlanTwoWaySourceDeletion_NormalDeletionAllowed(t *testing.T) {
+	source := newEventMap("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+	dest := newEventMap("a", "b", "c", "d", "e", "f", "g", "h", "i") // user deleted j on dest
+	prior := newPriorMap("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("legitimate single deletion should not trigger any guard: %q", warning)
+	}
+	if len(toDelete) != 1 || toDelete[0] != "j" {
+		t.Errorf("expected exactly one deletion of UID j, got %v", toDelete)
+	}
+}
+
+// TestPlanTwoWaySourceDeletion_RatioDisabledWhenZero verifies the
+// disable semantics (matches planOrphanDeletion + planTwoWayDeletion). (#82)
+func TestPlanTwoWaySourceDeletion_RatioDisabledWhenZero(t *testing.T) {
+	source := newEventMap("a", "b", "c", "d", "e")
+	dest := newEventMap()
+	// Need to bypass empty-dest guard with zero prior records
+	prior := newPriorMap()
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0)
+
+	if warning != "" {
+		t.Errorf("ratio=0 with no prior should not trigger any guard: %q", warning)
+	}
+	if len(toDelete) != 0 {
+		t.Errorf("expected 0 deletions, got %d", len(toDelete))
+	}
+}
+
+// TestPlanTwoWaySourceDeletion_RatioExactlyAtThresholdAllowed
+// verifies the boundary: exactly at the threshold is allowed (strict
+// greater-than). 4 of 8 = 50% exactly = allowed. (#82)
+func TestPlanTwoWaySourceDeletion_RatioExactlyAtThresholdAllowed(t *testing.T) {
+	source := newEventMap("a", "b", "c", "d", "e", "f", "g", "h")
+	dest := newEventMap("a", "b", "c", "d") // dest missing 4 of 8
+	prior := newPriorMap("a", "b", "c", "d", "e", "f", "g", "h")
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("ratio exactly at threshold should be allowed, got warning: %q", warning)
+	}
+	if len(toDelete) != 4 {
+		t.Errorf("expected 4 deletions, got %d", len(toDelete))
+	}
+}
+
+// TestPlanTwoWaySourceDeletion_OnlyDeletesFromOurPriorMap verifies
+// the ownership filter: events on source that were never in our
+// previouslySyncedMap (not synced by us) are not candidates for
+// deletion. They belong to the user. (#82)
+func TestPlanTwoWaySourceDeletion_OnlyDeletesFromOurPriorMap(t *testing.T) {
+	source := newEventMap("a", "b", "user-only-1", "user-only-2")
+	dest := newEventMap("a")
+	prior := newPriorMap("a", "b") // we never synced user-only-*
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("normal deletion should not trigger guard: %q", warning)
+	}
+	if len(toDelete) != 1 || toDelete[0] != "b" {
+		t.Errorf("expected exactly one deletion of UID b (user-only events untouched), got %v", toDelete)
+	}
+}
+
+// TestPlanTwoWaySourceDeletion_DoesNotDeleteEventsStillOnDest
+// verifies the basic correctness check. (#82)
+func TestPlanTwoWaySourceDeletion_DoesNotDeleteEventsStillOnDest(t *testing.T) {
+	source := newEventMap("a", "b", "c")
+	dest := newEventMap("a", "b", "c")
+	prior := newPriorMap("a", "b", "c")
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("no deletions case should not trigger guard: %q", warning)
+	}
+	if len(toDelete) != 0 {
+		t.Errorf("expected zero deletions, got %d", len(toDelete))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Symmetry canary
+// -----------------------------------------------------------------------------
+
+// TestPlanTwoWaySourceDeletion_SymmetricWithDestDeletion verifies
+// the two helpers behave symmetrically on a swap-the-sides matrix.
+// Each scenario describes the same story from each side and the
+// helper for that side must agree. This is a canary against future
+// refactors that drift the two helpers apart. (#82)
+func TestPlanTwoWaySourceDeletion_SymmetricWithDestDeletion(t *testing.T) {
+	cases := []struct {
+		name             string
+		side1, side2     map[string]Event
+		prior            map[string]*db.SyncedEvent
+		expectGuardFires bool
+	}{
+		{
+			name:             "both sides full, no overlap missing",
+			side1:            newEventMap("a", "b"),
+			side2:            newEventMap("a", "b"),
+			prior:            newPriorMap("a", "b"),
+			expectGuardFires: false,
+		},
+		{
+			name:             "side1 missing, prior records exist",
+			side1:            newEventMap(),
+			side2:            newEventMap("a", "b"),
+			prior:            newPriorMap("a", "b"),
+			expectGuardFires: true,
+		},
+		{
+			name:             "side2 missing, prior records exist",
+			side1:            newEventMap("a", "b"),
+			side2:            newEventMap(),
+			prior:            newPriorMap("a", "b"),
+			expectGuardFires: true,
+		},
+		{
+			name:             "neither missing, normal single deletion",
+			side1:            newEventMap("a", "b", "c"),
+			side2:            newEventMap("a", "b"),
+			prior:            newPriorMap("a", "b", "c"),
+			expectGuardFires: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// For source-deletion: side1 = source, side2 = dest.
+			_, sourceWarn := planTwoWaySourceDeletion(tc.side1, tc.side2, tc.prior, 0.5)
+			// For dest-deletion: side1 = source, side2 = dest (same arg
+			// order — both helpers take source then dest).
+			_, destWarn := planTwoWayDeletion(tc.side1, tc.side2, tc.prior, 0.5)
+
+			gotSourceFires := sourceWarn != ""
+			gotDestFires := destWarn != ""
+
+			if gotSourceFires != tc.expectGuardFires {
+				t.Errorf("source-deletion guard fired=%v, want %v (warn=%q)", gotSourceFires, tc.expectGuardFires, sourceWarn)
+			}
+			if gotDestFires != tc.expectGuardFires {
+				t.Errorf("dest-deletion guard fired=%v, want %v (warn=%q)", gotDestFires, tc.expectGuardFires, destWarn)
+			}
+			// The helpers must agree on whether to fire — they're
+			// symmetric mirrors. If they ever drift, this test
+			// catches it.
+			if gotSourceFires != gotDestFires {
+				t.Errorf("source-deletion and dest-deletion guards disagree: source=%v, dest=%v", gotSourceFires, gotDestFires)
+			}
+		})
+	}
+}

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -242,6 +242,90 @@ func planTwoWayDeletion(
 	return candidates, ""
 }
 
+// planTwoWaySourceDeletion determines which source events should be
+// deleted because they were removed from destination during a two-way
+// sync. It is the symmetric mirror of planTwoWayDeletion (which
+// handles dest-side deletions) and the source-side equivalent of
+// planOrphanDeletion's ratio guard.
+//
+// As of #82, this helper enforces the same three guards as
+// planTwoWayDeletion, plus the per-event safety threshold inherited
+// from the legacy inline source-delete loop. The guards are:
+//
+//  1. Empty-source guard: if source returned 0 events but we have
+//     prior records, refuse. Same rationale as planTwoWayDeletion.
+//
+//  2. Empty-dest guard: if destination returned 0 events but we have
+//     prior records, refuse. NEW for the source-deletion path. The
+//     existing shouldSkipTwoWayDeletion check covered this for the
+//     dest-side direction; this helper now covers the source side.
+//
+//  3. Mass-deletion ratio guard: if more than maxDeleteRatio of the
+//     prior records would be deleted from source in one cycle,
+//     refuse. NEW. Critical for the destination-recovery scenario:
+//     when the dest calendar is being repopulated after a previous
+//     mass-delete, the source-deletion pass would otherwise see
+//     half the prior UIDs as "missing from dest" and propagate the
+//     deletes back to source — exactly the cascade that ate
+//     William's iCloud calendar at ~360 events/cycle.
+//
+//  4. Per-event safety threshold (applied by the caller after the
+//     candidate list is returned): events whose CreatedAt is within
+//     the last sync interval are protected from deletion. This is
+//     the existing isWithinSyncSafetyThreshold check; the helper
+//     defers it to the caller because it needs the per-event
+//     synced_events record to evaluate.
+//
+// Returns the list of UIDs to delete from source and a non-empty
+// warning if any rule was triggered. When a warning is returned,
+// toDelete is nil — the caller must not perform any deletions in that
+// case. (#82)
+func planTwoWaySourceDeletion(
+	sourceEventMap map[string]Event,
+	destEventMap map[string]Event,
+	previouslySyncedMap map[string]*db.SyncedEvent,
+	maxDeleteRatio float64,
+) (toDelete []string, warning string) {
+	// Rule 1: empty source with prior records → refuse.
+	if len(sourceEventMap) == 0 && len(previouslySyncedMap) > 0 {
+		return nil, fmt.Sprintf(
+			"source returned 0 events but %d previously-synced records exist - "+
+				"skipping source-side deletion pass for safety (possible source query failure)",
+			len(previouslySyncedMap),
+		)
+	}
+	// Rule 2: empty destination with prior records → refuse.
+	if len(destEventMap) == 0 && len(previouslySyncedMap) > 0 {
+		return nil, fmt.Sprintf(
+			"destination returned 0 events but %d previously-synced records exist - "+
+				"skipping source-side deletion pass for safety (possible destination query failure)",
+			len(previouslySyncedMap),
+		)
+	}
+	// Build candidate list: previously-synced UIDs that still exist
+	// on source but no longer exist on destination.
+	candidates := make([]string, 0)
+	for uid := range previouslySyncedMap {
+		_, existsOnSource := sourceEventMap[uid]
+		_, existsOnDest := destEventMap[uid]
+		if existsOnSource && !existsOnDest {
+			candidates = append(candidates, uid)
+		}
+	}
+	// Rule 3: mass-deletion ratio guard.
+	if maxDeleteRatio > 0 && len(previouslySyncedMap) > 0 {
+		ratio := float64(len(candidates)) / float64(len(previouslySyncedMap))
+		if ratio > maxDeleteRatio {
+			return nil, fmt.Sprintf(
+				"source-side deletion pass would delete %d of %d previously-synced events from source (%.0f%%), "+
+					"exceeds safety threshold %.0f%% - skipping for safety (possible partial destination query failure or recovery in progress)",
+				len(candidates), len(previouslySyncedMap), ratio*100, maxDeleteRatio*100,
+			)
+		}
+	}
+	return candidates, ""
+}
+
 // planReverseCreate determines which destination events should be uploaded
 // to source as new creates during a two-way sync. It is the mirror of
 // planOrphanDeletion for the reverse direction.
@@ -1249,64 +1333,81 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 			handledByDestDelete[uid] = true
 		}
 
-		// Step 2: source-deletion + cleanup. Skip entirely if the
-		// dest query returned empty (would risk mass-deleting from
-		// source); the per-event safety threshold provides the
-		// remaining protection within an individual cycle.
-		skipSourceDeletion := shouldSkipTwoWayDeletion(syncDirection, len(destEventMap), len(previouslySyncedMap))
-		if skipSourceDeletion {
-			log.Printf("WARNING: Destination returned 0 events but we have %d previously synced events - skipping source-side deletions for safety", len(previouslySyncedMap))
+		// Step 2: source-deletion via planTwoWaySourceDeletion. The
+		// helper enforces three guards (empty-source, empty-dest, and
+		// mass-delete ratio). The per-event safety threshold
+		// (isWithinSyncSafetyThreshold) is still applied here per-UID
+		// inside the loop because it depends on each candidate's
+		// CreatedAt timestamp, which the helper does not have. (#82)
+		toDeleteFromSource, sourceDelWarning := planTwoWaySourceDeletion(
+			sourceEventMap,
+			destEventMap,
+			previouslySyncedMap,
+			defaultOrphanDeleteRatioThreshold,
+		)
+		if sourceDelWarning != "" {
+			log.Printf("WARNING: %s", sourceDelWarning)
+			result.Warnings = append(result.Warnings, sourceDelWarning)
 		}
-		if !skipSourceDeletion {
-			for uid, syncedEvent := range previouslySyncedMap {
-				if handledByDestDelete[uid] {
-					continue
-				}
-				sourceEvent, existsOnSource := sourceEventMap[uid]
-				_, existsOnDest := destEventMap[uid]
+		// Track UIDs handled by either deletion pass so the cleanup
+		// loop below skips them when reaping orphan synced_events.
+		handledBySourceDelete := make(map[string]bool, len(toDeleteFromSource))
+		for _, uid := range toDeleteFromSource {
+			if handledByDestDelete[uid] {
+				continue
+			}
+			syncedEvent := previouslySyncedMap[uid]
+			sourceEvent := sourceEventMap[uid]
 
-				if existsOnSource && !existsOnDest {
-					// SAFETY CHECK: Only delete from source if the event was
-					// FIRST synced before the safety threshold (commit 23e88c1,
-					// Issue #72). Prevents deleting events that just appeared
-					// and haven't had time to fully propagate.
-					//
-					// We deliberately read CreatedAt (sticky, set once at first
-					// sync) rather than UpdatedAt (bumped every cycle via
-					// UpsertSyncedEvent). Reading UpdatedAt was a bug: for
-					// any normally-running sync, UpdatedAt is always within
-					// one sync interval of "now" because the upsert at the
-					// end of every cycle resets it, which made this safety
-					// guard fire unconditionally and silently block every
-					// two-way source-side deletion. CreatedAt preserves the
-					// original intent ("protect brand-new events") without
-					// the "protect everything forever" accident.
-					if isWithinSyncSafetyThreshold(syncedEvent.CreatedAt, sourceInterval, now) {
-						log.Printf("Event %s not on destination but newly synced (CreatedAt=%v) - skipping deletion from source (safety)", uid, syncedEvent.CreatedAt)
-						continue
-					}
+			// SAFETY CHECK: Only delete from source if the event was
+			// FIRST synced before the safety threshold (commit 23e88c1,
+			// Issue #72). Prevents deleting events that just appeared
+			// and haven't had time to fully propagate.
+			//
+			// We deliberately read CreatedAt (sticky, set once at first
+			// sync) rather than UpdatedAt (bumped every cycle via
+			// UpsertSyncedEvent). Reading UpdatedAt was a bug: for
+			// any normally-running sync, UpdatedAt is always within
+			// one sync interval of "now" because the upsert at the
+			// end of every cycle resets it, which made this safety
+			// guard fire unconditionally and silently block every
+			// two-way source-side deletion. CreatedAt preserves the
+			// original intent ("protect brand-new events") without
+			// the "protect everything forever" accident.
+			if isWithinSyncSafetyThreshold(syncedEvent.CreatedAt, sourceInterval, now) {
+				log.Printf("Event %s not on destination but newly synced (CreatedAt=%v) - skipping deletion from source (safety)", uid, syncedEvent.CreatedAt)
+				continue
+			}
 
-					// Event was deleted from destination - delete from source too
-					log.Printf("Event %s deleted from destination, deleting from source", uid)
-					if err := sourceClient.DeleteEvent(ctx, sourceEvent.Path); err != nil {
-						result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to delete event from source: %v", err))
-					} else {
-						result.Deleted++
-						updateProgress()
-					}
-					// Remove from synced_events
-					if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, uid); err != nil {
-						log.Printf("Failed to delete synced event record: %v", err)
-					}
-					delete(sourceEventMap, uid)
-					continue
-				}
+			log.Printf("Event %s deleted from destination, deleting from source", uid)
+			if err := sourceClient.DeleteEvent(ctx, sourceEvent.Path); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to delete event from source: %v", err))
+			} else {
+				result.Deleted++
+				updateProgress()
+			}
+			// Remove from synced_events
+			if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, uid); err != nil {
+				log.Printf("Failed to delete synced event record: %v", err)
+			}
+			delete(sourceEventMap, uid)
+			handledBySourceDelete[uid] = true
+		}
 
-				if !existsOnSource && !existsOnDest {
-					// Event deleted from both - just clean up the record
-					if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, syncedEvent.EventUID); err != nil {
-						log.Printf("Failed to delete synced event record: %v", err)
-					}
+		// Cleanup pass: walk previouslySyncedMap one more time for
+		// the "deleted from both" case. Skip UIDs already handled by
+		// either deletion pass above to avoid double-deletes from
+		// synced_events.
+		for uid, syncedEvent := range previouslySyncedMap {
+			if handledByDestDelete[uid] || handledBySourceDelete[uid] {
+				continue
+			}
+			_, existsOnSource := sourceEventMap[uid]
+			_, existsOnDest := destEventMap[uid]
+			if !existsOnSource && !existsOnDest {
+				// Event deleted from both - just clean up the record
+				if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, syncedEvent.EventUID); err != nil {
+					log.Printf("Failed to delete synced event record: %v", err)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- **Critical hotfix #2**, follow-up to PR #82. Stops the recovery-cascade that's eating William's iCloud calendar at ~360 events/cycle.
- New pure helper \`planTwoWaySourceDeletion\` mirrors \`planTwoWayDeletion\`'s three-guard contract for the opposite direction (deleting from source when dest is missing UIDs).
- Inline source-deletion loop refactored into a helper call + per-UID safety threshold + a small "deleted from both" cleanup pass.
- 11 new unit tests including a direct reproduction of the William cascade.

## Why
PR #80 explicitly deferred the source-side ratio guard "to a follow-up" because the immediate damage was on the dest side. That deferral needed to ship within hours, not days: with the destination calendar mid-recovery from yesterday's mass-delete, the unguarded source-deletion pass propagated the dest gaps back to iCloud at ~360 events/cycle. Cascading data loss in the reverse direction.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (all packages green)
- [x] \`go test -race ./internal/caldav/...\`
- [x] 11 new tests in \`source_deletion_test.go\` covering each guard, the happy paths, boundary, ownership filter, disable semantics, the William cascade reproduction, and a symmetry canary
- [ ] **Post-deploy**: William's recovery cycle should drop \"deleted\" count to ~0 (the ratio guard fires while recovery is in progress) and dest forward sync continues replenishing SOGo from iCloud.

## Recovery notes
After this ships, William can recover data via:
1. Apple iCloud's Recently Deleted: icloud.com → Calendar → ⚙️ → Show Recently Deleted → restore. iCloud keeps deleted events for 30 days.
2. Forward sync will then naturally repopulate SOGo from the restored iCloud calendar over the next few cycles.
3. SOGo dest does not have a built-in trash; it depends on the iCloud restore plus our forward sync.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)