### PR TITLE
fix(web): tighten HTML handler source lookups to eliminate existence oracle (#109)

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -381,18 +381,15 @@ func (h *Handlers) EditSourcePage(c *gin.Context) {
 	session := auth.GetCurrentUser(c)
 	sourceID := c.Param("id")
 
-	source, err := h.db.GetSourceByID(sourceID)
+	// Scoped lookup — unscoped GetSourceByID + post-hoc UserID
+	// check would return 403 on a valid source owned by another
+	// user, which leaks the existence of that source. Scoped
+	// lookup returns ErrNotFound uniformly for "wrong owner" and
+	// "no such ID," matching the pattern in api_handlers.go. (#109)
+	source, err := h.db.GetSourceByIDForUser(sourceID, session.UserID)
 	if err != nil {
 		c.HTML(http.StatusNotFound, "error.html", gin.H{
 			"error": "Source not found",
-		})
-		return
-	}
-
-	// Verify ownership
-	if source.UserID != session.UserID {
-		c.HTML(http.StatusForbidden, "error.html", gin.H{
-			"error": "Access denied",
 		})
 		return
 	}
@@ -412,15 +409,11 @@ func (h *Handlers) UpdateSource(c *gin.Context) {
 	session := auth.GetCurrentUser(c)
 	sourceID := c.Param("id")
 
-	source, err := h.db.GetSourceByID(sourceID)
+	// Scoped lookup — see EditSourcePage for the 403/404 oracle
+	// rationale. (#109)
+	source, err := h.db.GetSourceByIDForUser(sourceID, session.UserID)
 	if err != nil {
 		h.respondError(c, http.StatusNotFound, "Source not found")
-		return
-	}
-
-	// Verify ownership
-	if source.UserID != session.UserID {
-		h.respondError(c, http.StatusForbidden, "Access denied")
 		return
 	}
 
@@ -479,15 +472,10 @@ func (h *Handlers) DeleteSource(c *gin.Context) {
 	session := auth.GetCurrentUser(c)
 	sourceID := c.Param("id")
 
-	source, err := h.db.GetSourceByID(sourceID)
+	// Scoped lookup to avoid the 403/404 oracle. (#109)
+	_, err := h.db.GetSourceByIDForUser(sourceID, session.UserID)
 	if err != nil {
 		h.respondError(c, http.StatusNotFound, "Source not found")
-		return
-	}
-
-	// Verify ownership
-	if source.UserID != session.UserID {
-		h.respondError(c, http.StatusForbidden, "Access denied")
 		return
 	}
 
@@ -513,15 +501,10 @@ func (h *Handlers) TriggerSync(c *gin.Context) {
 	session := auth.GetCurrentUser(c)
 	sourceID := c.Param("id")
 
-	source, err := h.db.GetSourceByID(sourceID)
+	// Scoped lookup to avoid the 403/404 oracle. (#109)
+	_, err := h.db.GetSourceByIDForUser(sourceID, session.UserID)
 	if err != nil {
 		h.respondError(c, http.StatusNotFound, "Source not found")
-		return
-	}
-
-	// Verify ownership
-	if source.UserID != session.UserID {
-		h.respondError(c, http.StatusForbidden, "Access denied")
 		return
 	}
 
@@ -543,15 +526,10 @@ func (h *Handlers) ToggleSource(c *gin.Context) {
 	session := auth.GetCurrentUser(c)
 	sourceID := c.Param("id")
 
-	source, err := h.db.GetSourceByID(sourceID)
+	// Scoped lookup to avoid the 403/404 oracle. (#109)
+	source, err := h.db.GetSourceByIDForUser(sourceID, session.UserID)
 	if err != nil {
 		h.respondError(c, http.StatusNotFound, "Source not found")
-		return
-	}
-
-	// Verify ownership
-	if source.UserID != session.UserID {
-		h.respondError(c, http.StatusForbidden, "Access denied")
 		return
 	}
 
@@ -583,18 +561,11 @@ func (h *Handlers) ViewLogs(c *gin.Context) {
 	session := auth.GetCurrentUser(c)
 	sourceID := c.Param("id")
 
-	source, err := h.db.GetSourceByID(sourceID)
+	// Scoped lookup to avoid the 403/404 oracle. (#109)
+	source, err := h.db.GetSourceByIDForUser(sourceID, session.UserID)
 	if err != nil {
 		c.HTML(http.StatusNotFound, "error.html", gin.H{
 			"error": "Source not found",
-		})
-		return
-	}
-
-	// Verify ownership
-	if source.UserID != session.UserID {
-		c.HTML(http.StatusForbidden, "error.html", gin.H{
-			"error": "Access denied",
 		})
 		return
 	}


### PR DESCRIPTION
## Summary

Six HTML handlers in \`internal/web/handlers.go\` were using \"unscoped \`GetSourceByID\` → post-hoc \`source.UserID != session.UserID\` check → 403 on mismatch.\" Refactor them to use \`GetSourceByIDForUser\` (the same pattern the API handlers already use).

**Not an IDOR** — the ownership check is always present — but the pattern has three downsides:

1. **403/404 existence oracle.** A request for a valid source ID owned by another user returned 403 \"Access denied\"; a non-existent ID returned 404 \"Source not found.\" That leaks the existence of sources across users. With the scoped lookup, both return 404 uniformly.
2. **Inconsistency with \`api_handlers.go\`** which already used the scoped pattern.
3. **Efficiency:** single scoped query instead of lookup + compare.

## Sites refactored

- \`EditSourcePage\`
- \`UpdateSource\`
- \`DeleteSource\` (uses \`_, err\` since the source struct was unused)
- \`TriggerSync\` (also \`_, err\`)
- \`ToggleSource\`
- \`ViewLogs\`

Net -29 lines of duplicated ownership-check boilerplate.

## Unchanged callers

- \`internal/db/queries_test.go\` — internal tests, no user context
- \`internal/scheduler/scheduler.go\` — background daemon with no user session

Both are legitimate unscoped usages.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./...\` all 11 packages green

No new tests — the refactor preserves the \"unauthorized returns an error response\" semantic; the only change is the status code from 403 to 404 for the unauthorized case. Existing tests don't assert on that specific code.

## Related

- First-pass audit: flagged the API handlers as clean (they were) but didn't look at the HTML handlers

Closes #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)