### PR TITLE
fix(caldav): surface remaining silent synced_events DB errors in fullSync (#107)

### DIFF
--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -1405,9 +1405,14 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 			_, existsOnSource := sourceEventMap[uid]
 			_, existsOnDest := destEventMap[uid]
 			if !existsOnSource && !existsOnDest {
-				// Event deleted from both - just clean up the record
+				// Event deleted from both - just clean up the record.
+				// Silent-log was the original pattern; surface to
+				// Warnings so operators see tracking-row leaks in the
+				// sync result instead of only in raw logs. (#108)
 				if err := se.db.DeleteSyncedEvent(source.ID, calendar.Path, syncedEvent.EventUID); err != nil {
-					log.Printf("Failed to delete synced event record: %v", err)
+					msg := fmt.Sprintf("Failed to delete orphaned synced event record for %s: %v", syncedEvent.EventUID, err)
+					log.Printf("%s", msg)
+					result.Warnings = append(result.Warnings, msg)
 				}
 			}
 		}
@@ -1730,6 +1735,15 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 	// sourceETag and destETag are what the next cycle will compare
 	// against to decide whether either side has changed — that is
 	// the fix for the infinite re-PUT loop in #79.
+	//
+	// We batch errors into a counter + first-error rather than
+	// appending one Warning per failing UID. A pathological DB
+	// outage could cause N failures where N == len(currentUIDs),
+	// which for a 1000-event calendar would flood SyncResult
+	// with 1000 near-identical warning strings. One aggregated
+	// warning is easier to read and still actionable. (#108)
+	upsertFailures := 0
+	var firstUpsertErr error
 	for uid, etags := range currentUIDs {
 		syncedEvent := &db.SyncedEvent{
 			SourceID:     source.ID,
@@ -1739,8 +1753,18 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 			DestETag:     etags.destETag,
 		}
 		if err := se.db.UpsertSyncedEvent(syncedEvent); err != nil {
-			log.Printf("Failed to upsert synced event: %v", err)
+			log.Printf("Failed to upsert synced event for %s: %v", uid, err)
+			upsertFailures++
+			if firstUpsertErr == nil {
+				firstUpsertErr = err
+			}
 		}
+	}
+	if upsertFailures > 0 {
+		result.Warnings = append(result.Warnings, fmt.Sprintf(
+			"Failed to upsert %d synced_events tracking rows at end of sync pass (first error: %v) - next cycle may retry unchanged events as if they were new",
+			upsertFailures, firstUpsertErr,
+		))
 	}
 
 	return result


### PR DESCRIPTION
## Summary

Cleanup pass on the audit's \"silently-dropped DB errors in fullSync\" finding. PR #94 covered the WebDAV-Sync path (~lines 997, 1027). This PR covers the two remaining sites in the \`fullSync\` main path.

## Sites fixed

1. **~line 1409, \"deleted from both\" cleanup loop** — leaked tracking rows on DB failure. Now appends to \`result.Warnings\`.

2. **~line 1741, end-of-pass upsert loop** — this is the critical one. Records every event's current \`(sourceETag, destETag)\` pair so the next cycle has a reference for the ETag compare that fixed the #79 infinite re-PUT loop. On DB failure the next cycle would see events as \"new to this relationship\" and false-positive retry. Now aggregates failures into a single Warning with a count + first-error:

> Failed to upsert N synced_events tracking rows at end of sync pass (first error: X) - next cycle may retry unchanged events as if they were new

Single-Warning aggregation because a pathological DB outage could cause every upsert to fail — for a 1000-event calendar that would flood \`SyncResult.Warnings\` with 1000 near-identical strings. The count is the signal; individual UIDs remain in the log lines.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./...\` all 11 packages green

No new tests in this PR — the fix is pure Warnings surfacing and the caldav test suite doesn't have interface-based DB mocking to exercise failure injection in these loops. Adding that scaffolding is a follow-up.

## Related

- #93 / #94 — audit observability (initial pass)
- #89 / #90 — unconditional synced_events delete hotfix
- #97 / #98 — performDeletionAndCleanup helper extraction
- First-pass audit items 9-10

Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)