### PR TITLE
fix(caldav): validate ICS feed URLs — SSRF hardening (#127)

### DIFF
--- a/internal/caldav/ics_client.go
+++ b/internal/caldav/ics_client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -25,10 +26,76 @@ type ICSClient struct {
 	httpClient *http.Client
 }
 
+// validateICSFeedURL rejects obviously unsafe ICS feed URLs. The
+// threat model for ICS subscriptions sits between webhook URLs
+// (strictly external HTTPS, private IPs rejected) and CalDAV
+// source URLs (LAN servers are common and legitimate). ICS feeds
+// are most often public calendar subscription URLs (Google
+// Calendar public feeds, university schedules, sports calendars)
+// but can also legitimately point at a LAN calendar with ICS
+// export. So this validator is deliberately narrower than
+// validateWebhookURL:
+//
+//  1. Scheme must be http or https. Rejects file://, gopher://,
+//     dict://, data://, and other schemes that would let a
+//     crafted feed URL exfiltrate local files or pivot to
+//     non-HTTP protocols. This is the primary SSRF defense — the
+//     Go HTTP client would technically try to dial a file:// URL
+//     as a relative path lookup, which is almost always the
+//     wrong behavior.
+//
+//  2. Hostname cannot be localhost / 127.0.0.1 / ::1. A feed URL
+//     pointing at the calbridgesync instance's own HTTP listener
+//     is almost always an operator typo — nobody legitimately
+//     subscribes their own instance to itself, and accepting it
+//     gives an attacker (or a confused user) the ability to
+//     trigger recursive fetches or probe internal endpoints.
+//
+//  3. Hostname cannot end in `.local` or `.internal`. Catches
+//     mDNS and intranet-style suffixes that are almost always
+//     operator typos for the non-suffixed form, and that leak
+//     intent about the internal network when they fail.
+//
+// **Not** blocked here: RFC 1918 private ranges (10.0.0.0/8,
+// 172.16.0.0/12, 192.168.0.0/16) and link-local (169.254/16).
+// Legitimate LAN ICS subscriptions exist (Nextcloud, Radicale,
+// DavMail exporting to a LAN address) and blocking them would
+// break real configurations on home / small-team deployments.
+// The webhook validator blocks private IPs because webhook
+// alerts are strictly external; ICS feeds are not.
+//
+// The second-pass audit flagged this gap after it observed that
+// PR #116 hardened the webhook path but left ICS completely
+// unvalidated. (#127)
+func validateICSFeedURL(feedURL string) error {
+	if feedURL == "" {
+		return fmt.Errorf("ICS feed URL is required")
+	}
+	parsed, err := url.Parse(feedURL)
+	if err != nil {
+		return fmt.Errorf("invalid ICS feed URL: %w", err)
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("ICS feed URL scheme must be http or https, got %q", scheme)
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return fmt.Errorf("ICS feed URL is missing a host")
+	}
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		return fmt.Errorf("ICS feed URL cannot point to localhost")
+	}
+	if strings.HasSuffix(host, ".local") || strings.HasSuffix(host, ".internal") {
+		return fmt.Errorf("ICS feed URL cannot point to .local or .internal hosts")
+	}
+	return nil
+}
+
 // NewICSClient creates a new ICS feed client.
 func NewICSClient(feedURL, username, password string) (*ICSClient, error) {
-	if feedURL == "" {
-		return nil, fmt.Errorf("%w: feed URL is required", ErrConnectionFailed)
+	if err := validateICSFeedURL(feedURL); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrConnectionFailed, err)
 	}
 
 	transport := &http.Transport{

--- a/internal/caldav/ics_validation_test.go
+++ b/internal/caldav/ics_validation_test.go
@@ -1,0 +1,117 @@
+package caldav
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateICSFeedURL covers the scheme + host block rules from
+// #127. The validator is intentionally narrower than the webhook
+// validator (private IPs are still allowed for LAN calendar
+// servers) so this table documents exactly which inputs pass and
+// which don't.
+func TestValidateICSFeedURL(t *testing.T) {
+	cases := []struct {
+		name       string
+		url        string
+		wantErr    bool
+		wantErrSub string // optional substring check on the error
+	}{
+		// Happy path — public HTTPS feeds
+		{"public https Google calendar", "https://calendar.google.com/calendar/ical/abc/basic.ics", false, ""},
+		{"public https university", "https://schedule.example.edu/events.ics", false, ""},
+		{"public http sports schedule", "http://sports.example.com/team.ics", false, ""},
+
+		// LAN / private IP — intentionally allowed (Nextcloud,
+		// Radicale, DavMail, etc.)
+		{"private 10.0.0.1", "https://10.0.0.1/calendar.ics", false, ""},
+		{"private 192.168.1.5", "https://192.168.1.5/cal.ics", false, ""},
+		{"private 172.16.0.1", "http://172.16.0.1/cal.ics", false, ""},
+		{"RFC 6598 CGNAT 100.64.0.1", "https://100.64.0.1/cal.ics", false, ""},
+		{"public 8.8.8.8 via IP", "https://8.8.8.8/cal.ics", false, ""},
+
+		// Scheme rejection
+		{"file scheme rejected", "file:///etc/passwd", true, "scheme must be http or https"},
+		{"gopher scheme rejected", "gopher://example.com/", true, "scheme must be http or https"},
+		{"ftp scheme rejected", "ftp://example.com/cal.ics", true, "scheme must be http or https"},
+		{"data scheme rejected", "data:text/plain;base64,SGVsbG8=", true, "scheme must be http or https"},
+		{"dict scheme rejected", "dict://example.com/", true, "scheme must be http or https"},
+		{"javascript scheme rejected", "javascript:alert(1)", true, "scheme must be http or https"},
+
+		// Localhost rejection — not private, specifically the
+		// loopback-or-name cases that are almost always operator
+		// typos.
+		{"localhost name rejected", "https://localhost/cal.ics", true, "localhost"},
+		{"127.0.0.1 rejected", "http://127.0.0.1/cal.ics", true, "localhost"},
+		{"IPv6 loopback rejected", "http://[::1]/cal.ics", true, "localhost"},
+		{"LOCALHOST uppercase rejected", "https://LOCALHOST/cal.ics", true, "localhost"},
+
+		// mDNS / intranet suffixes
+		{".local rejected", "https://server.local/cal.ics", true, ".local"},
+		{".internal rejected", "https://api.internal/cal.ics", true, ".internal"},
+		{".local uppercase rejected", "https://SERVER.LOCAL/cal.ics", true, ".local"},
+
+		// Malformed
+		{"empty URL rejected", "", true, "required"},
+		{"no scheme no host", "not-a-url", true, "scheme"},
+		{"scheme only", "http://", true, "host"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateICSFeedURL(tc.url)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error for %q, got nil", tc.url)
+				}
+				if tc.wantErrSub != "" && !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrSub)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("want no error for %q, got: %v", tc.url, err)
+				}
+			}
+		})
+	}
+}
+
+// TestNewICSClient_RejectsInvalidURLs verifies the validator
+// runs at constructor time so callers fail fast with a clear
+// error message rather than discovering the problem at HTTP-
+// send time.
+func TestNewICSClient_RejectsInvalidURLs(t *testing.T) {
+	cases := []string{
+		"",
+		"file:///etc/passwd",
+		"http://localhost/cal.ics",
+		"https://server.local/cal.ics",
+	}
+	for _, u := range cases {
+		t.Run(u, func(t *testing.T) {
+			_, err := NewICSClient(u, "", "")
+			if err == nil {
+				t.Errorf("NewICSClient(%q) should fail validation", u)
+			}
+		})
+	}
+}
+
+// TestNewICSClient_AcceptsLegitimateURLs is the positive
+// counterpart: real-world ICS feed URLs must not be rejected.
+func TestNewICSClient_AcceptsLegitimateURLs(t *testing.T) {
+	cases := []string{
+		"https://calendar.google.com/calendar/ical/example/basic.ics",
+		"https://nextcloud.example.com/remote.php/dav/public-calendars/abc/?export",
+		"http://192.168.1.10:5232/user/calendar.ics", // Radicale on LAN
+		"https://10.0.5.2/caldav/personal/export",
+	}
+	for _, u := range cases {
+		t.Run(u, func(t *testing.T) {
+			_, err := NewICSClient(u, "", "")
+			if err != nil {
+				t.Errorf("NewICSClient(%q) should succeed, got error: %v", u, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Surfaced by the second-pass audit: \`internal/caldav/ics_client.go\` had **zero URL validation** on ICS feed URLs. PR #116 and #118 hardened the webhook path but left ICS subscriptions completely unguarded — a user could save an ICS source pointing at \`file:///etc/passwd\`, \`http://localhost:8080/internal-api\`, or \`gopher://anything\` and calbridgesync would happily dial it.

Add \`validateICSFeedURL\` helper called from \`NewICSClient\` constructor.

## Threat-model-specific validation

ICS sits between webhooks and CalDAV sources:

| | Strict-block | ICS (this PR) | CalDAV |
|---|---|---|---|
| Non-http(s) schemes | blocked | **blocked** | allowed |
| localhost / 127.0.0.1 / ::1 | blocked | **blocked** | allowed |
| \`.local\` / \`.internal\` suffix | blocked | **blocked** | allowed |
| RFC 1918 private IPs | blocked | **allowed** | allowed |
| Link-local / CGNAT | blocked | **allowed** | allowed |

ICS is stricter than CalDAV (no \`file://\`) but more permissive than webhooks (LAN Radicale / Nextcloud still work).

## Tests

\`ics_validation_test.go\` — 20+ case table:

- **Scheme rejection:** \`file://\`, \`gopher://\`, \`ftp://\`, \`data://\`, \`dict://\`, \`javascript:\`
- **Localhost rejection:** \`localhost\`, \`127.0.0.1\`, \`[::1]\`, case-insensitive
- **Suffix rejection:** \`.local\`, \`.internal\`, case-insensitive
- **LAN allowed:** \`10.x\`, \`192.168.x\`, \`172.16.x\`, \`100.64.x\` CGNAT, \`8.8.8.8\`
- **Happy path:** public HTTPS Google Calendar, university, sports
- **Malformed:** empty, no scheme, scheme-only

Plus constructor-level \`TestNewICSClient_RejectsInvalidURLs\` and \`TestNewICSClient_AcceptsLegitimateURLs\` (including real-world Nextcloud / Radicale URLs on LAN addresses).

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./internal/caldav/... -run TestValidateICSFeedURL\` — 20+ cases green
- [x] \`go test -count=1 ./...\` full suite green

## Not in scope

- Dial-time DNS rebinding defense for ICS (analogous to PR #118 for webhooks). Would need a variant of \`safeDialContext\` that only refuses loopback, not all private IPs. Follow-up.
- HTTPS-only enforcement via \`STRICT_ICS_HTTPS\` env var. Current behavior allows \`http://\` since LAN ICS servers often don't run TLS.

## Related

- Second-pass audit finding #1
- #115 / #116 — webhook static IP literal check (the pattern this PR mirrors)
- #117 / #118 — webhook DNS rebind defense

Closes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)