### PR TITLE
fix(scheduler): bound Stop() drain with stopDrainTimeout (#133)

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -286,7 +286,42 @@ func (s *Scheduler) checkLiveness() {
 	}
 }
 
-// Stop gracefully shuts down all jobs.
+// stopDrainTimeout is the maximum time Stop will wait for in-flight
+// sync goroutines to drain after context cancellation. Exceeding it
+// logs a warning and returns anyway so the caller (typically main's
+// signal handler) is not blocked indefinitely on a stuck sync.
+//
+// Chosen smaller than the main.go shutdownTimeout (30s) so the
+// scheduler drain completes before the HTTP server's graceful
+// shutdown timer starts. 20s gives in-flight CalDAV operations
+// one or two more seconds of grace after s.cancel() propagates,
+// then surrenders — the alternative (no timeout) could block
+// main for up to syncTimeout = 2 hours if a sync ignores
+// context cancellation. (#133)
+//
+// Declared as var (not const) so tests can override with a very
+// short duration to exercise the timeout path in reasonable wall-
+// clock time. Production code never writes this value.
+var stopDrainTimeout = 20 * time.Second
+
+// Stop gracefully shuts down all jobs. Bounded by stopDrainTimeout
+// so the caller is not blocked indefinitely if an in-flight sync
+// fails to honor context cancellation.
+//
+// The process: cancel the scheduler's root context (which cascades
+// into every in-flight SyncSource via derived contexts), close job
+// stop channels, then wait for goroutines to return. Any goroutine
+// still running after stopDrainTimeout is left to its own devices
+// — the process is about to exit anyway, and the OS will reclaim
+// its resources.
+//
+// Before #133 this function called s.wg.Wait() with no timeout.
+// With syncTimeout = 2 hours, a single stuck sync could block
+// Stop() for that entire window, causing Kubernetes / Docker to
+// SIGKILL the pod (typical grace periods are 30s) and losing any
+// in-flight state that a proper drain would have preserved.
+// Bounding the wait is the operational fix: log loudly, surrender,
+// let the process exit cleanly within the orchestrator's budget.
 func (s *Scheduler) Stop() {
 	s.mu.Lock()
 	if !s.started {
@@ -296,7 +331,11 @@ func (s *Scheduler) Stop() {
 	s.started = false
 	s.mu.Unlock()
 
-	// Cancel context to stop all jobs
+	// Cancel context to stop all jobs. This cascades into every
+	// in-flight SyncSource via the context chain in executeSync
+	// (ctx, cancel := context.WithTimeout(s.ctx, syncTimeout))
+	// so HTTP operations in flight should unblock within their
+	// current request's remaining timeout.
 	s.cancel()
 
 	// Stop all job tickers
@@ -308,9 +347,21 @@ func (s *Scheduler) Stop() {
 	s.jobs = make(map[string]*Job)
 	s.mu.Unlock()
 
-	// Wait for all goroutines to finish
-	s.wg.Wait()
-	log.Println("Scheduler stopped")
+	// Wait for all goroutines to finish, bounded by
+	// stopDrainTimeout so we can never block the caller longer
+	// than the outer shutdown grace period. (#133)
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		log.Println("Scheduler stopped")
+	case <-time.After(stopDrainTimeout):
+		log.Printf("WARNING: scheduler Stop() drain timeout (%v) exceeded — forcing shutdown with in-flight goroutines still running. Check sync_timeout settings or investigate stuck CalDAV operations.", stopDrainTimeout)
+	}
 }
 
 // AddJob adds or replaces a sync job for a source.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -110,6 +110,90 @@ func TestSchedulerStartStop(t *testing.T) {
 		sched.Stop()
 		sched.Stop() // Should be safe to call multiple times
 	})
+
+	// TestSchedulerStop_DrainTimeout is the regression test for
+	// #133. It adds a goroutine to the scheduler's waitgroup that
+	// intentionally never returns, then calls Stop() with a very
+	// short stopDrainTimeout and verifies the call returns within
+	// the timeout window instead of hanging forever.
+	//
+	// Without the timeout added in #133, Stop() would block on
+	// wg.Wait() indefinitely because the dummy goroutine never
+	// calls wg.Done(). With the fix, Stop() logs a warning and
+	// returns when the drain timer fires.
+	t.Run("drain timeout forces return on stuck goroutine", func(t *testing.T) {
+		// Shrink the timeout so the test completes in reasonable
+		// wall-clock time. Restore at the end.
+		origTimeout := stopDrainTimeout
+		stopDrainTimeout = 50 * time.Millisecond
+		defer func() { stopDrainTimeout = origTimeout }()
+
+		sched := New(nil, nil, nil)
+
+		// Flip started = true so Stop() actually runs the drain
+		// logic (otherwise it short-circuits on !started).
+		sched.mu.Lock()
+		sched.started = true
+		sched.mu.Unlock()
+
+		// Add a goroutine to the waitgroup that blocks forever,
+		// simulating an in-flight sync that refuses to honor
+		// context cancellation. block channel ensures the
+		// goroutine is alive when Stop() is called.
+		block := make(chan struct{})
+		defer close(block) // let the goroutine exit after the test
+		sched.wg.Add(1)
+		go func() {
+			defer sched.wg.Done()
+			<-block
+		}()
+
+		start := time.Now()
+		sched.Stop()
+		elapsed := time.Since(start)
+
+		// Stop() must have returned within (timeout + scheduling
+		// jitter). Allow up to 5x the timeout as a generous upper
+		// bound to avoid CI flakiness.
+		if elapsed > 5*stopDrainTimeout {
+			t.Errorf("Stop() took %v, want < %v — drain timeout not enforced", elapsed, 5*stopDrainTimeout)
+		}
+		// And it must have taken at least the timeout (sanity
+		// check — we shouldn't be returning before the timer
+		// fires).
+		if elapsed < stopDrainTimeout/2 {
+			t.Errorf("Stop() returned in %v before drain timeout %v — the drain path didn't actually wait", elapsed, stopDrainTimeout)
+		}
+	})
+
+	t.Run("drain completes fast when goroutines exit promptly", func(t *testing.T) {
+		origTimeout := stopDrainTimeout
+		stopDrainTimeout = 5 * time.Second
+		defer func() { stopDrainTimeout = origTimeout }()
+
+		sched := New(nil, nil, nil)
+		sched.mu.Lock()
+		sched.started = true
+		sched.mu.Unlock()
+
+		// Add a goroutine that exits immediately when ctx is
+		// canceled. This models a well-behaved sync.
+		sched.wg.Add(1)
+		go func() {
+			defer sched.wg.Done()
+			<-sched.ctx.Done()
+		}()
+
+		start := time.Now()
+		sched.Stop()
+		elapsed := time.Since(start)
+
+		// Well-behaved goroutines should let Stop() return in
+		// milliseconds, well under the drain timeout.
+		if elapsed > stopDrainTimeout/2 {
+			t.Errorf("Stop() took %v with a well-behaved goroutine — should have drained in milliseconds", elapsed)
+		}
+	})
 }
 
 func TestGetSyncLock(t *testing.T) {


### PR DESCRIPTION
## Problem

\`Scheduler.Stop()\` called \`s.wg.Wait()\` with **no timeout**. A single in-flight sync that fails to honor context cancellation could block \`Stop()\` for up to \`syncTimeout = 2 hours\`. Main's 30-second \`shutdownTimeout\` applies only to the HTTP server shutdown, not the scheduler drain that runs **before** it — so if sched.Stop() hangs, Kubernetes / Docker wait the pod grace period (typically 30s) then send SIGKILL and in-flight state gets lost.

## Fix

Wrap \`wg.Wait()\` in a \`select\` with a \`stopDrainTimeout = 20s\` timer. Well-behaved goroutines finish in milliseconds; stuck ones get 20 seconds of grace then the scheduler surrenders with a loud WARNING log line. Total SIGTERM → process exit stays under typical orchestrator grace windows.

\`stopDrainTimeout\` is a \`var\` (not \`const\`) so tests can shrink it to 50ms to exercise the timeout path in reasonable wall-clock time.

## Tests

- **\`drain timeout forces return on stuck goroutine\`** — regression test. Adds a goroutine that blocks forever, verifies Stop() returns within the enforced window (not hanging).
- **\`drain completes fast when goroutines exit promptly\`** — positive counterpart. Well-behaved goroutine exits on ctx.Done(), Stop() returns in milliseconds.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./internal/scheduler/...\` new + existing green
- [x] \`go test -count=1 ./...\` full suite green

## Related

- First-pass audit checked panic recovery in goroutines (clean) but didn't check the drain-on-shutdown flow. This PR closes that gap.
- #122 — inline panic recovery in \`executeSync\` (sibling goroutine-safety fix)

Closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)