### PR TITLE
feat(caldav): STRICT_ICS_HTTPS env var to enforce HTTPS on ICS feeds (#131)

### DIFF
--- a/internal/caldav/ics_client.go
+++ b/internal/caldav/ics_client.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -166,6 +167,16 @@ type ICSClient struct {
 // The second-pass audit flagged this gap after it observed that
 // PR #116 hardened the webhook path but left ICS completely
 // unvalidated. (#127)
+//
+// STRICT_ICS_HTTPS (#131): operators who want to enforce
+// HTTPS-only ICS feeds in production can set the env var
+// STRICT_ICS_HTTPS=true. When enabled, `http://` feed URLs are
+// rejected at save time. Default is OFF because LAN calendar
+// servers (Radicale, DavMail exports) often don't run TLS, and
+// flipping to strict-by-default would break existing
+// configurations on upgrade. The env var is read lazily inside
+// the validator so tests can toggle it via t.Setenv without
+// needing to reconstruct the ICSClient.
 func validateICSFeedURL(feedURL string) error {
 	if feedURL == "" {
 		return fmt.Errorf("ICS feed URL is required")
@@ -178,6 +189,13 @@ func validateICSFeedURL(feedURL string) error {
 	if scheme != "http" && scheme != "https" {
 		return fmt.Errorf("ICS feed URL scheme must be http or https, got %q", scheme)
 	}
+	// Optional strict-HTTPS mode (#131). Reads env var lazily at
+	// validation time so operators can flip the flag without
+	// restarting existing sync jobs — the next save-or-reload
+	// picks up the new value. Default off.
+	if scheme == "http" && isStrictICSHTTPS() {
+		return fmt.Errorf("ICS feed URL must use HTTPS when STRICT_ICS_HTTPS=true is set in the instance environment")
+	}
 	host := strings.ToLower(parsed.Hostname())
 	if host == "" {
 		return fmt.Errorf("ICS feed URL is missing a host")
@@ -189,6 +207,16 @@ func validateICSFeedURL(feedURL string) error {
 		return fmt.Errorf("ICS feed URL cannot point to .local or .internal hosts")
 	}
 	return nil
+}
+
+// isStrictICSHTTPS returns true if the operator has opted into
+// strict HTTPS enforcement for ICS feed URLs via the
+// STRICT_ICS_HTTPS environment variable. Accepts "true", "1",
+// "yes" (case-insensitive). Anything else, including unset, is
+// treated as false (the LAN-friendly default). (#131)
+func isStrictICSHTTPS() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("STRICT_ICS_HTTPS")))
+	return v == "true" || v == "1" || v == "yes"
 }
 
 // NewICSClient creates a new ICS feed client.

--- a/internal/caldav/ics_validation_test.go
+++ b/internal/caldav/ics_validation_test.go
@@ -5,6 +5,90 @@ import (
 	"testing"
 )
 
+// TestIsStrictICSHTTPS covers the env var parsing for the
+// STRICT_ICS_HTTPS flag. Uses t.Setenv so each case starts from
+// a clean environment regardless of what the host has set. (#131)
+func TestIsStrictICSHTTPS(t *testing.T) {
+	cases := []struct {
+		env  string
+		want bool
+	}{
+		{"", false},
+		{"false", false},
+		{"no", false},
+		{"0", false},
+		{"off", false},     // not recognized as truthy
+		{"garbage", false}, // not recognized
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"1", true},
+		{"yes", true},
+		{"YES", true},
+		{" true ", true}, // whitespace tolerated via TrimSpace
+	}
+	for _, tc := range cases {
+		name := tc.env
+		if name == "" {
+			name = "(unset)"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("STRICT_ICS_HTTPS", tc.env)
+			if got := isStrictICSHTTPS(); got != tc.want {
+				t.Errorf("STRICT_ICS_HTTPS=%q → isStrictICSHTTPS() = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateICSFeedURL_StrictHTTPS covers the end-to-end
+// behavior of the #131 strict mode: when STRICT_ICS_HTTPS is
+// truthy, http:// URLs are rejected; when unset/false, http://
+// passes the scheme check.
+func TestValidateICSFeedURL_StrictHTTPS(t *testing.T) {
+	t.Run("http allowed by default (LAN compatibility)", func(t *testing.T) {
+		t.Setenv("STRICT_ICS_HTTPS", "")
+		if err := validateICSFeedURL("http://sports.example.com/team.ics"); err != nil {
+			t.Errorf("http:// must be allowed by default: %v", err)
+		}
+	})
+
+	t.Run("http rejected when strict mode is on", func(t *testing.T) {
+		t.Setenv("STRICT_ICS_HTTPS", "true")
+		err := validateICSFeedURL("http://sports.example.com/team.ics")
+		if err == nil {
+			t.Fatal("http:// must be rejected when STRICT_ICS_HTTPS=true")
+		}
+		if !strings.Contains(err.Error(), "STRICT_ICS_HTTPS") {
+			t.Errorf("error should mention STRICT_ICS_HTTPS for operator discoverability, got: %v", err)
+		}
+	})
+
+	t.Run("https always allowed", func(t *testing.T) {
+		t.Setenv("STRICT_ICS_HTTPS", "true")
+		if err := validateICSFeedURL("https://calendar.google.com/ical/example.ics"); err != nil {
+			t.Errorf("https:// must always pass: %v", err)
+		}
+	})
+
+	t.Run("other rejection rules still fire under strict mode", func(t *testing.T) {
+		// Even with strict mode on, the other checks (localhost,
+		// .local, file://) should still produce their own errors.
+		t.Setenv("STRICT_ICS_HTTPS", "true")
+
+		cases := []string{
+			"https://localhost/cal.ics",    // still rejected as localhost
+			"https://server.local/cal.ics", // still rejected as .local
+			"file:///etc/passwd",           // still rejected as non-http scheme
+		}
+		for _, u := range cases {
+			if err := validateICSFeedURL(u); err == nil {
+				t.Errorf("%q must still be rejected under strict mode", u)
+			}
+		}
+	})
+}
+
 // TestValidateICSFeedURL covers the scheme + host block rules from
 // #127. The validator is intentionally narrower than the webhook
 // validator (private IPs are still allowed for LAN calendar


### PR DESCRIPTION
## Summary

Stacked on PR #130. Adds an opt-in \`STRICT_ICS_HTTPS\` env var. When set to a truthy value (\`true\`, \`1\`, \`yes\`, case-insensitive, whitespace-tolerant), \`validateICSFeedURL\` rejects \`http://\` ICS feed URLs at save time. Default OFF — \`http://\` remains allowed for LAN compatibility.

## Why opt-in

- **Production with public feeds only:** can safely require HTTPS
- **Deployments with LAN calendar servers (Radicale, DavMail):** often run plain HTTP, would break on upgrade if strict-by-default

Opt-in is the safe default. Operators who want the stricter posture set the env var; everyone else is unaffected.

## Implementation

- \`isStrictICSHTTPS()\` private helper reads \`os.Getenv\` lazily, trims whitespace, lower-cases
- \`validateICSFeedURL\` calls it after the scheme check
- Lazy env read → operators can flip the flag without restarting the daemon (next source save picks up the new value)
- Error message mentions \`STRICT_ICS_HTTPS\` for operator grep-ability

## Tests

### \`TestIsStrictICSHTTPS\` — 13-case env var parsing
- **False:** unset, \`false\`, \`no\`, \`0\`, \`off\`, \`garbage\`
- **True:** \`true\`, \`TRUE\`, \`True\`, \`1\`, \`yes\`, \`YES\`, \` true \` (whitespace)

### \`TestValidateICSFeedURL_StrictHTTPS\`
- \`http://\` allowed by default (LAN compatibility)
- \`http://\` rejected when strict mode on (error mentions \`STRICT_ICS_HTTPS\`)
- \`https://\` always allowed
- Other rejection rules (localhost, .local, file://) still fire under strict mode — additive, not replacement

Uses \`t.Setenv\` so each case starts from a clean environment.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./internal/caldav/...\` passes — new tests + all existing ICS tests green
- [x] \`go test -count=1 ./...\` full suite green

## Operator guidance

Add to production \`.env\`:

\`\`\`
STRICT_ICS_HTTPS=true
\`\`\`

**Existing \`http://\` sources continue to sync** — validation happens at source save time, not at sync time. To enforce on existing sources, update them via the web UI (triggers re-validation).

## Stacked order

#128 → #130 → #131. Each PR's base is the previous one. When merging, GitHub auto-updates the base after each merge.

## Related

- #127 / #128 — validation-time ICS feed URL check (the function this PR extends)
- #129 / #130 — dial-time DNS rebinding defense for ICS
- Second-pass audit follow-up

Closes #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)