### PR TITLE
fix(notify): validate admin email recipients before joining into header (#125)

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -755,17 +755,37 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 	}
 
 	if emailEnabled {
-		// Build recipient list: user email + admin emails (deduplicated)
+		// Build recipient list: user email + admin emails (deduplicated).
+		//
+		// Every address goes through isValidEmail before being added
+		// to the set. User email was already validated; admin emails
+		// from ALERT_SMTP_TO are validated here too as a defense-in-
+		// depth measure. Rationale: sendEmail joins the recipient
+		// slice into a single "To: a, b, c" header string via
+		// strings.Join. If an operator typo or a manipulated env
+		// value contained a CRLF, the joined header would inject
+		// an additional SMTP header (Bcc:, Cc:, From:, etc.). The
+		// isValidEmail regex definitively excludes CRLF, so any
+		// entry that passes is safe to concatenate into a header.
+		// Also skip empty strings which strings.Split of a
+		// comma-separated env var can produce. (#125)
 		recipientSet := make(map[string]struct{})
 
-		// Add user email if provided and valid
-		if alert.UserEmail != "" && isValidEmail(alert.UserEmail) {
-			recipientSet[strings.ToLower(alert.UserEmail)] = struct{}{}
+		addIfValid := func(email string) {
+			email = strings.TrimSpace(email)
+			if email == "" {
+				return
+			}
+			if !isValidEmail(email) {
+				log.Printf("[Notify] rejecting malformed email recipient %q (failed isValidEmail check)", email)
+				return
+			}
+			recipientSet[strings.ToLower(email)] = struct{}{}
 		}
 
-		// Add admin emails
+		addIfValid(alert.UserEmail)
 		for _, email := range n.cfg.SMTPTo {
-			recipientSet[strings.ToLower(email)] = struct{}{}
+			addIfValid(email)
 		}
 
 		// Convert to slice


### PR DESCRIPTION
## Summary

User email was validated with \`isValidEmail\` before being added to the recipient list; admin emails from \`ALERT_SMTP_TO\` weren't. Since \`sendEmail\` joins all recipients into a \`To:\` header via \`strings.Join\`, an \`ALERT_SMTP_TO\` entry with a CRLF could inject additional SMTP headers (\`Bcc:\`, \`Cc:\`, etc.).

Practical exploitability is **low** — \`ALERT_SMTP_TO\` is operator-controlled — but defense in depth is free here. This PR routes every recipient through the same \`isValidEmail\` gate.

## Fix

Extract a small \`addIfValid\` closure: trim whitespace, skip empty strings, run \`isValidEmail\`, log and skip rejected entries. Apply to both user email and every entry in \`n.cfg.SMTPTo\`.

\`isValidEmail\` regex definitively excludes CR/LF, so anything that passes is safe to concatenate into a header.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./internal/notify/...\` passes

No new test — \`isValidEmail\` is already tested elsewhere; the new code is just calling that helper where it wasn't being called before. Dedicated SMTP integration testing is more machinery than the 10-line defensive change warrants.

## Related

- Sibling defense-in-depth security fixes from the overnight wave
- \`sanitizeForEmail\` (body content) already exists; this PR closes the parallel gap on recipients

Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)