### PR TITLE
fix: audit observability — surface silent errors in sync + scheduler + dashboard (#93)

### DIFF
--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -995,7 +995,17 @@ func (se *SyncEngine) syncCalendar(ctx context.Context, source *db.Source, sourc
 								SourceETag:   item.ETag,
 							}
 							if err := se.db.UpsertSyncedEvent(syncedEvent); err != nil {
-								log.Printf("Failed to upsert synced event record for %s: %v", event.UID, err)
+								// Previously this only logged. The next
+								// sync's previouslySyncedMap won't know
+								// this UID exists, so the forward pass
+								// may treat it as a new event and re-PUT
+								// it — wasted traffic, and potentially a
+								// duplicate if the parsed UID drifts.
+								// Surface as a Warning so operators see
+								// the DB write failure in SyncResult. (#93)
+								msg := fmt.Sprintf("Failed to upsert synced event record for %s: %v", event.UID, err)
+								log.Printf("%s", msg)
+								result.Warnings = append(result.Warnings, msg)
 							}
 						}
 					}
@@ -1025,7 +1035,17 @@ func (se *SyncEngine) syncCalendar(ctx context.Context, source *db.Source, sourc
 					// PutEvent convention.
 					if uid := extractUIDFromEventPath(destEventPath); uid != "" {
 						if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, uid); err != nil {
-							log.Printf("Failed to delete synced event record for %s: %v", uid, err)
+							// Same rationale as the UpsertSyncedEvent
+							// warning above: a failed DB cleanup means
+							// the next cycle's previouslySyncedMap
+							// still contains this UID even though it
+							// no longer exists on destination — the
+							// two-way deletion pass may then try to
+							// delete from source. Surface the failure
+							// so operators see it. (#93)
+							msg := fmt.Sprintf("Failed to delete synced event record for %s: %v", uid, err)
+							log.Printf("%s", msg)
+							result.Warnings = append(result.Warnings, msg)
 						}
 					}
 				}
@@ -1204,7 +1224,23 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 	updateStatus("fetching destination events")
 	destEvents, err := destClient.GetEvents(ctx, destCalendarPath, nil)
 	if err != nil {
-		log.Printf("Failed to get destination events (path: %s): %v", destCalendarPath, err)
+		// Previously this failure only logged and then proceeded with
+		// an empty destEvents slice. That silently masked a real
+		// destination failure — the rest of the sync would compute
+		// deltas against "zero destination events" and either mass-
+		// delete tracked UIDs (caught by the ratio guards from #80/#82)
+		// or mass-create them as if the destination was empty.
+		//
+		// Append to Warnings so operators actually see the failure
+		// surfaced in the sync result. Not escalated to result.Errors
+		// because one-way source_wins semantics can tolerate an
+		// empty-destination view — the ratio guards still protect
+		// against cascading deletions, and escalating to Errors would
+		// flip every transient destination fetch failure into a hard
+		// sync failure. Operator design call to tighten this further. (#93)
+		msg := fmt.Sprintf("Failed to get destination events (path: %s): %v - proceeding with empty destination view, ratio guards will protect against cascades", destCalendarPath, err)
+		log.Printf("%s", msg)
+		result.Warnings = append(result.Warnings, msg)
 		destEvents = []Event{}
 	}
 	log.Printf("Fetched %d events from destination calendar", len(destEvents))

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -64,6 +64,20 @@ type Job struct {
 	nextSyncAt time.Time
 }
 
+// consecutiveSkipWarnThreshold is the number of consecutive
+// executeSync skips on the same source that triggers a WARNING log
+// line. Each skip happens because the previous sync for that source
+// is still holding its per-source mutex — either legitimately slow
+// or hung. The liveness watchdog (#43) catches fully frozen
+// goroutines on a longer horizon; this counter catches the
+// slow-but-not-frozen case earlier so operators have a chance to
+// intervene (widen sync_interval, check CalDAV server health)
+// before the watchdog alert fires. Tunable via future env var if
+// needed; 3 is an empirical default — one skip is noise, three in
+// a row means the sync interval is too tight or something is
+// genuinely stuck. (#93)
+const consecutiveSkipWarnThreshold = 3
+
 // Scheduler manages background sync jobs.
 type Scheduler struct {
 	db         *db.DB
@@ -85,6 +99,15 @@ type Scheduler struct {
 	// on the hot path of job lookups.
 	heartbeatsMu sync.RWMutex
 	heartbeats   map[string]time.Time
+
+	// skipCounts tracks consecutive executeSync skips per source so
+	// the scheduler can escalate from a normal-volume log line to a
+	// WARNING after consecutiveSkipWarnThreshold in a row. Reset to
+	// zero every time a source successfully acquires its sync lock.
+	// Separate mutex from mu to keep the hot path of job lookups
+	// uncontended. (#93)
+	skipCountsMu sync.Mutex
+	skipCounts   map[string]int
 }
 
 // New creates a new scheduler.
@@ -99,7 +122,27 @@ func New(database *db.DB, syncEngine *caldav.SyncEngine, notifier *notify.Notifi
 		ctx:        ctx,
 		cancel:     cancel,
 		heartbeats: make(map[string]time.Time),
+		skipCounts: make(map[string]int),
 	}
+}
+
+// incrementSkipCount bumps the consecutive skip count for a source
+// and returns the new value. Safe for concurrent callers. (#93)
+func (s *Scheduler) incrementSkipCount(sourceID string) int {
+	s.skipCountsMu.Lock()
+	defer s.skipCountsMu.Unlock()
+	s.skipCounts[sourceID]++
+	return s.skipCounts[sourceID]
+}
+
+// resetSkipCount zeros the consecutive skip count for a source.
+// Called when the source successfully acquires its sync lock so a
+// single-cycle slowdown doesn't leave a stale counter behind. Safe
+// for concurrent callers. (#93)
+func (s *Scheduler) resetSkipCount(sourceID string) {
+	s.skipCountsMu.Lock()
+	defer s.skipCountsMu.Unlock()
+	delete(s.skipCounts, sourceID)
 }
 
 // Start loads all enabled sources and starts their sync jobs.
@@ -577,11 +620,24 @@ func (s *Scheduler) executeSync(sourceID string) {
 	// Get per-source lock to prevent concurrent syncs
 	lock := s.getSyncLock(sourceID)
 
-	// Try to acquire lock without blocking - skip if another sync is in progress
+	// Try to acquire lock without blocking - skip if another sync is in
+	// progress. Repeated skips on the same source indicate that a sync
+	// cycle is taking longer than the scheduler interval — either a
+	// hang the liveness watchdog will catch, or a legitimately slow
+	// sync (large calendar, network latency, CalDAV server throttling)
+	// that the operator should know about. Track per-source consecutive
+	// skip counts and escalate to a WARNING at the threshold so
+	// operators have a visible signal before the watchdog fires. (#93)
 	if !lock.TryLock() {
-		log.Printf("Skipping sync for source %s - another sync is already in progress", sourceID)
+		skips := s.incrementSkipCount(sourceID)
+		if skips >= consecutiveSkipWarnThreshold {
+			log.Printf("WARNING: sync for source %s has been skipped %d consecutive times — previous cycle is still running. Check for hung CalDAV calls or widen sync_interval.", sourceID, skips)
+		} else {
+			log.Printf("Skipping sync for source %s - another sync is already in progress (consecutive skips: %d)", sourceID, skips)
+		}
 		return
 	}
+	s.resetSkipCount(sourceID)
 	defer lock.Unlock()
 
 	// Get the source

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -140,6 +140,97 @@ func TestGetSyncLock(t *testing.T) {
 	})
 }
 
+// TestSkipCountAccounting covers the consecutive-skip counter helpers
+// introduced in #93 so the WARNING-on-threshold escalation has a
+// regression test. The counter is per-source, increments on skip,
+// resets on successful lock acquisition, and must be safe for
+// concurrent callers.
+func TestSkipCountAccounting(t *testing.T) {
+	t.Run("increment returns running total", func(t *testing.T) {
+		sched := New(nil, nil, nil)
+
+		if got := sched.incrementSkipCount("source-1"); got != 1 {
+			t.Errorf("first increment: want 1, got %d", got)
+		}
+		if got := sched.incrementSkipCount("source-1"); got != 2 {
+			t.Errorf("second increment: want 2, got %d", got)
+		}
+		if got := sched.incrementSkipCount("source-1"); got != 3 {
+			t.Errorf("third increment: want 3 (threshold), got %d", got)
+		}
+	})
+
+	t.Run("different sources counted independently", func(t *testing.T) {
+		sched := New(nil, nil, nil)
+
+		sched.incrementSkipCount("source-a")
+		sched.incrementSkipCount("source-a")
+		sched.incrementSkipCount("source-b")
+
+		if got := sched.incrementSkipCount("source-a"); got != 3 {
+			t.Errorf("source-a: want 3, got %d", got)
+		}
+		if got := sched.incrementSkipCount("source-b"); got != 2 {
+			t.Errorf("source-b: want 2, got %d", got)
+		}
+	})
+
+	t.Run("reset zeros the counter", func(t *testing.T) {
+		sched := New(nil, nil, nil)
+
+		sched.incrementSkipCount("source-1")
+		sched.incrementSkipCount("source-1")
+		sched.incrementSkipCount("source-1")
+		sched.resetSkipCount("source-1")
+
+		if got := sched.incrementSkipCount("source-1"); got != 1 {
+			t.Errorf("after reset: want 1, got %d", got)
+		}
+	})
+
+	t.Run("reset on unknown source is safe", func(t *testing.T) {
+		sched := New(nil, nil, nil)
+
+		// Must not panic on sources that never incremented
+		sched.resetSkipCount("never-seen")
+	})
+
+	t.Run("concurrent increments are race-free", func(t *testing.T) {
+		// Sanity check; run under `go test -race` to prove no race.
+		sched := New(nil, nil, nil)
+
+		const workers = 32
+		const per = 10
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for i := 0; i < workers; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < per; j++ {
+					sched.incrementSkipCount("hot-source")
+				}
+			}()
+		}
+		wg.Wait()
+
+		// Final count via one more increment so we don't need a
+		// getter — expected is workers*per + 1
+		want := workers*per + 1
+		if got := sched.incrementSkipCount("hot-source"); got != want {
+			t.Errorf("concurrent final count: want %d, got %d", want, got)
+		}
+	})
+
+	t.Run("threshold constant is sensible", func(t *testing.T) {
+		if consecutiveSkipWarnThreshold < 2 {
+			t.Errorf("threshold %d is too sensitive — one skip should not warn", consecutiveSkipWarnThreshold)
+		}
+		if consecutiveSkipWarnThreshold > 10 {
+			t.Errorf("threshold %d is too lax — more than 10 skips means the warning comes too late to be actionable", consecutiveSkipWarnThreshold)
+		}
+	})
+}
+
 func TestRemoveJob(t *testing.T) {
 	t.Run("remove non-existent job is safe", func(t *testing.T) {
 		sched := New(nil, nil, nil)

--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -337,10 +337,18 @@ func (h *Handlers) APIDashboardStats(c *gin.Context) {
 		}
 	}
 
-	// Count syncs today
+	// Count syncs today. GetSyncLogs errors are logged but not
+	// surfaced — the dashboard still renders with whatever stats we
+	// could compute. Previously this used `logs, _ :=` which hid the
+	// error entirely; operators couldn't tell the difference between
+	// "no syncs today" and "DB query failed." (#93)
 	today := time.Now().Truncate(24 * time.Hour)
 	for _, s := range sources {
-		logs, _ := h.db.GetSyncLogs(s.ID, 100)
+		logs, err := h.db.GetSyncLogs(s.ID, 100)
+		if err != nil {
+			log.Printf("APIDashboardStats: failed to load sync logs for source %s: %v", s.ID, err)
+			continue
+		}
 		for _, l := range logs {
 			if l.CreatedAt.After(today) {
 				stats.SyncsToday++
@@ -374,10 +382,18 @@ func (h *Handlers) APISyncHistory(c *gin.Context) {
 	}
 
 	// Collect all logs for all sources
-	// Use 2000 to support up to ~10 days at 192 syncs/day per source
+	// Use 2000 to support up to ~10 days at 192 syncs/day per source.
+	// GetSyncLogs errors are logged but not surfaced so a partial
+	// DB failure degrades the chart gracefully — previously this
+	// used `logs, _ :=` which silently treated a DB failure as
+	// "zero logs." (#93)
 	var allLogs []*db.SyncLog
 	for _, s := range sources {
-		logs, _ := h.db.GetSyncLogs(s.ID, 2000)
+		logs, err := h.db.GetSyncLogs(s.ID, 2000)
+		if err != nil {
+			log.Printf("APISyncHistory: failed to load sync logs for source %s: %v", s.ID, err)
+			continue
+		}
 		allLogs = append(allLogs, logs...)
 	}
 


### PR DESCRIPTION
## Summary

Four observability fixes from the deferred audit list. Every fix surfaces errors that were being silently dropped or only log-printed, so operators can see them in the usual places (\`SyncResult.Warnings\`, server logs). **None change sync engine semantics or data-safety logic.**

## What's in the box

1. **Scheduler consecutive-skip WARNING escalation** — \`internal/scheduler/scheduler.go\`. Tracks per-source consecutive skip counts and escalates to a WARNING log line after \`consecutiveSkipWarnThreshold = 3\` in a row. Previously, a slow-but-not-frozen sync cycle would silently keep dropping ticks until the liveness watchdog fired at its threshold — too late for operators to intervene (widen sync_interval, check CalDAV health). New helpers \`incrementSkipCount\` / \`resetSkipCount\` with their own mutex for race-free concurrent access.

2. **Destination fetch failure → \`result.Warnings\`** — \`internal/caldav/sync.go\` ~line 1205. Previously \`destEvents = []Event{}\` on error with no surfacing; now the failure shows up in SyncResult. Kept as Warning (not Errors) because one-way source_wins can tolerate an empty-dest view and the ratio guards already protect against cascades. Escalation to hard-error is a deferred operator design call.

3. **WebDAV-Sync path: synced_events DB errors → \`result.Warnings\`** — \`internal/caldav/sync.go\` ~lines 997 and 1027. Both \`UpsertSyncedEvent\` and \`DeleteSyncedEvent\` failures (after successful CalDAV ops) now surface in SyncResult instead of being silently log-only.

4. **Dashboard stats \`GetSyncLogs\` errors** — \`internal/web/api_handlers.go\` ~lines 343 and 380. Replaced \`logs, _ := ...\` with proper error-check + log + continue. Stats degrade gracefully instead of silently showing \"0 syncs\" on DB failure.

## New tests

\`TestSkipCountAccounting\` in \`internal/scheduler/scheduler_test.go\`:
- increment returns running total
- different sources counted independently
- reset zeros the counter
- reset on unknown source is safe
- concurrent increments are race-free (32 goroutines × 10 increments)
- threshold constant is sensible (2 ≤ threshold ≤ 10)

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./...\` passes (all 11 packages green, no regressions)
- [x] \`go test -race -count=1 ./internal/scheduler/...\` clean on the new skip-count concurrent test
- [ ] Manual on staging: verify the WARNING escalation fires when sync_interval is artificially tight
- [ ] Manual on staging: verify dashboard renders gracefully when a source is temporarily broken

## Related

- #78 / #79 / #80 / #82 — the data-loss hotfix wave that precipitated the deep audit
- #89 / #90 — hotfix: synced_events only scrubbed on successful two-way DELETE
- #91 / #92 — audit defense-in-depth: sync.Once race + RowsAffected error
- #85 / #86 — per-source Google OAuth refactor (task #39)
- #87 / #88 — \`cmd/purge-uid\` operator tool

Closes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)