### PR TITLE
fix(caldav): cap response body reads with io.LimitReader to prevent OOM (#119)

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -37,6 +37,19 @@ var (
 const (
 	defaultTimeout = 300 * time.Second // 5 minutes default for slow CalDAV servers like iCloud
 	minTLSVersion  = tls.VersionTLS12
+
+	// maxCalDAVResponseSize caps every io.ReadAll over a CalDAV
+	// response body so a misbehaving or malicious CalDAV server
+	// cannot force the daemon to allocate unbounded memory. The
+	// cap is generous (200 MB) — real PROPFIND / REPORT responses
+	// for a 5000-event calendar are typically in the low single-
+	// digit MB range, so this is five to ten orders of magnitude
+	// larger than any legitimate response we'd expect. The point
+	// is to catch the runaway case (infinite response, slowloris-
+	// style trickle, zip bomb) without false-flagging any real
+	// user workload. Matches the existing maxICSResponseSize
+	// convention in ics_client.go (which uses 50 MB for ICS feeds). (#119)
+	maxCalDAVResponseSize = 200 * 1024 * 1024
 )
 
 // Calendar represents a CalDAV calendar.
@@ -259,8 +272,10 @@ func (c *Client) getEventsViaList(ctx context.Context, calendarPath string, coll
 		return nil, fmt.Errorf("%w: unexpected status %d", ErrInvalidResponse, resp.StatusCode)
 	}
 
-	// Parse the multistatus response to get event paths
-	body, err := io.ReadAll(resp.Body)
+	// Parse the multistatus response to get event paths. Wrapped
+	// in io.LimitReader so a malicious or misbehaving CalDAV
+	// server cannot force an unbounded allocation. (#119)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxCalDAVResponseSize))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/internal/caldav/webdavsync.go
+++ b/internal/caldav/webdavsync.go
@@ -71,14 +71,22 @@ func (c *Client) SyncCollection(ctx context.Context, calendarPath, syncToken str
 		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotImplemented {
 			return nil, fmt.Errorf("WebDAV-Sync not supported")
 		}
-		body, readErr := io.ReadAll(resp.Body)
+		// Size-capped so an error response (which might be
+		// arbitrarily large under a misconfigured or malicious
+		// server) cannot force unbounded allocation. Error body
+		// is only used for the wrapped error message so a 200 MB
+		// cap is already absurdly generous for diagnostics. (#119)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxCalDAVResponseSize))
 		if readErr != nil {
 			return nil, fmt.Errorf("%w: unexpected status %d", ErrInvalidResponse, resp.StatusCode)
 		}
 		return nil, fmt.Errorf("%w: unexpected status %d: %s", ErrInvalidResponse, resp.StatusCode, string(body))
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	// Success path: cap the multistatus response the same way so
+	// a malicious server can't OOM the daemon via a runaway
+	// WebDAV-Sync response. (#119)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxCalDAVResponseSize))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}


### PR DESCRIPTION
## Summary

Three \`io.ReadAll(resp.Body)\` call sites in \`internal/caldav\` had no size cap. A misbehaving or malicious CalDAV server could force unbounded allocation and OOM the daemon. Wrap them in \`io.LimitReader(resp.Body, maxCalDAVResponseSize)\` with a 200 MB cap.

## Sites fixed

1. \`internal/caldav/client.go\` PROPFIND response parsing in \`getEventsViaList\`
2. \`internal/caldav/webdavsync.go\` WebDAV-Sync error-body read
3. \`internal/caldav/webdavsync.go\` WebDAV-Sync multistatus success response read

## Cap rationale

200 MB is ~5-10 orders of magnitude larger than any legitimate PROPFIND / REPORT response for a 5000-event calendar. Catches runaway cases without false-flagging real workloads. Matches the existing \`maxICSResponseSize = 50 MB\` convention in \`ics_client.go\` (separate constant because ICS files and multistatus responses have different expected sizes).

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./internal/caldav/...\` passes — all existing tests unaffected

No new tests — exercising OOM prevention requires a mock server streaming an infinite body, which is integration-test territory. The \`io.LimitReader\` contract is well-tested in the stdlib and the change is a 3-line wrap that preserves behavior on every legitimate response.

## Related

- First-pass audit checked \"response bodies always closed\" (yes) but didn't check for size caps. This PR closes the gap.
- Sibling DoS / resource-exhaustion hardening in the overnight wave.

Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)