### PR TITLE
fix(web): reject enabling email alerts when no SMTP configured (#103)

### DIFF
--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -1135,6 +1135,35 @@ func (h *Handlers) APIUpdateAlertPreferences(c *gin.Context) {
 		return
 	}
 
+	// Reject email_enabled=true when the instance has no SMTP
+	// configured (#103). Without this check, the Settings page
+	// happily accepts the toggle, the DB row is persisted, and
+	// the first alert send fails silently at notify.go:362 with
+	// `addr := ":587"` — then the 60-minute cooldown prevents
+	// any retry for an hour and the user thinks alerts are
+	// working until they aren't. Better to refuse at save time
+	// with a clear error pointing at the missing env var so the
+	// operator (or the user, via the operator) knows what to fix.
+	//
+	// We only fire this check when the request is TURNING ON
+	// email. If req.EmailEnabled is nil (unchanged), false
+	// (turning off), or the operator has configured SMTP, no
+	// error. We also don't check when disabling email on an
+	// instance with no SMTP — disabling something that was
+	// never going to work is harmless and the user shouldn't
+	// be blocked from cleaning up their own state.
+	//
+	// The h.cfg nil-check defends against test harnesses that
+	// construct a Handlers with a zero-value cfg — the existing
+	// setupTestHandlers helper does exactly this. Production
+	// code always passes a real Config via NewHandlers.
+	if req.EmailEnabled != nil && *req.EmailEnabled && h.cfg != nil && h.cfg.Alerts.SMTPHost == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Cannot enable email alerts: this instance has no SMTP configured. Ask your operator to set ALERT_SMTP_HOST / ALERT_SMTP_PORT / ALERT_SMTP_FROM (and ALERT_SMTP_USERNAME / ALERT_SMTP_PASSWORD if the server requires auth).",
+		})
+		return
+	}
+
 	prefs := &db.UserAlertPreferences{
 		UserID:          session.UserID,
 		EmailEnabled:    req.EmailEnabled,

--- a/internal/web/api_handlers_test.go
+++ b/internal/web/api_handlers_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/macjediwizard/calbridgesync/internal/auth"
+	"github.com/macjediwizard/calbridgesync/internal/config"
 	"github.com/macjediwizard/calbridgesync/internal/db"
 	"github.com/macjediwizard/calbridgesync/internal/scheduler"
 )
@@ -1571,6 +1572,150 @@ func TestValidateSourceInputUsernameLength(t *testing.T) {
 
 		if result == "" || !strings.Contains(result, "Destination username") {
 			t.Error("expected error about destination username length")
+		}
+	})
+}
+
+// TestAPIUpdateAlertPreferences_EmailEnableRejectedWhenNoSMTP covers the
+// regression for #103: the handler must reject a request that tries to
+// flip email_enabled to true when the operator hasn't configured SMTP,
+// because accepting it would save a DB row that results in silent
+// delivery failures for an hour (cooldown) on the first send attempt.
+func TestAPIUpdateAlertPreferences_EmailEnableRejectedWhenNoSMTP(t *testing.T) {
+	t.Run("prod with SMTP unset rejects email_enabled=true", func(t *testing.T) {
+		th := setupTestHandlers(t)
+		defer th.cleanup()
+
+		// Explicitly wire a Config with empty SMTPHost. The default
+		// setupTestHandlers doesn't populate cfg; we set it here
+		// for this one test.
+		th.handlers.cfg = &config.Config{
+			Alerts: config.AlertConfig{
+				SMTPHost: "",
+			},
+		}
+
+		user, err := th.db.GetOrCreateUser("alerts-test@example.com", "Alerts Tester")
+		if err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+
+		enable := true
+		reqBody := APIAlertPreferences{EmailEnabled: &enable}
+		body, _ := json.Marshal(reqBody)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPut, "/api/settings/alerts", strings.NewReader(string(body)))
+		c.Request.Header.Set("Content-Type", "application/json")
+		setAuthContext(c, user.ID, user.Email)
+
+		th.handlers.APIUpdateAlertPreferences(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want status 400, got %d: %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "SMTP") {
+			t.Errorf("error body must mention SMTP for operator discoverability, got: %s", w.Body.String())
+		}
+
+		// The DB row must NOT have been written.
+		prefs, err := th.db.GetUserAlertPreferences(user.ID)
+		if err != nil {
+			t.Fatalf("unexpected DB error: %v", err)
+		}
+		if prefs != nil {
+			t.Errorf("prefs row should not have been saved on validation error, got %+v", prefs)
+		}
+	})
+
+	t.Run("prod with SMTP configured accepts email_enabled=true", func(t *testing.T) {
+		th := setupTestHandlers(t)
+		defer th.cleanup()
+
+		th.handlers.cfg = &config.Config{
+			Alerts: config.AlertConfig{
+				SMTPHost: "smtp.example.com",
+				SMTPPort: 587,
+			},
+		}
+
+		user, err := th.db.GetOrCreateUser("alerts-ok@example.com", "Alerts OK")
+		if err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+
+		enable := true
+		reqBody := APIAlertPreferences{EmailEnabled: &enable}
+		body, _ := json.Marshal(reqBody)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPut, "/api/settings/alerts", strings.NewReader(string(body)))
+		c.Request.Header.Set("Content-Type", "application/json")
+		setAuthContext(c, user.ID, user.Email)
+
+		th.handlers.APIUpdateAlertPreferences(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("want status 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("email_enabled=false never blocked (user can disable even with no SMTP)", func(t *testing.T) {
+		th := setupTestHandlers(t)
+		defer th.cleanup()
+
+		th.handlers.cfg = &config.Config{
+			Alerts: config.AlertConfig{SMTPHost: ""},
+		}
+
+		user, err := th.db.GetOrCreateUser("alerts-disable@example.com", "Alerts Disable")
+		if err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+
+		disable := false
+		reqBody := APIAlertPreferences{EmailEnabled: &disable}
+		body, _ := json.Marshal(reqBody)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPut, "/api/settings/alerts", strings.NewReader(string(body)))
+		c.Request.Header.Set("Content-Type", "application/json")
+		setAuthContext(c, user.ID, user.Email)
+
+		th.handlers.APIUpdateAlertPreferences(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("disabling email should be allowed even without SMTP; want 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("nil cfg allows the request (test-harness compatibility)", func(t *testing.T) {
+		th := setupTestHandlers(t)
+		defer th.cleanup()
+		// Explicitly leave th.handlers.cfg as its default (nil)
+
+		user, err := th.db.GetOrCreateUser("alerts-nilcfg@example.com", "Alerts NilCfg")
+		if err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+
+		enable := true
+		reqBody := APIAlertPreferences{EmailEnabled: &enable}
+		body, _ := json.Marshal(reqBody)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPut, "/api/settings/alerts", strings.NewReader(string(body)))
+		c.Request.Header.Set("Content-Type", "application/json")
+		setAuthContext(c, user.ID, user.Email)
+
+		th.handlers.APIUpdateAlertPreferences(c)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("nil cfg should permit the request (existing test harness compatibility); want 200, got %d: %s", w.Code, w.Body.String())
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Reject \`email_enabled=true\` in \`APIUpdateAlertPreferences\` when the instance operator hasn't configured SMTP. Prevents the silent-failure mode the first-pass audit flagged: user enables email in Settings → DB row saved → first send fails at \`notify.go:362\` with \`addr := \":587\"\` → 60-minute cooldown masks the failure for an hour → user only notices when alerts don't arrive.

## Change

- \`internal/web/api_handlers.go\` \`APIUpdateAlertPreferences\`: add a gate after the webhook/cooldown validation that returns 400 with a clear, grep-able error when \`req.EmailEnabled == true\` and \`h.cfg.Alerts.SMTPHost == \"\"\`.
- \`h.cfg != nil\` guard keeps the existing \`setupTestHandlers\` harness compatible.
- New test \`TestAPIUpdateAlertPreferences_EmailEnableRejectedWhenNoSMTP\` with 4 subcases.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./internal/web/... -run TestAPIUpdateAlertPreferences\` — 4 subcases pass:
  - prod with SMTP unset → 400 with \"SMTP\" in body + DB row not written
  - prod with SMTP configured → 200
  - \`email_enabled=false\` never blocked
  - nil cfg permits the request
- [x] \`go test -count=1 ./...\` full suite green

## Not in scope

The larger alert-enablement semantics question from the audit (should env flags be a hard gate, or should users be able to bring their own per-user SMTP) is still deferred for your design decision. This fix is compatible with either direction.

## Related

- First-pass audit \"Real gap #1 — SMTP pre-validation\"
- #93 / #94 — audit observability
- #101 / #102 — audit ALLOWED_ORIGINS hard-fail (sibling fail-fast pattern)

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)