### PR TITLE
fix: defense-in-depth from deep repo audit (#91)

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -800,7 +800,17 @@ func (db *DB) DeleteAllMalformedEventsForUser(userID string) (int64, error) {
 		return 0, fmt.Errorf("failed to delete all malformed events: %w", err)
 	}
 
-	deleted, _ := result.RowsAffected()
+	// Previously this call discarded the RowsAffected error with
+	// `deleted, _ :=`. Every other RowsAffected call in this file
+	// checks the error; this one did not, which meant a driver-side
+	// RowsAffected failure would silently return deleted=0 and make
+	// the UI show "0 events deleted" even if the DELETE itself
+	// succeeded. Matches the pattern used at line ~254/275/297/314/
+	// 361/446/619/768/889. (#91)
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected for delete all malformed events: %w", err)
+	}
 	return deleted, nil
 }
 

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -159,49 +160,56 @@ func ValidateOrigin() gin.HandlerFunc {
 	}
 }
 
-// allowedOriginsCache caches the parsed origins to avoid repeated parsing and logging
-var allowedOriginsCache []string
-var allowedOriginsCacheInit bool
+// allowedOriginsCache caches the parsed origins so we don't re-parse
+// ALLOWED_ORIGINS on every request. Initialization is guarded by
+// allowedOriginsOnce so the parse happens exactly once even under
+// concurrent first-request load. Previously this was a bool +
+// unguarded slice pair, which was a data race: two goroutines hitting
+// the first request simultaneously could read and write the slice
+// with no synchronization, and under the Go memory model that's
+// undefined behavior — in the worst case a half-initialized slice
+// visible to one goroutine before the cache init flag flipped
+// could cause a request to fail-open or fail-closed depending on
+// scheduling. sync.Once gives us a lock-free fast path after the
+// initialization completes, so the per-request cost stays trivial. (#91)
+var (
+	allowedOriginsCache []string
+	allowedOriginsOnce  sync.Once
+)
 
 // getAllowedOrigins returns the list of allowed origins for CSRF validation.
 // SECURITY: In production, always set ALLOWED_ORIGINS environment variable.
 func getAllowedOrigins() []string {
-	// Return cached value if already initialized
-	if allowedOriginsCacheInit {
-		return allowedOriginsCache
-	}
+	allowedOriginsOnce.Do(func() {
+		origins := []string{}
 
-	origins := []string{}
-
-	// Add from environment variable if set
-	if env := os.Getenv("ALLOWED_ORIGINS"); env != "" {
-		for _, o := range strings.Split(env, ",") {
-			origin := strings.TrimSpace(o)
-			if isValidOrigin(origin) {
-				origins = append(origins, origin)
-			} else {
-				log.Printf("WARNING: Invalid origin in ALLOWED_ORIGINS ignored: %s", origin)
+		// Add from environment variable if set
+		if env := os.Getenv("ALLOWED_ORIGINS"); env != "" {
+			for _, o := range strings.Split(env, ",") {
+				origin := strings.TrimSpace(o)
+				if isValidOrigin(origin) {
+					origins = append(origins, origin)
+				} else {
+					log.Printf("WARNING: Invalid origin in ALLOWED_ORIGINS ignored: %s", origin)
+				}
 			}
 		}
-	}
 
-	// Fall back to localhost origins for development only
-	if len(origins) == 0 {
-		// Log warning - this should not happen in production
-		log.Printf("WARNING: ALLOWED_ORIGINS not set - using localhost defaults. Set ALLOWED_ORIGINS in production!")
-		origins = []string{
-			"http://localhost:8080",
-			"http://localhost:5173",
-			"http://127.0.0.1:8080",
-			"http://127.0.0.1:5173",
+		// Fall back to localhost origins for development only
+		if len(origins) == 0 {
+			// Log warning - this should not happen in production
+			log.Printf("WARNING: ALLOWED_ORIGINS not set - using localhost defaults. Set ALLOWED_ORIGINS in production!")
+			origins = []string{
+				"http://localhost:8080",
+				"http://localhost:5173",
+				"http://127.0.0.1:8080",
+				"http://127.0.0.1:5173",
+			}
 		}
-	}
 
-	// Cache the result
-	allowedOriginsCache = origins
-	allowedOriginsCacheInit = true
-
-	return origins
+		allowedOriginsCache = origins
+	})
+	return allowedOriginsCache
 }
 
 // isValidOrigin validates that an origin string is a proper URL format.

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -220,7 +221,7 @@ func TestRequireJSONContentType(t *testing.T) {
 func TestValidateOrigin(t *testing.T) {
 	// Reset cache before tests
 	allowedOriginsCache = nil
-	allowedOriginsCacheInit = false
+	allowedOriginsOnce = sync.Once{}
 
 	t.Run("allows GET requests without origin", func(t *testing.T) {
 		w := httptest.NewRecorder()
@@ -264,7 +265,7 @@ func TestValidateOrigin(t *testing.T) {
 	t.Run("rejects POST without origin", func(t *testing.T) {
 		// Reset cache
 		allowedOriginsCache = nil
-		allowedOriginsCacheInit = false
+		allowedOriginsOnce = sync.Once{}
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
@@ -284,7 +285,7 @@ func TestValidateOrigin(t *testing.T) {
 	t.Run("allows POST with valid origin", func(t *testing.T) {
 		// Reset cache and set allowed origins
 		allowedOriginsCache = nil
-		allowedOriginsCacheInit = false
+		allowedOriginsOnce = sync.Once{}
 		os.Setenv("ALLOWED_ORIGINS", "http://localhost:8080")
 		defer os.Unsetenv("ALLOWED_ORIGINS")
 
@@ -304,7 +305,7 @@ func TestValidateOrigin(t *testing.T) {
 	t.Run("rejects POST with invalid origin", func(t *testing.T) {
 		// Reset cache and set allowed origins
 		allowedOriginsCache = nil
-		allowedOriginsCacheInit = false
+		allowedOriginsOnce = sync.Once{}
 		os.Setenv("ALLOWED_ORIGINS", "http://localhost:8080")
 		defer os.Unsetenv("ALLOWED_ORIGINS")
 
@@ -327,7 +328,7 @@ func TestValidateOrigin(t *testing.T) {
 	t.Run("extracts origin from referer", func(t *testing.T) {
 		// Reset cache and set allowed origins
 		allowedOriginsCache = nil
-		allowedOriginsCacheInit = false
+		allowedOriginsOnce = sync.Once{}
 		os.Setenv("ALLOWED_ORIGINS", "http://localhost:8080")
 		defer os.Unsetenv("ALLOWED_ORIGINS")
 
@@ -403,7 +404,7 @@ func TestGetAllowedOrigins(t *testing.T) {
 	t.Run("returns cached origins on subsequent calls", func(t *testing.T) {
 		// Reset cache
 		allowedOriginsCache = nil
-		allowedOriginsCacheInit = false
+		allowedOriginsOnce = sync.Once{}
 		os.Unsetenv("ALLOWED_ORIGINS")
 
 		// First call initializes cache
@@ -419,7 +420,7 @@ func TestGetAllowedOrigins(t *testing.T) {
 	t.Run("parses ALLOWED_ORIGINS environment variable", func(t *testing.T) {
 		// Reset cache
 		allowedOriginsCache = nil
-		allowedOriginsCacheInit = false
+		allowedOriginsOnce = sync.Once{}
 
 		os.Setenv("ALLOWED_ORIGINS", "http://localhost:8080,https://example.com")
 		defer os.Unsetenv("ALLOWED_ORIGINS")
@@ -449,7 +450,7 @@ func TestGetAllowedOrigins(t *testing.T) {
 	t.Run("uses localhost defaults when env not set", func(t *testing.T) {
 		// Reset cache
 		allowedOriginsCache = nil
-		allowedOriginsCacheInit = false
+		allowedOriginsOnce = sync.Once{}
 		os.Unsetenv("ALLOWED_ORIGINS")
 
 		origins := getAllowedOrigins()
@@ -474,7 +475,7 @@ func TestGetAllowedOrigins(t *testing.T) {
 	t.Run("ignores invalid origins in env", func(t *testing.T) {
 		// Reset cache
 		allowedOriginsCache = nil
-		allowedOriginsCacheInit = false
+		allowedOriginsOnce = sync.Once{}
 
 		os.Setenv("ALLOWED_ORIGINS", "http://valid.com,invalid,http://also-valid.com")
 		defer os.Unsetenv("ALLOWED_ORIGINS")
@@ -484,6 +485,42 @@ func TestGetAllowedOrigins(t *testing.T) {
 		// Should have 2 valid origins
 		if len(origins) != 2 {
 			t.Errorf("expected 2 valid origins, got %d: %v", len(origins), origins)
+		}
+	})
+
+	// TestGetAllowedOrigins_ConcurrentInit is a regression test for
+	// the data race fixed in #91. Previously getAllowedOrigins used
+	// an unguarded bool+slice pair for its cache, which meant
+	// concurrent first-request callers could observe a partially
+	// initialized cache. With sync.Once the initialization runs
+	// exactly once even under heavy concurrent load.
+	//
+	// Run this test under `go test -race` to actually catch
+	// regressions — a reintroduced race is only visible with the
+	// race detector enabled.
+	t.Run("concurrent init is race-free", func(t *testing.T) {
+		allowedOriginsCache = nil
+		allowedOriginsOnce = sync.Once{}
+		os.Setenv("ALLOWED_ORIGINS", "http://one.example.com,http://two.example.com")
+		defer os.Unsetenv("ALLOWED_ORIGINS")
+
+		const workers = 64
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		results := make([][]string, workers)
+		for i := 0; i < workers; i++ {
+			i := i
+			go func() {
+				defer wg.Done()
+				results[i] = getAllowedOrigins()
+			}()
+		}
+		wg.Wait()
+
+		for i, got := range results {
+			if len(got) != 2 {
+				t.Errorf("worker %d: expected 2 origins, got %d: %v", i, len(got), got)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Two small defense-in-depth fixes from the ultra-deep audit pass. Neither has been observed in production but both are real latent bugs.

1. **\`allowedOriginsCache\` data race** — CSRF allowed-origins cache was an unguarded \`bool\` + \`[]string\` pair. Replaced with \`sync.Once\`-guarded slice. Regression test with 64 concurrent goroutines, verified under \`go test -race\`.
2. **\`DeleteAllMalformedEventsForUser\` RowsAffected error silently dropped** — one-liner, matches the pattern used by every other \`RowsAffected\` call in \`queries.go\`.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./...\` passes (all packages, no regressions)
- [x] \`go test -race -count=1 ./internal/web/... ./internal/db/...\` clean under the race detector
- [x] New \`TestGetAllowedOrigins/concurrent init is race-free\` test (64 goroutines) passes

## Related audit findings NOT in this PR

- \`planOrphanDeletion\` empty-dest guard: analyzed — candidate list is naturally empty when destEventMap is empty, so no data-safety risk. Adding a guard would improve observability only, deferred as non-urgent.
- \`shouldUpdateSourceFromDest\` nil asymmetry: may be intentional design. Needs maintainer decision before changing.
- \`ALLOWED_ORIGINS\` missing from \`docker-compose.yml\`: deployment config issue, not code. Flagged in the audit report for deployment-side cleanup.
- Alert SMTP pre-validation on user enable: UX design call — should a user be allowed to enable email alerts on an instance with no SMTP configured?
- Dashboard stats \`GetSyncLogs\` errors ignored: cosmetic — stats become 0 on DB failure instead of surfacing an error.

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)