### PR TITLE
fix(config): hard-fail on missing ALLOWED_ORIGINS in production (#101)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,6 +353,39 @@ func (c *Config) Validate(ctx context.Context) error {
 		return fmt.Errorf("%w: DEFAULT_DEST_URL: %w", ErrValidationFailed, err)
 	}
 
+	// ALLOWED_ORIGINS is required in production mode. See
+	// validateAllowedOriginsForProd for the full rationale.
+	if err := validateAllowedOriginsForProd(c.IsProduction(), os.Getenv("ALLOWED_ORIGINS")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateAllowedOriginsForProd enforces that ALLOWED_ORIGINS is
+// set when running in production mode. Returns nil in development
+// mode or when the env var is non-empty. Returns a wrapped
+// ErrValidationFailed otherwise.
+//
+// Without this check, internal/web/middleware.go falls back to
+// localhost-only defaults — correct for dev, but silently blocks
+// every legitimate non-localhost origin in prod. The bug path the
+// audit flagged (#101) was: operator deploys to a public domain,
+// forgets ALLOWED_ORIGINS, CORS rejects every request, user sees
+// a blank dashboard, operator blames the app. Fail-fast at
+// startup instead.
+//
+// Extracted as a package-private helper so the rule can be
+// unit-tested without spinning up a full Config.Validate() call
+// chain (which also hits ValidateOIDCIssuer, a network call).
+// The caller in Validate() passes the pre-computed inputs.
+func validateAllowedOriginsForProd(isProd bool, allowedOriginsEnv string) error {
+	if !isProd {
+		return nil
+	}
+	if allowedOriginsEnv == "" {
+		return fmt.Errorf("%w: ALLOWED_ORIGINS must be set in production mode (comma-separated list of allowed origins, e.g. https://calbridgesync.example.com) - the localhost-only defaults silently block non-localhost CORS requests", ErrValidationFailed)
+	}
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -826,6 +827,90 @@ func TestGoogleOAuthConfig_Enabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.cfg.Enabled(); got != tt.wantOk {
 				t.Errorf("Enabled() = %v, want %v", got, tt.wantOk)
+			}
+		})
+	}
+}
+
+// TestValidateAllowedOriginsForProd covers the production-mode
+// hard-fail from #101: if ENVIRONMENT=production and ALLOWED_ORIGINS
+// is unset, Config.Validate must return an error. Development mode
+// and explicitly-set production values must pass cleanly.
+func TestValidateAllowedOriginsForProd(t *testing.T) {
+	cases := []struct {
+		name        string
+		isProd      bool
+		envVar      string
+		wantErr     bool
+		wantErrType error
+	}{
+		{
+			name:    "dev mode + empty is OK (localhost defaults)",
+			isProd:  false,
+			envVar:  "",
+			wantErr: false,
+		},
+		{
+			name:    "dev mode + explicit is OK",
+			isProd:  false,
+			envVar:  "http://localhost:3000",
+			wantErr: false,
+		},
+		{
+			name:        "prod mode + empty is a hard fail",
+			isProd:      true,
+			envVar:      "",
+			wantErr:     true,
+			wantErrType: ErrValidationFailed,
+		},
+		{
+			name:    "prod mode + single origin is OK",
+			isProd:  true,
+			envVar:  "https://calbridgesync.example.com",
+			wantErr: false,
+		},
+		{
+			name:    "prod mode + multiple origins is OK",
+			isProd:  true,
+			envVar:  "https://calbridgesync.example.com,https://admin.example.com",
+			wantErr: false,
+		},
+		{
+			// The validator only checks "non-empty." Format
+			// validation (isValidOrigin) happens later in
+			// middleware.go's getAllowedOrigins. A whitespace-only
+			// value makes it past this check but then gets logged
+			// as invalid by middleware and falls back to empty,
+			// which in turn blocks all non-empty origins. That's
+			// a deployment bug but not our job to catch here —
+			// the goal of this check is the far-more-common
+			// "operator forgot to set it" case.
+			name:    "prod mode + whitespace-only env passes (not our layer to format-check)",
+			isProd:  true,
+			envVar:  "   ",
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAllowedOriginsForProd(tc.isProd, tc.envVar)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil")
+				}
+				if tc.wantErrType != nil && !errors.Is(err, tc.wantErrType) {
+					t.Errorf("want error type %v, got %v", tc.wantErrType, err)
+				}
+				// The error message should mention ALLOWED_ORIGINS so
+				// operators can grep the startup logs and find it.
+				if !strings.Contains(err.Error(), "ALLOWED_ORIGINS") {
+					t.Errorf("error message must mention ALLOWED_ORIGINS for operator grep-ability, got: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Escalate the silent \`ALLOWED_ORIGINS\` fallback in production mode to a startup-time hard fail. Prevents the deployment hazard the audit flagged: operator forgets to set \`ALLOWED_ORIGINS\` → CORS rejects every non-localhost request → users see a blank dashboard → no startup signal pointing at the real cause.

## Change

- New package-private helper \`validateAllowedOriginsForProd(isProd bool, envVar string) error\` in \`internal/config/config.go\`
- Called from \`Config.Validate()\` after the other URL checks
- Development mode: unchanged (localhost defaults still work)
- Production mode: empty \`ALLOWED_ORIGINS\` → wrapped \`ErrValidationFailed\` at startup with an error message mentioning \`ALLOWED_ORIGINS\` for operator grep-ability

Extracted as a pure helper so the test can exercise the rule without going through \`Config.Validate()\` which calls \`ValidateOIDCIssuer\` (a real network lookup). Avoids pulling in a mock OIDC server for a 6-case table test.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./internal/config/...\` passes with new \`TestValidateAllowedOriginsForProd\` table
- [x] \`go test -count=1 ./...\` full suite green, no regressions

Table covers:
- dev + empty → pass
- dev + explicit → pass
- prod + empty → hard fail (with \`ALLOWED_ORIGINS\` in message)
- prod + single origin → pass
- prod + multiple origins → pass
- prod + whitespace-only → pass (format validation is middleware's job)

## Not in scope

- Moving the actual origin parsing from \`internal/web/middleware.go\` onto the Config struct — cleaner long-term design but bigger than warranted for this targeted fix
- Validating origin format in this layer (duplicates \`isValidOrigin\` in middleware)

Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)