### PR TITLE
refactor: per-source Google OAuth credentials (#85)

### DIFF
--- a/cmd/calbridgesync/main.go
+++ b/cmd/calbridgesync/main.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 
 	"github.com/macjediwizard/calbridgesync/internal/auth"
 	"github.com/macjediwizard/calbridgesync/internal/caldav"
@@ -86,33 +84,21 @@ func main() {
 		cfg.Security.OAuthStateMaxAgeSecs,
 	)
 
-	// Build the Google OAuth2 config if credentials are configured.
-	// This is passed through to the sync engine so Google sources can
-	// authenticate via Bearer tokens. nil when the feature is not
-	// configured — in that case, attempting to sync a Google source
-	// will surface a clear error from the engine. (#70)
-	var googleOAuthConfig *oauth2.Config
+	// As of #79 the Google OAuth client_id and client_secret are
+	// stored per-source in the database, so the global env-var
+	// oauth2.Config that the sync engine used to take has been
+	// removed. The redirect URL is still instance-level (Google
+	// requires it to be pre-registered in each user's Google Cloud
+	// Console project) and is read from cfg.GoogleOAuth.RedirectURL
+	// inside the web handlers when starting an OAuth flow.
 	if cfg.GoogleOAuth.Enabled() {
-		googleOAuthConfig = &oauth2.Config{
-			ClientID:     cfg.GoogleOAuth.ClientID,
-			ClientSecret: cfg.GoogleOAuth.ClientSecret,
-			RedirectURL:  cfg.GoogleOAuth.RedirectURL,
-			Endpoint:     google.Endpoint,
-			Scopes: []string{
-				// Full calendar scope is required for CalDAV access.
-				// The narrower .events scope is NOT sufficient because
-				// CalDAV requires PROPFIND on calendar-home-set.
-				"https://www.googleapis.com/auth/calendar",
-				// Needed to fetch the user's primary email during the
-				// OAuth callback so we can build the per-calendar URL.
-				"https://www.googleapis.com/auth/userinfo.email",
-			},
-		}
-		log.Printf("Google OAuth2 enabled (redirect=%s)", cfg.GoogleOAuth.RedirectURL)
+		log.Printf("Google OAuth2 enabled (redirect=%s, per-source credentials in DB)", cfg.GoogleOAuth.RedirectURL)
 	}
 
-	// Initialize sync engine
-	syncEngine := caldav.NewSyncEngine(database, encryptor, googleOAuthConfig)
+	// Initialize sync engine. The engine builds a per-source oauth2
+	// config at sync time from the credentials stored on each Google
+	// source row, so no instance-level OAuth config is passed in.
+	syncEngine := caldav.NewSyncEngine(database, encryptor)
 
 	// Initialize notifier for alerts
 	notifyCfg := &notify.Config{

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -25,10 +25,10 @@ const (
 // PendingGoogleSource holds the form data for a Google source that is
 // mid-OAuth. It's stashed in a short-lived session cookie between the
 // "prepare" API call and the OAuth callback, then read and cleared by
-// the callback when it creates the real Source row. DestPassword is
-// already encrypted via the application's AES-256-GCM Encryptor
-// before it lands in this struct — the session cookie does NOT carry
-// a plaintext password. (#70)
+// the callback when it creates the real Source row. DestPassword and
+// GoogleClientSecretEnc are already encrypted via the application's
+// AES-256-GCM Encryptor before they land in this struct — the
+// session cookie does NOT carry plaintext credentials. (#70 + #79)
 type PendingGoogleSource struct {
 	State            string `json:"state"`
 	Name             string `json:"name"`
@@ -39,6 +39,16 @@ type PendingGoogleSource struct {
 	DestURL          string `json:"dest_url"`
 	DestUsername     string `json:"dest_username"`
 	DestPasswordEnc  string `json:"dest_password_enc"` // already encrypted
+	// GoogleClientID is the user's Google Cloud OAuth client ID
+	// (public identifier — stored in plain text). Carried through
+	// the OAuth flow so the callback can build the same oauth2.Config
+	// as the prepare step. (#79)
+	GoogleClientID string `json:"google_client_id"`
+	// GoogleClientSecretEnc is the user's Google Cloud OAuth client
+	// secret, encrypted before being stashed in the session cookie.
+	// The callback decrypts it just long enough to call cfg.Exchange,
+	// then re-encrypts it for storage on the Source row. (#79)
+	GoogleClientSecretEnc string `json:"google_client_secret_enc"`
 }
 
 var (

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -802,7 +802,7 @@ func TestSanitizeLogDetails(t *testing.T) {
 
 func TestNewSyncEngine(t *testing.T) {
 	t.Run("creates sync engine with nil dependencies", func(t *testing.T) {
-		engine := NewSyncEngine(nil, nil, nil)
+		engine := NewSyncEngine(nil, nil)
 
 		if engine == nil {
 			t.Fatal("expected non-nil engine")
@@ -1347,7 +1347,7 @@ func TestSanitizeLogDetailsEdgeCases(t *testing.T) {
 
 func TestSyncEngineTestConnection(t *testing.T) {
 	t.Run("returns error for invalid URL", func(t *testing.T) {
-		engine := NewSyncEngine(nil, nil, nil)
+		engine := NewSyncEngine(nil, nil)
 
 		err := engine.TestConnection(context.Background(), "", "user", "pass")
 		if err == nil {

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 
 	"github.com/macjediwizard/calbridgesync/internal/activity"
 	"github.com/macjediwizard/calbridgesync/internal/crypto"
@@ -700,24 +701,58 @@ type SyncEngine struct {
 	db        *db.DB
 	encryptor *crypto.Encryptor
 	tracker   *activity.Tracker
-	// googleOAuth is the OAuth2 configuration used when syncing
-	// source_type == google. Nil if the feature is not configured on
-	// this instance; SyncSource will then surface a clear error
-	// instead of silently falling back to Basic Auth (which Google
-	// would reject anyway). (#70)
-	googleOAuth *oauth2.Config
 }
 
-// NewSyncEngine creates a new sync engine. googleOAuth is optional
-// and should be nil unless Google OAuth2 credentials have been
-// configured via GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET.
-func NewSyncEngine(database *db.DB, encryptor *crypto.Encryptor, googleOAuth *oauth2.Config) *SyncEngine {
+// NewSyncEngine creates a new sync engine. As of #79 the engine no
+// longer holds a global Google OAuth config — Google sources carry
+// their own client_id and client_secret on the source row, and the
+// sync code builds an oauth2.Config per request from those columns.
+func NewSyncEngine(database *db.DB, encryptor *crypto.Encryptor) *SyncEngine {
 	return &SyncEngine{
-		db:          database,
-		encryptor:   encryptor,
-		tracker:     activity.NewTracker(),
-		googleOAuth: googleOAuth,
+		db:        database,
+		encryptor: encryptor,
+		tracker:   activity.NewTracker(),
 	}
+}
+
+// googleScopes are the OAuth scopes every Google CalDAV sync needs.
+// Hardcoded because they are the same for every source — different
+// scopes would require a separate consent flow per source, which is
+// not a feature we expose. (#79)
+var googleScopes = []string{
+	// Full calendar scope is required for CalDAV access. The narrower
+	// .events scope is NOT sufficient because CalDAV requires
+	// PROPFIND on calendar-home-set.
+	"https://www.googleapis.com/auth/calendar",
+	// Needed to fetch the user's primary email during the OAuth
+	// callback so we can build the per-calendar URL.
+	"https://www.googleapis.com/auth/userinfo.email",
+}
+
+// buildPerSourceGoogleOAuthConfig assembles a fresh *oauth2.Config
+// from the credentials stored on a single source row plus the
+// instance-level redirect URL. Returns an error if either the client
+// ID or the (decrypted) client secret is missing — Google sources
+// without their own credentials are a hard configuration failure
+// rather than a silent Basic-Auth fallback. (#79)
+func (se *SyncEngine) buildPerSourceGoogleOAuthConfig(source *db.Source, redirectURL string) (*oauth2.Config, error) {
+	if source.GoogleClientID == "" {
+		return nil, fmt.Errorf("source %q has no Google OAuth client_id — re-add the source via the web UI", source.Name)
+	}
+	if source.GoogleClientSecret == "" {
+		return nil, fmt.Errorf("source %q has no Google OAuth client_secret — re-add the source via the web UI", source.Name)
+	}
+	clientSecret, err := se.encryptor.Decrypt(source.GoogleClientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt Google client_secret for source %q: %w", source.Name, err)
+	}
+	return &oauth2.Config{
+		ClientID:     source.GoogleClientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+		Endpoint:     google.Endpoint,
+		Scopes:       googleScopes,
+	}, nil
 }
 
 // GetActivityTracker returns the activity tracker for external use.
@@ -773,25 +808,32 @@ func (se *SyncEngine) SyncSource(ctx context.Context, source *db.Source) *SyncRe
 		return result
 	}
 
-	// Create source client — branch on source type (#70).
+	// Create source client — branch on source type (#70 + #79).
 	// Google sources use OAuth2 Bearer auth; everything else uses
-	// Basic Auth. A Google source without an OAuth config on the
-	// server or without a stored refresh token is a hard failure —
-	// we must not silently fall back to Basic Auth because Google
-	// will reject it with 401, which would look like bad credentials
-	// even though the real fix is to finish configuring OAuth.
+	// Basic Auth. A Google source without per-source client_id /
+	// client_secret / refresh_token is a hard failure — we must not
+	// silently fall back to Basic Auth because Google will reject it
+	// with 401, which would look like bad credentials even though the
+	// real fix is to re-add the source via the web UI.
+	//
+	// As of #79 the OAuth client config is built per-source from the
+	// credentials stored on the source row (not from a global env-var
+	// config). The redirect URL is irrelevant for token refresh —
+	// only the consent-screen flow uses it, and that runs in the web
+	// handlers, not here — so we pass an empty string.
 	var sourceClient *Client
 	if source.SourceType == db.SourceTypeGoogle {
-		if se.googleOAuth == nil {
-			result.Message = "Google OAuth is not configured on this server (GOOGLE_OAUTH_CLIENT_ID missing)"
+		if source.OAuthRefreshToken == "" {
+			result.Message = "Google source is missing its OAuth refresh token — reconnect via the web UI"
 			result.Errors = append(result.Errors, result.Message)
 			result.Duration = time.Since(start)
 			se.finishSync(source.ID, result)
 			return result
 		}
-		if source.OAuthRefreshToken == "" {
-			result.Message = "Google source is missing its OAuth refresh token — reconnect via the web UI"
-			result.Errors = append(result.Errors, result.Message)
+		perSourceOAuthConfig, cfgErr := se.buildPerSourceGoogleOAuthConfig(source, "")
+		if cfgErr != nil {
+			result.Message = cfgErr.Error()
+			result.Errors = append(result.Errors, cfgErr.Error())
 			result.Duration = time.Since(start)
 			se.finishSync(source.ID, result)
 			return result
@@ -805,7 +847,7 @@ func (se *SyncEngine) SyncSource(ctx context.Context, source *db.Source) *SyncRe
 			return result
 		}
 		token := &oauth2.Token{RefreshToken: refreshToken}
-		sourceClient, err = NewOAuthClient(ctx, source.SourceURL, se.googleOAuth, token)
+		sourceClient, err = NewOAuthClient(ctx, source.SourceURL, perSourceOAuthConfig, token)
 	} else {
 		sourceClient, err = NewClient(source.SourceURL, source.SourceUsername, sourcePassword)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,20 +42,32 @@ type Config struct {
 	GoogleOAuth  GoogleOAuthConfig
 }
 
-// GoogleOAuthConfig holds the OAuth2 credentials for Google Calendar
-// source_type. These are optional: if ClientID or ClientSecret is unset,
-// the feature is disabled and the web UI surfaces a clear error instead
-// of letting the user start a flow that would 401 at the end. (#70)
+// GoogleOAuthConfig holds instance-level Google OAuth2 settings. As of
+// #79, the per-source client ID and client secret were moved out of
+// global env vars and into the sources table, so each user (or each
+// source) carries its own Google Cloud project credentials. This
+// struct now only holds the redirect URL, which must be a single
+// stable value because Google requires the redirect URI to be
+// pre-registered in each Cloud Console project — every user is
+// expected to register the same URL (this instance's callback) in
+// their own project. (#70 + #79)
 type GoogleOAuthConfig struct {
-	ClientID     string
-	ClientSecret string
-	RedirectURL  string
+	// RedirectURL is the OAuth callback URL the application uses for
+	// every Google source on this instance. Computed from BASE_URL by
+	// default; can be overridden via GOOGLE_OAUTH_REDIRECT_URL for
+	// non-standard deployments. Must match what each user registers
+	// in their Google Cloud Console.
+	RedirectURL string
 }
 
-// Enabled returns true if both client ID and secret are configured.
-// Call this before routing users into the Google OAuth flow.
+// Enabled reports whether the Google OAuth feature can be used on
+// this instance at all. As of #79 the per-source credentials live in
+// the database, so the only instance-level requirement is a redirect
+// URL. The feature is enabled iff RedirectURL is non-empty. The web
+// handlers still validate that each individual source has its own
+// client_id and client_secret before starting a flow.
 func (g GoogleOAuthConfig) Enabled() bool {
-	return g.ClientID != "" && g.ClientSecret != ""
+	return g.RedirectURL != ""
 }
 
 // AlertConfig holds alerting configuration.
@@ -275,16 +287,16 @@ func Load() (*Config, error) {
 	}
 	cfg.Alerts.InitialBackoffMS = initialBackoffMS
 
-	// Google OAuth2 configuration (optional; feature is disabled when
-	// ClientID/ClientSecret are unset). (#70)
-	cfg.GoogleOAuth.ClientID = getEnv("GOOGLE_OAUTH_CLIENT_ID", "")
-	cfg.GoogleOAuth.ClientSecret = getEnv("GOOGLE_OAUTH_CLIENT_SECRET", "")
+	// Google OAuth2 configuration. As of #79 the per-source client_id
+	// and client_secret live in the sources table, not in env vars.
+	// The only instance-level setting is the redirect URL, which
+	// defaults to <BASE_URL>/auth/oauth/google/callback unless
+	// explicitly overridden. Operators no longer need to set
+	// GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET — those env
+	// vars are intentionally ignored to avoid drift between the global
+	// values and the per-source values stored in the DB.
 	cfg.GoogleOAuth.RedirectURL = getEnv("GOOGLE_OAUTH_REDIRECT_URL", "")
-	// If redirect URL is not explicitly set but base URL is, default to
-	// <BASE_URL>/auth/oauth/google/callback. This matches the route
-	// registered in internal/web/routes.go and means operators usually
-	// only need to set the client id and secret.
-	if cfg.GoogleOAuth.RedirectURL == "" && cfg.Server.BaseURL != "" && cfg.GoogleOAuth.ClientID != "" {
+	if cfg.GoogleOAuth.RedirectURL == "" && cfg.Server.BaseURL != "" {
 		cfg.GoogleOAuth.RedirectURL = strings.TrimRight(cfg.Server.BaseURL, "/") + "/auth/oauth/google/callback"
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -787,9 +787,11 @@ func TestConfigStructs(t *testing.T) {
 }
 
 // TestGoogleOAuthConfig_Enabled verifies the feature-gate helper. (#70)
-// Enabled() must return true only when BOTH client id and secret are
-// set; a half-configured state must be reported as disabled so we
-// don't start a flow that would fail at the token exchange step.
+// Enabled() reports whether the Google OAuth feature is usable on
+// this instance. As of #79 the per-source client_id / client_secret
+// live in the database (not in env vars), so the only instance-level
+// requirement is the redirect URL. Per-source credential validation
+// happens in the web handlers when each source is created.
 func TestGoogleOAuthConfig_Enabled(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -797,29 +799,14 @@ func TestGoogleOAuthConfig_Enabled(t *testing.T) {
 		wantOk bool
 	}{
 		{
-			name:   "both unset",
+			name:   "empty config is disabled",
 			cfg:    GoogleOAuthConfig{},
 			wantOk: false,
 		},
 		{
-			name:   "only client id",
-			cfg:    GoogleOAuthConfig{ClientID: "x"},
-			wantOk: false,
-		},
-		{
-			name:   "only client secret",
-			cfg:    GoogleOAuthConfig{ClientSecret: "y"},
-			wantOk: false,
-		},
-		{
-			name:   "both set",
-			cfg:    GoogleOAuthConfig{ClientID: "x", ClientSecret: "y"},
+			name:   "redirect url set is enabled",
+			cfg:    GoogleOAuthConfig{RedirectURL: "https://example.com/auth/oauth/google/callback"},
 			wantOk: true,
-		},
-		{
-			name:   "redirect url alone is not enough",
-			cfg:    GoogleOAuthConfig{RedirectURL: "https://example.com/cb"},
-			wantOk: false,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -230,6 +230,19 @@ func (db *DB) migrate() error {
 		// AES-256-GCM Encryptor, same as source_password. Nullable
 		// because non-Google sources never populate it.
 		`ALTER TABLE sources ADD COLUMN oauth_refresh_token TEXT`,
+
+		// Migration (#79): Add per-source Google OAuth client
+		// credentials. Previously the OAuth client_id and client_secret
+		// were global env vars (GOOGLE_OAUTH_CLIENT_ID /
+		// GOOGLE_OAUTH_CLIENT_SECRET) shared across every Google source
+		// on the instance. That blocked multi-tenant use cases where
+		// each user has their own Google Cloud project. Now each
+		// Google source carries its own client_id (plain text — public
+		// identifier) and client_secret (encrypted, same as
+		// oauth_refresh_token and source_password). NULL for non-Google
+		// sources.
+		`ALTER TABLE sources ADD COLUMN google_client_id TEXT`,
+		`ALTER TABLE sources ADD COLUMN google_client_secret TEXT`,
 	}
 
 	for _, migration := range migrations {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -180,21 +180,34 @@ type Source struct {
 	// OAuthRefreshToken holds the encrypted Google OAuth2 refresh
 	// token for source_type == google. Empty for all other source
 	// types. Never exposed via JSON. (#70)
-	OAuthRefreshToken string           `json:"-"`
-	DestURL           string           `json:"dest_url"`
-	DestUsername      string           `json:"dest_username"`
-	DestPassword      string           `json:"-"` // Never include in JSON
-	SyncInterval      int              `json:"sync_interval"`
-	SyncDaysPast      int              `json:"sync_days_past"` // How many days in the past to sync (0 = unlimited)
-	SyncDirection     SyncDirection    `json:"sync_direction"`
-	ConflictStrategy  ConflictStrategy `json:"conflict_strategy"`
-	SelectedCalendars []CalendarConfig `json:"selected_calendars"` // Calendar configs to sync (empty = all)
-	Enabled           bool             `json:"enabled"`
-	LastSyncAt        *time.Time       `json:"last_sync_at"`
-	LastSyncStatus    SyncStatus       `json:"last_sync_status"`
-	LastSyncMessage   string           `json:"last_sync_message"`
-	CreatedAt         time.Time        `json:"created_at"`
-	UpdatedAt         time.Time        `json:"updated_at"`
+	OAuthRefreshToken string `json:"-"`
+	// GoogleClientID is the per-source Google Cloud OAuth client ID
+	// (public identifier — stored in plain text). Populated for
+	// source_type == google. Empty for all other source types. (#79)
+	//
+	// Per-source rather than global so each user can use their own
+	// Google Cloud project; the previous global env-var design only
+	// allowed a single client_id across the entire instance.
+	GoogleClientID string `json:"google_client_id,omitempty"`
+	// GoogleClientSecret is the per-source Google Cloud OAuth client
+	// secret, encrypted via the application's AES-256-GCM Encryptor
+	// (same as SourcePassword and OAuthRefreshToken). Populated for
+	// source_type == google. Never exposed via JSON. (#79)
+	GoogleClientSecret string           `json:"-"`
+	DestURL            string           `json:"dest_url"`
+	DestUsername       string           `json:"dest_username"`
+	DestPassword       string           `json:"-"` // Never include in JSON
+	SyncInterval       int              `json:"sync_interval"`
+	SyncDaysPast       int              `json:"sync_days_past"` // How many days in the past to sync (0 = unlimited)
+	SyncDirection      SyncDirection    `json:"sync_direction"`
+	ConflictStrategy   ConflictStrategy `json:"conflict_strategy"`
+	SelectedCalendars  []CalendarConfig `json:"selected_calendars"` // Calendar configs to sync (empty = all)
+	Enabled            bool             `json:"enabled"`
+	LastSyncAt         *time.Time       `json:"last_sync_at"`
+	LastSyncStatus     SyncStatus       `json:"last_sync_status"`
+	LastSyncMessage    string           `json:"last_sync_message"`
+	CreatedAt          time.Time        `json:"created_at"`
+	UpdatedAt          time.Time        `json:"updated_at"`
 }
 
 // SyncState represents the synchronization state for a calendar.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -106,11 +106,27 @@ func (db *DB) CreateSource(source *Source) error {
 		oauthRefreshToken = &t
 	}
 
+	// Per-source Google OAuth credentials (#79). Stored as nullable
+	// text columns; non-Google sources leave both empty. ClientID is
+	// plain text (a public identifier), ClientSecret is encrypted
+	// upstream by the API handler.
+	var googleClientID *string
+	if source.GoogleClientID != "" {
+		t := source.GoogleClientID
+		googleClientID = &t
+	}
+	var googleClientSecret *string
+	if source.GoogleClientSecret != "" {
+		t := source.GoogleClientSecret
+		googleClientSecret = &t
+	}
+
 	query := `INSERT INTO sources (
 		id, user_id, name, source_type, source_url, source_username, source_password,
 		dest_url, dest_username, dest_password, sync_interval, sync_days_past, sync_direction, conflict_strategy,
-		selected_calendars, enabled, last_sync_status, oauth_refresh_token, created_at, updated_at
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		selected_calendars, enabled, last_sync_status, oauth_refresh_token,
+		google_client_id, google_client_secret, created_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	_, err := db.conn.Exec(query,
 		source.ID, source.UserID, source.Name, source.SourceType,
@@ -118,7 +134,9 @@ func (db *DB) CreateSource(source *Source) error {
 		source.DestURL, source.DestUsername, source.DestPassword,
 		source.SyncInterval, source.SyncDaysPast, source.SyncDirection, source.ConflictStrategy,
 		selectedCalendarsJSON, source.Enabled,
-		source.LastSyncStatus, oauthRefreshToken, source.CreatedAt, source.UpdatedAt,
+		source.LastSyncStatus, oauthRefreshToken,
+		googleClientID, googleClientSecret,
+		source.CreatedAt, source.UpdatedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create source: %w", err)
@@ -129,11 +147,13 @@ func (db *DB) CreateSource(source *Source) error {
 
 // sourceSelectColumns is the canonical SELECT column list for sources,
 // kept in one place so every query + scan function stays in lockstep.
-// (#70) added oauth_refresh_token at the end so the positional scans
-// only needed a single new field.
+// (#70) added oauth_refresh_token at the end. (#79) appended
+// google_client_id and google_client_secret so per-source Google
+// credentials follow the same scan-positional contract.
 const sourceSelectColumns = `id, user_id, name, source_type, source_url, source_username, source_password,
 	dest_url, dest_username, dest_password, sync_interval, sync_days_past, sync_direction, conflict_strategy,
-	selected_calendars, enabled, last_sync_at, last_sync_status, last_sync_message, created_at, updated_at, oauth_refresh_token`
+	selected_calendars, enabled, last_sync_at, last_sync_status, last_sync_message, created_at, updated_at,
+	oauth_refresh_token, google_client_id, google_client_secret`
 
 // GetSourceByID returns a source by its ID.
 func (db *DB) GetSourceByID(id string) (*Source, error) {
@@ -234,18 +254,37 @@ func (db *DB) UpdateSource(source *Source) error {
 		oauthRefreshToken = &t
 	}
 
+	// Same COALESCE-on-empty rule for the per-source Google OAuth
+	// credentials (#79). A normal source-edit form does not re-collect
+	// the client secret from the user, so an empty value here means
+	// "no change" and must preserve the existing stored value.
+	var googleClientID *string
+	if source.GoogleClientID != "" {
+		t := source.GoogleClientID
+		googleClientID = &t
+	}
+	var googleClientSecret *string
+	if source.GoogleClientSecret != "" {
+		t := source.GoogleClientSecret
+		googleClientSecret = &t
+	}
+
 	query := `UPDATE sources SET
 		name = ?, source_type = ?, source_url = ?, source_username = ?, source_password = ?,
 		dest_url = ?, dest_username = ?, dest_password = ?, sync_interval = ?, sync_days_past = ?,
 		sync_direction = ?, conflict_strategy = ?, selected_calendars = ?, enabled = ?,
-		oauth_refresh_token = COALESCE(?, oauth_refresh_token), updated_at = ?
+		oauth_refresh_token = COALESCE(?, oauth_refresh_token),
+		google_client_id = COALESCE(?, google_client_id),
+		google_client_secret = COALESCE(?, google_client_secret),
+		updated_at = ?
 		WHERE id = ?`
 
 	result, err := db.conn.Exec(query,
 		source.Name, source.SourceType, source.SourceURL, source.SourceUsername, source.SourcePassword,
 		source.DestURL, source.DestUsername, source.DestPassword, source.SyncInterval, source.SyncDaysPast,
 		source.SyncDirection, source.ConflictStrategy, selectedCalendarsJSON, source.Enabled,
-		oauthRefreshToken, source.UpdatedAt, source.ID,
+		oauthRefreshToken, googleClientID, googleClientSecret,
+		source.UpdatedAt, source.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update source: %w", err)
@@ -491,6 +530,8 @@ func scanSource(row *sql.Row) (*Source, error) {
 	var syncDirection sql.NullString
 	var selectedCalendarsJSON sql.NullString
 	var oauthRefreshToken sql.NullString
+	var googleClientID sql.NullString
+	var googleClientSecret sql.NullString
 
 	err := row.Scan(
 		&source.ID, &source.UserID, &source.Name, &source.SourceType,
@@ -499,7 +540,8 @@ func scanSource(row *sql.Row) (*Source, error) {
 		&source.SyncInterval, &source.SyncDaysPast, &syncDirection, &source.ConflictStrategy,
 		&selectedCalendarsJSON, &source.Enabled,
 		&lastSyncAt, &source.LastSyncStatus, &lastSyncMessage,
-		&source.CreatedAt, &source.UpdatedAt, &oauthRefreshToken,
+		&source.CreatedAt, &source.UpdatedAt,
+		&oauthRefreshToken, &googleClientID, &googleClientSecret,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -519,6 +561,12 @@ func scanSource(row *sql.Row) (*Source, error) {
 	if oauthRefreshToken.Valid {
 		source.OAuthRefreshToken = oauthRefreshToken.String
 	}
+	if googleClientID.Valid {
+		source.GoogleClientID = googleClientID.String
+	}
+	if googleClientSecret.Valid {
+		source.GoogleClientSecret = googleClientSecret.String
+	}
 
 	// Decode selected_calendars from JSON (backward compatible)
 	if selectedCalendarsJSON.Valid {
@@ -536,6 +584,8 @@ func scanSourceFromRows(rows *sql.Rows) (*Source, error) {
 	var syncDirection sql.NullString
 	var selectedCalendarsJSON sql.NullString
 	var oauthRefreshToken sql.NullString
+	var googleClientID sql.NullString
+	var googleClientSecret sql.NullString
 
 	err := rows.Scan(
 		&source.ID, &source.UserID, &source.Name, &source.SourceType,
@@ -544,7 +594,8 @@ func scanSourceFromRows(rows *sql.Rows) (*Source, error) {
 		&source.SyncInterval, &source.SyncDaysPast, &syncDirection, &source.ConflictStrategy,
 		&selectedCalendarsJSON, &source.Enabled,
 		&lastSyncAt, &source.LastSyncStatus, &lastSyncMessage,
-		&source.CreatedAt, &source.UpdatedAt, &oauthRefreshToken,
+		&source.CreatedAt, &source.UpdatedAt,
+		&oauthRefreshToken, &googleClientID, &googleClientSecret,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan source: %w", err)
@@ -560,6 +611,12 @@ func scanSourceFromRows(rows *sql.Rows) (*Source, error) {
 	}
 	if oauthRefreshToken.Valid {
 		source.OAuthRefreshToken = oauthRefreshToken.String
+	}
+	if googleClientID.Valid {
+		source.GoogleClientID = googleClientID.String
+	}
+	if googleClientSecret.Valid {
+		source.GoogleClientSecret = googleClientSecret.String
 	}
 
 	// Decode selected_calendars from JSON (backward compatible)

--- a/internal/web/oauth_google.go
+++ b/internal/web/oauth_google.go
@@ -56,16 +56,24 @@ type googleUserinfo struct {
 	Name          string `json:"name"`
 }
 
-// googleOAuthConfig builds the oauth2.Config from handler config.
-// Returns nil if the feature is disabled on this instance (no client
-// id or secret set).
-func (h *Handlers) googleOAuthConfig() *oauth2.Config {
-	if !h.cfg.GoogleOAuth.Enabled() {
+// buildGoogleOAuthConfig assembles an oauth2.Config from per-request
+// credentials plus the instance-level redirect URL. As of #79 the
+// client ID and client secret are NOT stored in the global config —
+// each user provides their own when adding a Google source — so the
+// helper takes them as explicit parameters and the caller is
+// responsible for sourcing them (from the form during prepare, from
+// the pending session cookie during callback, or from the source row
+// during sync).
+//
+// Returns nil if the redirect URL is unset (the feature is fully
+// disabled on this instance) or if either credential is empty.
+func (h *Handlers) buildGoogleOAuthConfig(clientID, clientSecret string) *oauth2.Config {
+	if !h.cfg.GoogleOAuth.Enabled() || clientID == "" || clientSecret == "" {
 		return nil
 	}
 	return &oauth2.Config{
-		ClientID:     h.cfg.GoogleOAuth.ClientID,
-		ClientSecret: h.cfg.GoogleOAuth.ClientSecret,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
 		RedirectURL:  h.cfg.GoogleOAuth.RedirectURL,
 		Endpoint:     google.Endpoint,
 		Scopes: []string{
@@ -78,16 +86,20 @@ func (h *Handlers) googleOAuthConfig() *oauth2.Config {
 // APIPrepareGoogleSourceRequest is the payload the React SPA sends to
 // kick off a Google OAuth source. It contains only the fields the user
 // sets in the form — source_url/username/password are intentionally
-// omitted because they're filled in after OAuth completes.
+// omitted because they're filled in after OAuth completes. As of #79
+// the user must also provide their own google_client_id and
+// google_client_secret from their personal Google Cloud project.
 type APIPrepareGoogleSourceRequest struct {
-	Name             string `json:"name"`
-	SyncInterval     int    `json:"sync_interval"`
-	SyncDaysPast     int    `json:"sync_days_past"`
-	SyncDirection    string `json:"sync_direction"`
-	ConflictStrategy string `json:"conflict_strategy"`
-	DestURL          string `json:"dest_url"`
-	DestUsername     string `json:"dest_username"`
-	DestPassword     string `json:"dest_password"`
+	Name               string `json:"name"`
+	SyncInterval       int    `json:"sync_interval"`
+	SyncDaysPast       int    `json:"sync_days_past"`
+	SyncDirection      string `json:"sync_direction"`
+	ConflictStrategy   string `json:"conflict_strategy"`
+	DestURL            string `json:"dest_url"`
+	DestUsername       string `json:"dest_username"`
+	DestPassword       string `json:"dest_password"`
+	GoogleClientID     string `json:"google_client_id"`
+	GoogleClientSecret string `json:"google_client_secret"`
 }
 
 // APIPrepareGoogleSourceResponse tells the SPA where to send the user
@@ -115,10 +127,9 @@ func (h *Handlers) APIPrepareGoogleSource(c *gin.Context) {
 		return
 	}
 
-	cfg := h.googleOAuthConfig()
-	if cfg == nil {
+	if !h.cfg.GoogleOAuth.Enabled() {
 		c.JSON(http.StatusServiceUnavailable, gin.H{
-			"error": "Google OAuth is not configured on this server. Set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET.",
+			"error": "Google OAuth is not configured on this server (BASE_URL / GOOGLE_OAUTH_REDIRECT_URL must be set).",
 		})
 		return
 	}
@@ -134,6 +145,24 @@ func (h *Handlers) APIPrepareGoogleSource(c *gin.Context) {
 	if req.Name == "" || req.DestURL == "" || req.DestUsername == "" || req.DestPassword == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "Name and destination URL/username/password are required",
+		})
+		return
+	}
+
+	// Per-source Google OAuth credentials are required as of #79.
+	// Each user provides their own Google Cloud project credentials.
+	if req.GoogleClientID == "" || req.GoogleClientSecret == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Google OAuth client ID and client secret are required (from your Google Cloud project)",
+		})
+		return
+	}
+
+	// Build the per-request oauth2.Config from the form credentials.
+	cfg := h.buildGoogleOAuthConfig(req.GoogleClientID, req.GoogleClientSecret)
+	if cfg == nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid Google OAuth credentials in request",
 		})
 		return
 	}
@@ -170,6 +199,16 @@ func (h *Handlers) APIPrepareGoogleSource(c *gin.Context) {
 		return
 	}
 
+	// Encrypt the per-source Google client secret before stashing it
+	// in the session cookie. The cookie itself is signed (gorilla
+	// sessions) but we still encrypt at the application layer so a
+	// stolen cookie does not expose the plaintext secret. (#79)
+	encGoogleClientSecret, err := h.encryptor.Encrypt(req.GoogleClientSecret)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to encrypt Google client secret"})
+		return
+	}
+
 	state, err := auth.GenerateState()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate state"})
@@ -185,15 +224,17 @@ func (h *Handlers) APIPrepareGoogleSource(c *gin.Context) {
 	}
 
 	pending := &auth.PendingGoogleSource{
-		State:            state,
-		Name:             req.Name,
-		SyncInterval:     req.SyncInterval,
-		SyncDaysPast:     req.SyncDaysPast,
-		SyncDirection:    req.SyncDirection,
-		ConflictStrategy: req.ConflictStrategy,
-		DestURL:          req.DestURL,
-		DestUsername:     req.DestUsername,
-		DestPasswordEnc:  encDestPwd,
+		State:                 state,
+		Name:                  req.Name,
+		SyncInterval:          req.SyncInterval,
+		SyncDaysPast:          req.SyncDaysPast,
+		SyncDirection:         req.SyncDirection,
+		ConflictStrategy:      req.ConflictStrategy,
+		DestURL:               req.DestURL,
+		DestUsername:          req.DestUsername,
+		DestPasswordEnc:       encDestPwd,
+		GoogleClientID:        req.GoogleClientID,
+		GoogleClientSecretEnc: encGoogleClientSecret,
 	}
 	if err := h.session.SetPendingGoogleSource(c.Writer, c.Request, pending); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save pending source"})
@@ -225,8 +266,7 @@ func (h *Handlers) APIPrepareGoogleSource(c *gin.Context) {
 // prepare endpoint first, they'll be bounced back to /sources/add
 // with an error.
 func (h *Handlers) GoogleOAuthStart(c *gin.Context) {
-	cfg := h.googleOAuthConfig()
-	if cfg == nil {
+	if !h.cfg.GoogleOAuth.Enabled() {
 		c.Redirect(http.StatusFound, "/sources/add?error=google_not_configured")
 		return
 	}
@@ -245,8 +285,7 @@ func (h *Handlers) GoogleOAuthStart(c *gin.Context) {
 // reads the pending form data from the session, creates the real
 // Source row, and redirects back to /sources.
 func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
-	cfg := h.googleOAuthConfig()
-	if cfg == nil {
+	if !h.cfg.GoogleOAuth.Enabled() {
 		c.Redirect(http.StatusFound, "/sources/add?error=google_not_configured")
 		return
 	}
@@ -278,13 +317,42 @@ func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
 		return
 	}
 
+	// Read back the pending form data BEFORE exchanging the code, so
+	// we have the per-source client_id and client_secret to build the
+	// oauth2.Config that the exchange call needs. As of #79 these
+	// credentials live on each source, not in global env vars, so the
+	// pending session cookie is the only place they exist between the
+	// prepare step and this callback. GetPendingGoogleSource also
+	// clears the cookie.
+	pending, err := h.session.GetPendingGoogleSource(c.Writer, c.Request)
+	if err != nil {
+		log.Printf("Google OAuth callback: no pending source in session: %v", err)
+		c.Redirect(http.StatusFound, "/sources/add?error=pending_expired")
+		return
+	}
+
+	// Decrypt the client secret just long enough to build the
+	// oauth2.Config. We re-encrypt it later for storage on the
+	// Source row using h.encryptor.Encrypt.
+	googleClientSecret, err := h.encryptor.Decrypt(pending.GoogleClientSecretEnc)
+	if err != nil {
+		log.Printf("Google OAuth callback: failed to decrypt pending Google client secret: %v", err)
+		c.Redirect(http.StatusFound, "/sources/add?error=encrypt_failed")
+		return
+	}
+	cfg := h.buildGoogleOAuthConfig(pending.GoogleClientID, googleClientSecret)
+	if cfg == nil {
+		log.Printf("Google OAuth callback: pending source had invalid Google credentials")
+		c.Redirect(http.StatusFound, "/sources/add?error=google_not_configured")
+		return
+	}
+
 	// Exchange the authorization code for an access + refresh token.
 	// This hits https://oauth2.googleapis.com/token with the client
 	// secret; it MUST happen server-side, never in the browser.
 	token, err := cfg.Exchange(c.Request.Context(), code)
 	if err != nil {
 		log.Printf("Google OAuth callback: code exchange failed: %v", err)
-		_, _ = h.session.GetPendingGoogleSource(c.Writer, c.Request)
 		c.Redirect(http.StatusFound, "/sources/add?error=exchange_failed")
 		return
 	}
@@ -296,7 +364,6 @@ func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
 		// can't proceed — a source without a refresh token can't
 		// sync past the first access token expiry.
 		log.Printf("Google OAuth callback: Google did not return a refresh token")
-		_, _ = h.session.GetPendingGoogleSource(c.Writer, c.Request)
 		c.Redirect(http.StatusFound, "/sources/add?error=no_refresh_token")
 		return
 	}
@@ -307,17 +374,7 @@ func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
 	email, err := fetchGoogleUserEmail(c.Request.Context(), cfg, token)
 	if err != nil {
 		log.Printf("Google OAuth callback: failed to fetch user email: %v", err)
-		_, _ = h.session.GetPendingGoogleSource(c.Writer, c.Request)
 		c.Redirect(http.StatusFound, "/sources/add?error=userinfo_failed")
-		return
-	}
-
-	// Read back the pending form data. GetPendingGoogleSource also
-	// clears the cookie.
-	pending, err := h.session.GetPendingGoogleSource(c.Writer, c.Request)
-	if err != nil {
-		log.Printf("Google OAuth callback: no pending source in session: %v", err)
-		c.Redirect(http.StatusFound, "/sources/add?error=pending_expired")
 		return
 	}
 
@@ -369,22 +426,35 @@ func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
 		conflictStrategy = db.ConflictSourceWins
 	}
 
+	// Re-encrypt the Google client secret for storage on the Source
+	// row. We held it in plaintext only for the duration of the
+	// cfg.Exchange call above; the value-at-rest in synced_events
+	// must always be encrypted.
+	encGoogleClientSecret, err := h.encryptor.Encrypt(googleClientSecret)
+	if err != nil {
+		log.Printf("Google OAuth callback: failed to encrypt Google client secret for storage: %v", err)
+		c.Redirect(http.StatusFound, "/sources/add?error=encrypt_failed")
+		return
+	}
+
 	source := &db.Source{
-		UserID:            session.UserID,
-		Name:              pending.Name,
-		SourceType:        db.SourceTypeGoogle,
-		SourceURL:         sourceURL,
-		SourceUsername:    email, // Informational only; OAuth doesn't use it
-		SourcePassword:    "",    // Intentionally empty for OAuth sources
-		OAuthRefreshToken: encRefreshToken,
-		DestURL:           pending.DestURL,
-		DestUsername:      pending.DestUsername,
-		DestPassword:      pending.DestPasswordEnc,
-		SyncInterval:      syncInterval,
-		SyncDaysPast:      syncDaysPast,
-		SyncDirection:     syncDirection,
-		ConflictStrategy:  conflictStrategy,
-		Enabled:           true,
+		UserID:             session.UserID,
+		Name:               pending.Name,
+		SourceType:         db.SourceTypeGoogle,
+		SourceURL:          sourceURL,
+		SourceUsername:     email, // Informational only; OAuth doesn't use it
+		SourcePassword:     "",    // Intentionally empty for OAuth sources
+		OAuthRefreshToken:  encRefreshToken,
+		GoogleClientID:     pending.GoogleClientID,
+		GoogleClientSecret: encGoogleClientSecret,
+		DestURL:            pending.DestURL,
+		DestUsername:       pending.DestUsername,
+		DestPassword:       pending.DestPasswordEnc,
+		SyncInterval:       syncInterval,
+		SyncDaysPast:       syncDaysPast,
+		SyncDirection:      syncDirection,
+		ConflictStrategy:   conflictStrategy,
+		Enabled:            true,
 	}
 
 	if err := h.db.CreateSource(source); err != nil {

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CalBridgeSync</title>
-    <script type="module" crossorigin src="/assets/index-aeidQp52.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Dphe-pvq.css">
+    <script type="module" crossorigin src="/assets/index-Bjsil5E3.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BLOeowkf.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/pages/SourceAdd.tsx
+++ b/web/src/pages/SourceAdd.tsx
@@ -7,7 +7,7 @@ import type { SourceFormData, Calendar } from '../types';
 // Google OAuth callback redirects back with when something goes
 // wrong. Keep this in sync with internal/web/oauth_google.go. (#70)
 const GOOGLE_OAUTH_ERRORS: Record<string, string> = {
-  google_not_configured: 'Google OAuth is not configured on this server. Ask your admin to set GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET.',
+  google_not_configured: 'Google OAuth is not configured on this server. The instance redirect URL must be set (BASE_URL or GOOGLE_OAUTH_REDIRECT_URL).',
   invalid_state: 'OAuth state mismatch. Please start the flow again.',
   google_denied: 'You denied the Google consent request.',
   missing_code: 'Google did not return an authorization code.',
@@ -43,6 +43,8 @@ export default function SourceAdd() {
     sync_direction: 'one_way',
     conflict_strategy: 'source_wins',
     selected_calendars: [],
+    google_client_id: '',
+    google_client_secret: '',
   });
 
   // Surface Google OAuth errors returned by the backend callback as a
@@ -143,6 +145,13 @@ export default function SourceAdd() {
         // Google sources take a different path: hand the form to the
         // prepare endpoint, then redirect to Google's consent screen.
         // The backend callback creates the source and redirects back. (#70)
+        // As of #79 the user provides their own per-source Google
+        // Cloud OAuth credentials, so we pass them along.
+        if (!form.google_client_id || !form.google_client_secret) {
+          setError('Google OAuth Client ID and Client Secret are required');
+          setLoading(false);
+          return;
+        }
         const { redirect_url } = await prepareGoogleSource({
           name: form.name,
           sync_interval: form.sync_interval,
@@ -152,6 +161,8 @@ export default function SourceAdd() {
           dest_url: form.dest_url,
           dest_username: form.dest_username,
           dest_password: form.dest_password,
+          google_client_id: form.google_client_id,
+          google_client_secret: form.google_client_secret,
         });
         window.location.href = redirect_url;
         return;
@@ -282,17 +293,52 @@ export default function SourceAdd() {
                 </h3>
 
                 {isGoogleOAuth ? (
-                  /* Google sources use OAuth2 — no URL/username/password fields. (#70) */
-                  <div className="p-4 rounded border border-zinc-700 bg-black/30 space-y-3">
-                    <p className="text-sm text-white">
-                      Google Calendar requires OAuth2. When you click <span className="font-semibold">Connect Google Account & Save</span>, you'll be redirected to Google to sign in and approve calendar access.
-                    </p>
-                    <p className="text-xs text-gray-400">
-                      calbridgesync will store a refresh token so it can sync on your behalf. You can revoke access at any time at <a href="https://myaccount.google.com/permissions" className="text-red-400 underline" target="_blank" rel="noreferrer">myaccount.google.com/permissions</a>.
-                    </p>
-                    <p className="text-xs text-gray-500">
-                      Your admin must have configured <code className="text-red-400">GOOGLE_OAUTH_CLIENT_ID</code> and <code className="text-red-400">GOOGLE_OAUTH_CLIENT_SECRET</code> on this server for this to work.
-                    </p>
+                  /* Google sources use OAuth2 with per-source credentials (#79). */
+                  <div className="space-y-4">
+                    <div className="p-4 rounded border border-zinc-700 bg-black/30 space-y-3">
+                      <p className="text-sm text-white">
+                        Google Calendar requires OAuth2. Provide your own Google Cloud project credentials below — each user supplies their own client ID and secret instead of relying on a shared instance-wide value.
+                      </p>
+                      <p className="text-xs text-gray-400">
+                        Create a project at <a href="https://console.cloud.google.com" className="text-red-400 underline" target="_blank" rel="noreferrer">console.cloud.google.com</a>, enable the Google Calendar API, create an OAuth 2.0 Client ID (Web application), and add this app's callback URL to the authorized redirect URIs.
+                      </p>
+                      <p className="text-xs text-gray-400">
+                        When you click <span className="font-semibold">Connect Google Account &amp; Save</span>, you'll be redirected to Google to approve calendar access. You can revoke access at any time at <a href="https://myaccount.google.com/permissions" className="text-red-400 underline" target="_blank" rel="noreferrer">myaccount.google.com/permissions</a>.
+                      </p>
+                    </div>
+                    <div>
+                      <label htmlFor="google_client_id" className="block text-sm font-medium text-gray-300 mb-1">
+                        Google OAuth Client ID
+                      </label>
+                      <input
+                        type="text"
+                        name="google_client_id"
+                        id="google_client_id"
+                        value={form.google_client_id || ''}
+                        onChange={handleChange}
+                        required
+                        autoComplete="off"
+                        placeholder="123456789012-abc...apps.googleusercontent.com"
+                        className="w-full"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="google_client_secret" className="block text-sm font-medium text-gray-300 mb-1">
+                        Google OAuth Client Secret
+                      </label>
+                      <input
+                        type="password"
+                        name="google_client_secret"
+                        id="google_client_secret"
+                        value={form.google_client_secret || ''}
+                        onChange={handleChange}
+                        required
+                        autoComplete="new-password"
+                        placeholder="GOCSPX-..."
+                        className="w-full"
+                      />
+                      <p className="text-xs text-gray-500 mt-1">Stored encrypted at rest (AES-256-GCM). Never shown back after saving.</p>
+                    </div>
                   </div>
                 ) : (
                   <>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -61,6 +61,11 @@ export interface PrepareGoogleSourceRequest {
   dest_url: string;
   dest_username: string;
   dest_password: string;
+  // Per-source Google OAuth credentials (#79). The user provides
+  // their own Google Cloud project client_id + client_secret instead
+  // of relying on a global env-var configured value.
+  google_client_id: string;
+  google_client_secret: string;
 }
 
 export interface PrepareGoogleSourceResponse {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -75,6 +75,10 @@ export interface SourceFormData {
   sync_direction: 'one_way' | 'two_way';
   conflict_strategy: string;
   selected_calendars: CalendarConfig[];
+  // Per-source Google OAuth credentials (#79). Only populated when
+  // source_type === 'google'. Empty for all other source types.
+  google_client_id?: string;
+  google_client_secret?: string;
 }
 
 export interface ApiResponse<T> {


### PR DESCRIPTION
## Summary

- Moves Google OAuth client_id and client_secret from global env vars (`GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET`) to per-source DB columns so each user on a multi-tenant instance can use their own Google Cloud project
- Redirect URL stays instance-level (Google requires it pre-registered in every Cloud Console project)
- Frontend collects credentials in the source-add form with links to console.cloud.google.com; encrypted with AES-256-GCM like `source_password`

## Why

On a single instance hosting multiple users, only one of them could use Google Calendar as a source because they'd share whichever `client_id` the operator registered as a global env var. This PR unblocks multi-tenant use.

## Scope

- **DB:** `google_client_id` (TEXT nullable, public identifier) and `google_client_secret` (TEXT nullable, AES-256-GCM encrypted) added to `sources`
- **Models / queries:** Source struct, `CreateSource`, `UpdateSource` (with `COALESCE` preservation on empty edit), `scanSource` / `scanSourceFromRows` all updated in lockstep
- **Config:** `GoogleOAuthConfig` stripped to just `RedirectURL`; `Enabled()` reports instance-level availability; per-source credential validation moves to web handlers
- **Session:** `PendingGoogleSource` carries `GoogleClientID` + `GoogleClientSecretEnc` through the OAuth flow (ciphertext-only in cookie)
- **Sync engine:** `SyncEngine` drops the global `*oauth2.Config` field; `buildPerSourceGoogleOAuthConfig` assembles a fresh config per sync from the row; Google sources without credentials hard-fail with a clear error
- **Handlers:** `APIPrepareGoogleSource` validates new fields, encrypts client secret before session storage; `GoogleOAuthCallback` reads pending data before the code exchange so it can build the per-request config
- **Frontend:** `SourceAdd.tsx` adds two fields for Google sources with help text; `types/index.ts` and `services/api.ts` updated

## Deployment impact

**Can remove from deployment env:**
- ~~`GOOGLE_OAUTH_CLIENT_ID`~~
- ~~`GOOGLE_OAUTH_CLIENT_SECRET`~~

**Must keep (or derive from BASE_URL):**
- `GOOGLE_OAUTH_REDIRECT_URL`

**Upgrade note:** existing Google sources must be re-added through the web UI so the new columns get populated. Sync attempts against a pre-migration Google source fail fast with a clear error (not a silent Basic Auth fallback that would 401 anyway).

## Test plan

- [x] `go build ./...` passes
- [x] `go test -count=1 ./...` passes (all 11 packages green)
- [x] `npm run build` in web/ passes (vite build succeeds, dist hashes updated)
- [ ] Manual: re-add a Google source via the web UI on staging instance
- [ ] Manual: verify sync succeeds against the re-added source
- [ ] Manual: verify existing iCloud / generic CalDAV sources are unaffected (no breakage on non-Google source types)

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)