### PR TITLE
fix(caldav): ICS dial-time SSRF defense + STRICT_ICS_HTTPS — resubmit of #130/#132

### DIFF
--- a/internal/caldav/ics_client.go
+++ b/internal/caldav/ics_client.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -166,6 +167,16 @@ type ICSClient struct {
 // The second-pass audit flagged this gap after it observed that
 // PR #116 hardened the webhook path but left ICS completely
 // unvalidated. (#127)
+//
+// STRICT_ICS_HTTPS (#131): operators who want to enforce
+// HTTPS-only ICS feeds in production can set the env var
+// STRICT_ICS_HTTPS=true. When enabled, `http://` feed URLs are
+// rejected at save time. Default is OFF because LAN calendar
+// servers (Radicale, DavMail exports) often don't run TLS, and
+// flipping to strict-by-default would break existing
+// configurations on upgrade. The env var is read lazily inside
+// the validator so tests can toggle it via t.Setenv without
+// needing to reconstruct the ICSClient.
 func validateICSFeedURL(feedURL string) error {
 	if feedURL == "" {
 		return fmt.Errorf("ICS feed URL is required")
@@ -178,6 +189,13 @@ func validateICSFeedURL(feedURL string) error {
 	if scheme != "http" && scheme != "https" {
 		return fmt.Errorf("ICS feed URL scheme must be http or https, got %q", scheme)
 	}
+	// Optional strict-HTTPS mode (#131). Reads env var lazily at
+	// validation time so operators can flip the flag without
+	// restarting existing sync jobs — the next save-or-reload
+	// picks up the new value. Default off.
+	if scheme == "http" && isStrictICSHTTPS() {
+		return fmt.Errorf("ICS feed URL must use HTTPS when STRICT_ICS_HTTPS=true is set in the instance environment")
+	}
 	host := strings.ToLower(parsed.Hostname())
 	if host == "" {
 		return fmt.Errorf("ICS feed URL is missing a host")
@@ -189,6 +207,16 @@ func validateICSFeedURL(feedURL string) error {
 		return fmt.Errorf("ICS feed URL cannot point to .local or .internal hosts")
 	}
 	return nil
+}
+
+// isStrictICSHTTPS returns true if the operator has opted into
+// strict HTTPS enforcement for ICS feed URLs via the
+// STRICT_ICS_HTTPS environment variable. Accepts "true", "1",
+// "yes" (case-insensitive). Anything else, including unset, is
+// treated as false (the LAN-friendly default). (#131)
+func isStrictICSHTTPS() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("STRICT_ICS_HTTPS")))
+	return v == "true" || v == "1" || v == "yes"
 }
 
 // NewICSClient creates a new ICS feed client.

--- a/internal/caldav/ics_client.go
+++ b/internal/caldav/ics_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,6 +18,104 @@ import (
 const (
 	maxICSResponseSize = 50 * 1024 * 1024 // 50MB limit for ICS feed responses
 )
+
+// icsLoopbackOnlyDialContext is the dial-time DNS-rebinding defense
+// for ICS feed subscriptions. It's analogous to the notify package's
+// safeDialContext but intentionally NARROWER: the webhook dial
+// rejects ALL private IPs (10/8, 172.16/12, 192.168/16, CGNAT,
+// link-local, etc.) because webhooks target external services, but
+// ICS feed URLs legitimately point at LAN calendar servers
+// (Nextcloud on 192.168.x, Radicale on 10.x, DavMail export to a
+// LAN host). Blocking private IPs would break real-world LAN
+// configurations.
+//
+// So this dial-time check only refuses the narrow set that is
+// ALWAYS an operator mistake for an ICS feed URL:
+//
+//  1. Loopback (127.0.0.0/8, ::1, ::ffff:127.0.0.1) — subscribing
+//     the calbridgesync instance's own listener to itself is
+//     operator typo, never legitimate.
+//
+//  2. Unspecified (0.0.0.0, ::) — routes to loopback on many
+//     systems, same category of mistake.
+//
+//  3. Link-local unicast / multicast (169.254.0.0/16, fe80::/10) —
+//     includes cloud metadata endpoints (AWS / GCP / Azure IMDS).
+//     Critical SSRF defense against credential exfiltration via
+//     a malicious DNS answer pointing at 169.254.169.254.
+//
+// RFC 1918 private, carrier NAT, unique-local IPv6 (fc00::/7)
+// remain allowed so LAN use cases work.
+//
+// Validation-time hostname checks (PR #128) catch the obvious
+// static cases at save time. This dial-time check catches DNS
+// rebinding: a hostname that resolved to a public IP at save time
+// but now resolves to 127.0.0.1 (or 169.254.169.254) at fetch
+// time. Same architecture as notify package's safeDialContext. (#129)
+//
+// Like the webhook dial, this resolves the host and dials the
+// resolved IP directly to close a last-mile TOCTOU window between
+// check and connect.
+func icsLoopbackOnlyDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address: %w", err)
+	}
+
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+	if err != nil {
+		return nil, fmt.Errorf("DNS resolution failed for %s: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no IPs resolved for %s", host)
+	}
+
+	// Reject if ANY resolved IP is in the narrow block-list. A
+	// DNS answer of [public-ip, 127.0.0.1] must not slip through
+	// just because Go's dialer might pick the public one — same
+	// defensive posture as the webhook dial.
+	for _, ip := range ips {
+		if blocked, reason := isICSBlockedIP(ip); blocked {
+			return nil, fmt.Errorf("blocked destination: %s resolves to %s (%s)", host, ip.String(), reason)
+		}
+	}
+
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	// Dial the first resolved IP directly to prevent a second
+	// resolver lookup from returning a different answer.
+	dialAddr := net.JoinHostPort(ips[0].String(), port)
+	return dialer.DialContext(ctx, network, dialAddr)
+}
+
+// isICSBlockedIP is the ICS-specific block classifier. Narrower
+// than notify.isBlockedIP: private IPs are allowed. See
+// icsLoopbackOnlyDialContext for the rationale. (#129)
+func isICSBlockedIP(ip net.IP) (bool, string) {
+	if ip == nil {
+		return true, "unparseable IP"
+	}
+	if ip.IsLoopback() {
+		return true, "loopback"
+	}
+	if ip.IsUnspecified() {
+		return true, "unspecified"
+	}
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return true, "link-local (includes cloud IMDS)"
+	}
+	return false, ""
+}
+
+// icsDialContext is the dial function the ICS http.Client uses.
+// Package-level variable so future tests that spin up an
+// httptest.NewServer (which binds to 127.0.0.1) can swap in a
+// permissive dialer. Not currently needed by existing ICS tests
+// but keeping the pattern consistent with notify/webhookDialContext
+// avoids retrofitting if httptest-based ICS tests get added. (#129)
+var icsDialContext = icsLoopbackOnlyDialContext
 
 // ICSClient fetches and parses ICS calendar feeds over HTTP.
 type ICSClient struct {
@@ -99,6 +198,7 @@ func NewICSClient(feedURL, username, password string) (*ICSClient, error) {
 	}
 
 	transport := &http.Transport{
+		DialContext: icsDialContext,
 		TLSClientConfig: &tls.Config{
 			MinVersion: minTLSVersion,
 		},

--- a/internal/caldav/ics_dial_test.go
+++ b/internal/caldav/ics_dial_test.go
@@ -1,0 +1,149 @@
+package caldav
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+)
+
+// TestIsICSBlockedIP covers the ICS-specific IP classifier from
+// #129. The ICS block-list is intentionally narrower than the
+// webhook block-list (notify.isBlockedIP): private IPs are
+// allowed because LAN calendar servers are a real use case. Only
+// loopback, unspecified, and link-local are refused — anything
+// that is ALWAYS an operator mistake for an ICS feed URL.
+func TestIsICSBlockedIP(t *testing.T) {
+	cases := []struct {
+		name       string
+		ip         string
+		wantBlock  bool
+		wantReason string
+	}{
+		// Happy path — public IPs pass.
+		{"public IPv4 8.8.8.8", "8.8.8.8", false, ""},
+		{"public IPv4 1.1.1.1", "1.1.1.1", false, ""},
+		{"public IPv6 Google DNS", "2001:4860:4860::8888", false, ""},
+
+		// Private / LAN — ALLOWED (intentional difference from
+		// notify.isBlockedIP). LAN Nextcloud, Radicale, DavMail
+		// all live on private ranges.
+		{"private 10.0.0.1 allowed", "10.0.0.1", false, ""},
+		{"private 192.168.1.1 allowed", "192.168.1.1", false, ""},
+		{"private 172.16.0.1 allowed", "172.16.0.1", false, ""},
+		{"private 172.31.255.254 allowed", "172.31.255.254", false, ""},
+		{"CGNAT 100.64.0.1 allowed", "100.64.0.1", false, ""},
+		{"IPv6 unique-local fc00::1 allowed", "fc00::1", false, ""},
+
+		// Loopback — blocked (operator typo).
+		{"loopback 127.0.0.1", "127.0.0.1", true, "loopback"},
+		{"loopback 127.0.0.2", "127.0.0.2", true, "loopback"},
+		{"loopback 127.1.2.3", "127.1.2.3", true, "loopback"},
+		{"IPv6 loopback ::1", "::1", true, "loopback"},
+
+		// Link-local — blocked (includes cloud IMDS).
+		{"link-local AWS IMDS 169.254.169.254", "169.254.169.254", true, "link-local"},
+		{"link-local 169.254.1.1", "169.254.1.1", true, "link-local"},
+		{"IPv6 link-local fe80::1", "fe80::1", true, "link-local"},
+
+		// Unspecified — blocked.
+		{"unspecified 0.0.0.0", "0.0.0.0", true, "unspecified"},
+		{"IPv6 unspecified ::", "::", true, "unspecified"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			if ip == nil {
+				t.Fatalf("test setup: unparseable IP literal %q", tc.ip)
+			}
+			blocked, reason := isICSBlockedIP(ip)
+			if blocked != tc.wantBlock {
+				t.Errorf("isICSBlockedIP(%s) = blocked:%v reason:%q, want blocked:%v", tc.ip, blocked, reason, tc.wantBlock)
+			}
+			if tc.wantBlock && tc.wantReason != "" && !strings.Contains(reason, tc.wantReason) {
+				t.Errorf("isICSBlockedIP(%s) reason %q does not contain expected substring %q", tc.ip, reason, tc.wantReason)
+			}
+			if !tc.wantBlock && reason != "" {
+				t.Errorf("isICSBlockedIP(%s) unexpectedly returned reason %q for non-blocked IP", tc.ip, reason)
+			}
+		})
+	}
+}
+
+// TestIsICSBlockedIP_NilFailsClosed ensures the defensive nil
+// branch fails closed rather than allowing a nil IP through.
+func TestIsICSBlockedIP_NilFailsClosed(t *testing.T) {
+	blocked, reason := isICSBlockedIP(nil)
+	if !blocked {
+		t.Error("nil IP must block (fail-closed)")
+	}
+	if reason == "" {
+		t.Error("nil IP must return a diagnostic reason")
+	}
+}
+
+// TestICSLoopbackOnlyDialContext_BlocksLiteralLoopback verifies
+// the dial helper refuses a literal loopback IP address even if
+// the hostname itself would pass validation (e.g., because it's
+// an IP rather than a name). This is the dial-time half of the
+// defense in PR #128 — the validator catches "localhost" as a
+// string, and this dial catches 127.0.0.x post-resolution.
+func TestICSLoopbackOnlyDialContext_BlocksLiteralLoopback(t *testing.T) {
+	_, err := icsLoopbackOnlyDialContext(context.Background(), "tcp", "127.0.0.1:12345")
+	if err == nil {
+		t.Fatal("127.0.0.1 must be blocked at dial time")
+	}
+	if !strings.Contains(err.Error(), "blocked destination") {
+		t.Errorf("error should mention 'blocked destination', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "loopback") {
+		t.Errorf("error should classify as loopback, got: %v", err)
+	}
+}
+
+// TestICSLoopbackOnlyDialContext_BlocksLiteralIMDS is the
+// headline cloud-metadata exfiltration defense. A malicious DNS
+// answer returning 169.254.169.254 must be refused even though
+// the hostname passed static validation.
+func TestICSLoopbackOnlyDialContext_BlocksLiteralIMDS(t *testing.T) {
+	_, err := icsLoopbackOnlyDialContext(context.Background(), "tcp", "169.254.169.254:80")
+	if err == nil {
+		t.Fatal("cloud IMDS 169.254.169.254 must be blocked")
+	}
+	if !strings.Contains(err.Error(), "link-local") {
+		t.Errorf("error should classify as link-local (IMDS), got: %v", err)
+	}
+}
+
+// TestICSLoopbackOnlyDialContext_InvalidAddress verifies the
+// helper returns a clear error for malformed addresses instead
+// of hanging on DNS.
+func TestICSLoopbackOnlyDialContext_InvalidAddress(t *testing.T) {
+	_, err := icsLoopbackOnlyDialContext(context.Background(), "tcp", "not-a-valid-addr")
+	if err == nil {
+		t.Fatal("malformed addr must error")
+	}
+	if !strings.Contains(err.Error(), "invalid address") {
+		t.Errorf("error should mention 'invalid address', got: %v", err)
+	}
+}
+
+// TestICSLoopbackOnlyDialContext_BlocksLocalhostByName verifies
+// that a NAME (not an IP literal) resolving to loopback is
+// blocked at dial time. This is the DNS-rebinding defense — the
+// hostname itself might have passed static validation at save
+// time but resolves to 127.0.0.1 at fetch time.
+//
+// "localhost" resolves to 127.0.0.1 on virtually every system,
+// making it a reliable test input for the resolve-then-classify
+// path.
+func TestICSLoopbackOnlyDialContext_BlocksLocalhostByName(t *testing.T) {
+	_, err := icsLoopbackOnlyDialContext(context.Background(), "tcp", "localhost:12345")
+	if err == nil {
+		t.Fatal("localhost must resolve to loopback and be blocked")
+	}
+	if !strings.Contains(err.Error(), "blocked destination") {
+		t.Errorf("error should mention 'blocked destination', got: %v", err)
+	}
+}

--- a/internal/caldav/ics_validation_test.go
+++ b/internal/caldav/ics_validation_test.go
@@ -5,6 +5,90 @@ import (
 	"testing"
 )
 
+// TestIsStrictICSHTTPS covers the env var parsing for the
+// STRICT_ICS_HTTPS flag. Uses t.Setenv so each case starts from
+// a clean environment regardless of what the host has set. (#131)
+func TestIsStrictICSHTTPS(t *testing.T) {
+	cases := []struct {
+		env  string
+		want bool
+	}{
+		{"", false},
+		{"false", false},
+		{"no", false},
+		{"0", false},
+		{"off", false},     // not recognized as truthy
+		{"garbage", false}, // not recognized
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"1", true},
+		{"yes", true},
+		{"YES", true},
+		{" true ", true}, // whitespace tolerated via TrimSpace
+	}
+	for _, tc := range cases {
+		name := tc.env
+		if name == "" {
+			name = "(unset)"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("STRICT_ICS_HTTPS", tc.env)
+			if got := isStrictICSHTTPS(); got != tc.want {
+				t.Errorf("STRICT_ICS_HTTPS=%q → isStrictICSHTTPS() = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateICSFeedURL_StrictHTTPS covers the end-to-end
+// behavior of the #131 strict mode: when STRICT_ICS_HTTPS is
+// truthy, http:// URLs are rejected; when unset/false, http://
+// passes the scheme check.
+func TestValidateICSFeedURL_StrictHTTPS(t *testing.T) {
+	t.Run("http allowed by default (LAN compatibility)", func(t *testing.T) {
+		t.Setenv("STRICT_ICS_HTTPS", "")
+		if err := validateICSFeedURL("http://sports.example.com/team.ics"); err != nil {
+			t.Errorf("http:// must be allowed by default: %v", err)
+		}
+	})
+
+	t.Run("http rejected when strict mode is on", func(t *testing.T) {
+		t.Setenv("STRICT_ICS_HTTPS", "true")
+		err := validateICSFeedURL("http://sports.example.com/team.ics")
+		if err == nil {
+			t.Fatal("http:// must be rejected when STRICT_ICS_HTTPS=true")
+		}
+		if !strings.Contains(err.Error(), "STRICT_ICS_HTTPS") {
+			t.Errorf("error should mention STRICT_ICS_HTTPS for operator discoverability, got: %v", err)
+		}
+	})
+
+	t.Run("https always allowed", func(t *testing.T) {
+		t.Setenv("STRICT_ICS_HTTPS", "true")
+		if err := validateICSFeedURL("https://calendar.google.com/ical/example.ics"); err != nil {
+			t.Errorf("https:// must always pass: %v", err)
+		}
+	})
+
+	t.Run("other rejection rules still fire under strict mode", func(t *testing.T) {
+		// Even with strict mode on, the other checks (localhost,
+		// .local, file://) should still produce their own errors.
+		t.Setenv("STRICT_ICS_HTTPS", "true")
+
+		cases := []string{
+			"https://localhost/cal.ics",    // still rejected as localhost
+			"https://server.local/cal.ics", // still rejected as .local
+			"file:///etc/passwd",           // still rejected as non-http scheme
+		}
+		for _, u := range cases {
+			if err := validateICSFeedURL(u); err == nil {
+				t.Errorf("%q must still be rejected under strict mode", u)
+			}
+		}
+	})
+}
+
 // TestValidateICSFeedURL covers the scheme + host block rules from
 // #127. The validator is intentionally narrower than the webhook
 // validator (private IPs are still allowed for LAN calendar


### PR DESCRIPTION
## Summary

Resubmit of the two ICS PRs (#130 dial-time SSRF defense + #132 STRICT_ICS_HTTPS env var) that were auto-closed by GitHub when their stack parent (#128) merged and its base branch was deleted. Both commits cherry-picked cleanly onto main, tests still green.

## What's in this PR

1. **#130's commit** — dial-time DNS rebinding defense for ICS client via custom \`DialContext\`. Narrower block-list than the webhook version (loopback + unspecified + link-local only; RFC 1918 private ranges still allowed for LAN calendar servers).

2. **#132's commit** — opt-in \`STRICT_ICS_HTTPS\` env var. When set truthy, validateICSFeedURL rejects http:// ICS feed URLs. Default OFF because LAN ICS often runs plain HTTP.

Both commits are described fully in the referenced original PRs; the content here is identical.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./internal/caldav/...\` passes — all cases from both original PRs green (ICS dial tests, STRICT_ICS_HTTPS env parsing, validation table)

## Why a resubmit

The original stacked design (#128 → #130 → #132) worked fine for review but hit a GitHub quirk at merge time: merging #128 deleted its branch, which auto-closed #130 (whose base was that branch), and the API refused to reopen or rebase a closed PR. Rather than fight the tooling, I cherry-picked both commits onto a fresh branch from main and opened this single replacement PR.

## Related

- #128 (merged) — ICS feed URL static validation
- #130 (auto-closed) — this PR's first commit
- #132 (closed, superseded) — this PR's second commit