### PR TITLE
fix(scheduler): inline panic recovery in executeSync so a panic doesn't kill the job loop (#121)

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -573,7 +573,26 @@ func (s *Scheduler) getSyncLock(sourceID string) *sync.Mutex {
 }
 
 // executeSync runs the sync for a source.
+//
+// Has its own defer recoverPanic even though every caller already
+// wraps executeSync in its own recoverPanic (runJob, runJobFromTicker,
+// runJobWithDelay, TriggerSync). The caller's recover is enough to
+// keep the process alive, but it is NOT enough to keep the caller's
+// sync-loop alive: Go's panic propagation unwinds past the enclosing
+// `for { select { ... executeSync(...) } }` loop, so a panic in
+// sync.go silently kills the entire scheduler loop for that source
+// until the daemon restarts. Users silently stop getting syncs.
+//
+// With an inline recover, a panic inside SyncSource becomes a single
+// loud log line, executeSync returns normally, and the caller's
+// loop continues on the next tick. If the panic is caused by a
+// persistent condition (bad config, libical bug, etc.) every tick
+// will repeat the panic — that's intentional noise; it's easier for
+// operators to fix a persistently-crashing sync than to notice that
+// one source stopped syncing entirely. (#121)
 func (s *Scheduler) executeSync(sourceID string) {
+	defer recoverPanic(fmt.Sprintf("scheduler.executeSync[%s]", sourceID))
+
 	// Get per-source lock to prevent concurrent syncs
 	lock := s.getSyncLock(sourceID)
 


### PR DESCRIPTION
## Summary

Add \`defer recoverPanic(...)\` at the top of \`executeSync\`. Previously, every goroutine calling \`executeSync\` already had its own \`defer recoverPanic\` — that kept the process alive but **not the sync loop**. Go's panic propagation unwinds past the enclosing \`for { select { ... } }\` loop, so a panic in \`SyncSource\` silently killed the entire scheduler loop for that source until daemon restart. Users noticed only when their calendar drifted.

## Why two recover layers are needed

- **Outer** (in \`runJob\` / \`TriggerSync\` / etc.) — process-safety backstop. Keeps the daemon alive.
- **Inner** (this PR) — loop-safety backstop. Keeps the source's \`for\`-loop ticking after a panic.

Both layers target different scopes. Outer catches at goroutine boundary; inner catches at function boundary so the outer loop keeps iterating.

## Noise trade-off

If a panic is caused by a persistent condition (bad source config, libical parser bug, corrupt event), every tick will repeat the panic. That's **intentional noise** — operators can fix a persistently-crashing sync far more easily than they can notice that one source silently stopped. Log spam is a feature here.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./...\` all 11 packages green, no regressions

No new regression test — the \`Scheduler.syncEngine\` field is a concrete \`*caldav.SyncEngine\`, not an interface, so injecting a panic stub for end-to-end testing requires a larger interface refactor. The fix is a single line using the established \`recoverPanic\` primitive (already covered by \`safe_test.go\`). Flagged as follow-up if interface-based scheduler tests get added later.

## Related

- First-pass audit labeled \"panic recovery in background goroutines\" as clean (it was — every goroutine has it). Didn't check that the recovery was positioned to keep sub-loops alive. This PR closes the gap.
- Sibling goroutine/panic-safety hardening in the overnight wave.

Closes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)