### PR TITLE
feat: quick wins — version display + sync window viz + calendar refresh (#136)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY . .
 
 # Build the binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -ldflags="-w -s -X main.Version=$(git describe --tags --always --dirty 2>/dev/null || echo 'dev')" \
+    -ldflags="-w -s -X github.com/macjediwizard/calbridgesync/internal/version.Version=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}" \
     -o /app/calbridgesync \
     ./cmd/calbridgesync
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,12 @@
+// Package version holds the build version string. The variable is
+// set at compile time via ldflags in the Dockerfile:
+//
+//	go build -ldflags="-X github.com/macjediwizard/calbridgesync/internal/version.Version=0.0.66"
+//
+// When running from source without ldflags, Version defaults to "dev".
+package version
+
+// Version is the semantic version of the calbridgesync binary,
+// injected at build time. Used by the /api/version endpoint and
+// displayed in the web UI footer.
+var Version = "dev"

--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/macjediwizard/calbridgesync/internal/caldav"
 	"github.com/macjediwizard/calbridgesync/internal/db"
 	"github.com/macjediwizard/calbridgesync/internal/notify"
+	"github.com/macjediwizard/calbridgesync/internal/version"
 )
 
 // sanitizeError returns a user-safe error message without exposing internal details.
@@ -299,6 +300,13 @@ func (h *Handlers) APIAuthStatus(c *gin.Context) {
 			Avatar: session.Picture,
 		},
 	})
+}
+
+// APIGetVersion returns the build version of the calbridgesync binary.
+// Unauthenticated — available on the public API group so the login
+// page and footer can display the version without a session.
+func (h *Handlers) APIGetVersion(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"version": version.Version})
 }
 
 // APILogout logs out the user.

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -50,6 +50,7 @@ func SetupRoutes(r *gin.Engine, h *Handlers, sm *auth.SessionManager) {
 	apiGroup.Use(auth.OptionalAuth(sm))
 	{
 		apiGroup.GET("/auth/status", h.APIAuthStatus)
+		apiGroup.GET("/version", h.APIGetVersion)
 		apiGroup.POST("/auth/logout", h.APILogout)
 	}
 

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CalBridgeSync</title>
-    <script type="module" crossorigin src="/assets/index-Bjsil5E3.js"></script>
+    <script type="module" crossorigin src="/assets/index-DuXLdpnc.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-BLOeowkf.css">
   </head>
   <body>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link, useLocation, Outlet } from 'react-router-dom';
 import type { User } from '../types';
+import { getVersion } from '../services/api';
 
 // Local logo
 const LOGO_URL = '/logo.png';
@@ -13,6 +14,11 @@ interface LayoutProps {
 export default function Layout({ user, onLogout }: LayoutProps) {
   const location = useLocation();
   const [logoError, setLogoError] = useState(false);
+  const [appVersion, setAppVersion] = useState<string>('');
+
+  useEffect(() => {
+    getVersion().then(v => setAppVersion(v.version)).catch(() => {});
+  }, []);
 
   const isActive = (path: string) => {
     if (path === '/') return location.pathname === '/';
@@ -126,7 +132,7 @@ export default function Layout({ user, onLogout }: LayoutProps) {
       {/* Footer */}
       <footer className="bg-zinc-900 border-t border-zinc-800 py-4 mt-auto">
         <div className="max-w-6xl mx-auto px-4 text-center">
-          <p className="text-gray-500 text-sm">CalBridgeSync - CalDAV Synchronization</p>
+          <p className="text-gray-500 text-sm">CalBridgeSync{appVersion ? ` v${appVersion}` : ''} - CalDAV Synchronization</p>
           <p className="text-gray-600 text-xs mt-1">Powered by MacJediWizard Digital Wizardry</p>
         </div>
       </footer>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -416,7 +416,16 @@ export default function Dashboard() {
                           </div>
                         </div>
                       </td>
-                      <td className="px-4 py-3 text-gray-400">{source.source_type}</td>
+                      <td className="px-4 py-3">
+                        <span className="text-gray-400">{source.source_type}</span>
+                        {source.sync_days_past > 0 ? (
+                          <span className="ml-2 text-xs text-gray-600" title={`Syncing events from the last ${source.sync_days_past} days`}>
+                            {source.sync_days_past}d
+                          </span>
+                        ) : (
+                          <span className="ml-2 text-xs text-gray-600" title="Syncing all events (no date filter)">all</span>
+                        )}
+                      </td>
                       <td className="px-4 py-3">
                         <div className="flex items-center space-x-2">
                           {source.enabled ? (

--- a/web/src/pages/SourceEdit.tsx
+++ b/web/src/pages/SourceEdit.tsx
@@ -68,22 +68,18 @@ export default function SourceEdit() {
       return;
     }
 
-    // For editing, we need to use the stored password if not changed
-    const password = form.source_password || 'USE_EXISTING';
-    if (password === 'USE_EXISTING' && !source) {
-      setDiscoverError('Please enter password to discover calendars');
+    // Calendar discovery requires the source password because the
+    // backend makes a live CalDAV PROPFIND against the server.
+    // Stored passwords are encrypted and not returned by the API,
+    // so the user must re-enter the password to rediscover.
+    if (!form.source_password) {
+      setDiscoverError('Re-enter your source password above to rediscover calendars (stored passwords are encrypted and cannot be reused for discovery)');
       return;
     }
 
     setDiscovering(true);
     setDiscoverError(null);
     try {
-      // If password is empty, we can't discover - need to inform user
-      if (!form.source_password) {
-        setDiscoverError('Please enter password to discover calendars');
-        setDiscovering(false);
-        return;
-      }
       const discovered = await discoverCalendars(form.source_url, form.source_username, form.source_password);
       setCalendars(discovered);
       // If no calendars selected yet, select all by default with source default sync direction
@@ -272,6 +268,13 @@ export default function SourceEdit() {
                   <option value={90}>90 days</option>
                   <option value={0}>Unlimited</option>
                 </select>
+                {form.sync_days_past > 0 ? (
+                  <p className="text-xs text-gray-500 mt-1">
+                    Syncing events from {new Date(Date.now() - form.sync_days_past * 86400000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} to today
+                  </p>
+                ) : (
+                  <p className="text-xs text-gray-500 mt-1">Syncing all events regardless of date</p>
+                )}
               </div>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -18,6 +18,11 @@ export const logout = async (): Promise<void> => {
   await api.post('/auth/logout');
 };
 
+export const getVersion = async (): Promise<{ version: string }> => {
+  const response = await api.get('/version');
+  return response.data;
+};
+
 // Dashboard
 export const getDashboardStats = async (): Promise<DashboardStats> => {
   const response = await api.get('/dashboard/stats');


### PR DESCRIPTION
## PR 1 of 15-feature wave

Three S-complexity features bundled:

### Version display (Feature 4)
- New \`internal/version/version.go\` package — \`var Version = \"dev\"\` set at build time via ldflags
- Dockerfile updated: \`-X github.com/macjediwizard/calbridgesync/internal/version.Version=...\`
- New \`GET /api/version\` endpoint (unauthenticated)
- Layout.tsx footer: "CalBridgeSync v0.0.66 - CalDAV Synchronization"

### Sync window visualization (Feature 10)
- Dashboard source rows: compact "30d" / "all" badge after source type
- SourceEdit: computed date range below Past Events dropdown ("Syncing events from Mar 13 to today")
- Pure frontend, no backend changes

### Calendar refresh polish (Feature 3)
- SourceEdit already preserved existing selections on rediscovery (correct logic)
- Replaced confusing dual error messages with clear explanation of why password re-entry is needed

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./...\` all packages green
- [x] \`npm run build\` passes

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)