### PR TITLE
fix(web): constant-time OAuth state comparison in Google callback (#113)

### DIFF
--- a/internal/web/oauth_google.go
+++ b/internal/web/oauth_google.go
@@ -24,6 +24,7 @@ package web
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -253,9 +254,15 @@ func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
 
 	// Validate state BEFORE anything else — this is the CSRF check.
 	// GetOAuthState atomically reads and clears the state cookie.
+	// Compared constant-time because queryState is attacker-
+	// controllable (comes from the Google redirect query string)
+	// and savedState is secret (our server-generated random value
+	// stashed in the session cookie). Same rationale as the CSRF
+	// token comparison fix in #111. (#113)
 	queryState := c.Query("state")
 	savedState, err := h.session.GetOAuthState(c.Writer, c.Request)
-	if err != nil || savedState == "" || savedState != googleOAuthStatePrefix+queryState {
+	expectedState := googleOAuthStatePrefix + queryState
+	if err != nil || savedState == "" || subtle.ConstantTimeCompare([]byte(savedState), []byte(expectedState)) != 1 {
 		log.Printf("Google OAuth callback: state mismatch (saved=%q query=%q err=%v)", savedState, queryState, err)
 		c.Redirect(http.StatusFound, "/sources/add?error=invalid_state")
 		return
@@ -323,8 +330,10 @@ func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
 
 	// Cross-check: the state in the pending source cookie must
 	// match the state we just validated. This is belt-and-braces on
-	// top of the state cookie CSRF check.
-	if pending.State != queryState {
+	// top of the state cookie CSRF check. Constant-time comparison
+	// for the same reason as above — queryState is attacker-
+	// controllable, pending.State is server-side secret. (#113)
+	if subtle.ConstantTimeCompare([]byte(pending.State), []byte(queryState)) != 1 {
 		log.Printf("Google OAuth callback: pending state mismatch (pending=%q query=%q)", pending.State, queryState)
 		c.Redirect(http.StatusFound, "/sources/add?error=state_mismatch")
 		return


### PR DESCRIPTION
## Summary

Second installment of the \"constant-time comparison for secret tokens\" sweep started in PR #112. \`internal/web/oauth_google.go\` compared the OAuth state from the Google redirect query string against the server-stashed state with \`!=\` at two sites; both now use \`crypto/subtle.ConstantTimeCompare\`.

1. **Line 258** — state validation before the code exchange. \`savedState\` is secret (session cookie), \`queryState\` is attacker-controllable.
2. **Line 327** — belt-and-braces pending-state cross-check.

## Exploitability

Low. Same analysis as #112: random tokens behind HTTPS + network jitter swamps timing signal. Defense-in-depth only. But the wrong default is exactly what lights up security audits and static analyzers. Fix is free.

## Interaction with PR #86

PR #86 (per-source Google OAuth refactor) also touches \`oauth_google.go\` and restructures the callback handler. **Merge conflict expected** — both PRs modify the same logical region. Conflict resolution is trivial (keep both PR #86's structural changes and this PR's constant-time primitive). Either merge order works.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./internal/web/...\` passes
- [x] \`go test -count=1 ./...\` full suite green

No new tests — behavior observationally identical; only the comparison primitive changed.

## Related

- #111 / #112 — CSRF constant-time comparison (same pattern)
- #85 / #86 — per-source Google OAuth refactor (conflict expected)

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)