### PR TITLE
fix(auth): use constant-time comparison for CSRF token validation (#111)

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"crypto/subtle"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -76,8 +77,26 @@ func ValidateCSRF(sm *SessionManager) gin.HandlerFunc {
 			csrfToken = c.GetHeader("X-CSRF-Token")
 		}
 
-		// Validate token
-		if csrfToken == "" || csrfToken != session.CSRFToken {
+		// Validate token with a constant-time comparison so the
+		// comparison loop's timing does not reveal the token
+		// byte-by-byte. Go's default `!=` on strings short-circuits
+		// on the first mismatching byte, which in theory lets an
+		// attacker measure response latency and deduce prefix
+		// length. In practice the CSRF token is 32 random bytes
+		// behind HTTPS and the network jitter swamps any timing
+		// signal, so this fix is defense-in-depth rather than a
+		// practical exploit fix — but subtle.ConstantTimeCompare
+		// is free and the wrong default is the kind of thing that
+		// will come up in a security audit or the next static
+		// analyzer pass. Matches the standard library guidance
+		// for comparing MACs and tokens. (#111)
+		//
+		// subtle.ConstantTimeCompare requires equal-length inputs
+		// and panics on nil; the csrfToken == "" short-circuit
+		// handles the zero-length case, and we convert to []byte
+		// so the comparison operates on raw bytes rather than
+		// Go's string-interning fast path.
+		if csrfToken == "" || subtle.ConstantTimeCompare([]byte(csrfToken), []byte(session.CSRFToken)) != 1 {
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "invalid CSRF token"})
 			return
 		}


### PR DESCRIPTION
## Summary

Replace \`csrfToken != session.CSRFToken\` with \`subtle.ConstantTimeCompare\` so the comparison duration is independent of content. Matches standard library guidance for MAC/token comparisons.

## Practical exploitability

**Low.** CSRF tokens are 32 random bytes behind HTTPS; network jitter swamps any timing signal. This is defense-in-depth, not an exploit fix. But the wrong default is exactly the kind of thing that lights up static analyzers, security audits, and \"all secret comparisons should be constant-time\" lint rules. Easier to ship the correct primitive once than re-argue the exploitability every time.

## Change

\`\`\`go
// Before
if csrfToken == \"\" || csrfToken != session.CSRFToken { ... }

// After
if csrfToken == \"\" || subtle.ConstantTimeCompare([]byte(csrfToken), []byte(session.CSRFToken)) != 1 { ... }
\`\`\`

Empty-string short-circuit stays to handle zero-length cleanly.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./internal/auth/...\` existing \`TestValidateCSRF\` suite passes
- [x] \`go test -count=1 ./...\` full suite green

No new tests — the change is observationally identical for every input; only the comparison primitive changed.

## Related

- First-pass audit validated \"authorization / CSRF\" as clean but missed this one primitive. Caught on the targeted security sweep during the overnight wave.

Closes #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)