### PR TITLE
feat: operational foundation — log retention config + credential expiry detection (#138)

### DIFF
--- a/cmd/calbridgesync/main.go
+++ b/cmd/calbridgesync/main.go
@@ -131,8 +131,8 @@ func main() {
 			cfg.Alerts.WebhookEnabled, cfg.Alerts.EmailEnabled, cfg.Alerts.CooldownMinutes)
 	}
 
-	// Initialize scheduler
-	sched := scheduler.New(database, syncEngine, notifier)
+	// Initialize scheduler with configurable log retention
+	sched := scheduler.New(database, syncEngine, notifier, cfg.LogRetentionDays)
 
 	// Initialize health checker
 	healthChecker := health.NewChecker(database, cfg.OIDC.Issuer, cfg.CalDAV.DefaultDestURL)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,10 @@ type Config struct {
 	Sync         SyncConfig
 	Alerts       AlertConfig
 	GoogleOAuth  GoogleOAuthConfig
+	// LogRetentionDays controls how many days of sync logs the
+	// scheduler's daily cleanup routine keeps. Configurable via
+	// SYNC_LOG_RETENTION_DAYS env var. Default 30.
+	LogRetentionDays int
 }
 
 // GoogleOAuthConfig holds instance-level Google OAuth2 settings. As of
@@ -299,6 +303,19 @@ func Load() (*Config, error) {
 	if cfg.GoogleOAuth.RedirectURL == "" && cfg.Server.BaseURL != "" {
 		cfg.GoogleOAuth.RedirectURL = strings.TrimRight(cfg.Server.BaseURL, "/") + "/auth/oauth/google/callback"
 	}
+
+	// Sync log retention (default 30 days, range 1-365)
+	logRetention, err := getEnvInt("SYNC_LOG_RETENTION_DAYS", 30)
+	if err != nil {
+		return nil, fmt.Errorf("%w: SYNC_LOG_RETENTION_DAYS: %w", ErrInvalidConfig, err)
+	}
+	if logRetention < 1 {
+		logRetention = 1
+	}
+	if logRetention > 365 {
+		logRetention = 365
+	}
+	cfg.LogRetentionDays = logRetention
 
 	// Check for missing required configuration
 	missing := cfg.getMissingRequired()

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -490,6 +490,18 @@ func (db *DB) CleanOldSyncLogs(olderThan time.Time) (int64, error) {
 	return affected, nil
 }
 
+// GetSyncLogStats returns aggregate stats about the sync_logs table:
+// total count and oldest log timestamp. Used by the Settings page to
+// show log retention status. (#136)
+func (db *DB) GetSyncLogStats() (count int64, oldest time.Time, err error) {
+	row := db.conn.QueryRow(`SELECT COUNT(*), COALESCE(MIN(created_at), CURRENT_TIMESTAMP) FROM sync_logs`)
+	err = row.Scan(&count, &oldest)
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("failed to get sync log stats: %w", err)
+	}
+	return count, oldest, nil
+}
+
 // parseSelectedCalendars parses selected_calendars JSON with backward compatibility.
 // Old format: ["path1", "path2"] (array of strings)
 // New format: [{"path": "path1", "sync_direction": "one_way"}] (array of CalendarConfig)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -14,12 +14,12 @@ import (
 )
 
 const (
-	cleanupInterval   = 24 * time.Hour
-	logRetentionDays  = 30
-	syncTimeout       = 120 * time.Minute // Maximum time for a single sync operation (2 hours for slow iCloud with multiple calendars)
-	healthLogInterval = 5 * time.Minute   // Interval for scheduler health logging
-	staleMultiplier   = 2                 // Source is stale if last sync > staleMultiplier * interval
-	startupStagger    = 30 * time.Second  // Delay between starting each source's first sync
+	cleanupInterval         = 24 * time.Hour
+	defaultLogRetentionDays = 30
+	syncTimeout             = 120 * time.Minute // Maximum time for a single sync operation (2 hours for slow iCloud with multiple calendars)
+	healthLogInterval       = 5 * time.Minute   // Interval for scheduler health logging
+	staleMultiplier         = 2                 // Source is stale if last sync > staleMultiplier * interval
+	startupStagger          = 30 * time.Second  // Delay between starting each source's first sync
 
 	// Liveness watchdog constants (Issue #43). The watchdog detects
 	// routines that have crashed (caught by PR #38 panic recovery but
@@ -108,21 +108,40 @@ type Scheduler struct {
 	// uncontended. (#93)
 	skipCountsMu sync.Mutex
 	skipCounts   map[string]int
+
+	// logRetentionDays is the number of days to keep sync logs before
+	// the daily cleanup routine purges them. Configurable via
+	// SYNC_LOG_RETENTION_DAYS env var; defaults to 30. (#136)
+	logRetentionDays int
+
+	// authFailCounts tracks consecutive authentication failures per
+	// source so the scheduler can alert when credentials may have
+	// expired. Reset on successful sync. (#136)
+	authFailCountsMu sync.Mutex
+	authFailCounts   map[string]int
 }
 
-// New creates a new scheduler.
-func New(database *db.DB, syncEngine *caldav.SyncEngine, notifier *notify.Notifier) *Scheduler {
+// New creates a new scheduler. logRetentionDays controls how many
+// days of sync logs the daily cleanup routine keeps. Pass 0 to use
+// the default (30 days).
+func New(database *db.DB, syncEngine *caldav.SyncEngine, notifier *notify.Notifier, logRetentionDays ...int) *Scheduler {
+	retention := defaultLogRetentionDays
+	if len(logRetentionDays) > 0 && logRetentionDays[0] > 0 {
+		retention = logRetentionDays[0]
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Scheduler{
-		db:         database,
-		syncEngine: syncEngine,
-		notifier:   notifier,
-		jobs:       make(map[string]*Job),
-		syncLocks:  make(map[string]*sync.Mutex),
-		ctx:        ctx,
-		cancel:     cancel,
-		heartbeats: make(map[string]time.Time),
-		skipCounts: make(map[string]int),
+		db:               database,
+		syncEngine:       syncEngine,
+		notifier:         notifier,
+		logRetentionDays: retention,
+		jobs:             make(map[string]*Job),
+		syncLocks:        make(map[string]*sync.Mutex),
+		ctx:              ctx,
+		cancel:           cancel,
+		heartbeats:       make(map[string]time.Time),
+		skipCounts:       make(map[string]int),
+		authFailCounts:   make(map[string]int),
 	}
 }
 
@@ -143,6 +162,77 @@ func (s *Scheduler) resetSkipCount(sourceID string) {
 	s.skipCountsMu.Lock()
 	defer s.skipCountsMu.Unlock()
 	delete(s.skipCounts, sourceID)
+}
+
+// authFailureAlertThreshold is how many consecutive auth failures
+// must occur before the scheduler sends a credential-expiry alert.
+// Fires exactly once at the threshold; subsequent failures are
+// logged but don't re-alert (the regular sync failure alert
+// covers those). Reset on any successful sync. (#136)
+const authFailureAlertThreshold = 3
+
+// incrementAuthFailCount bumps the auth failure counter and returns
+// the new value. Safe for concurrent callers.
+func (s *Scheduler) incrementAuthFailCount(sourceID string) int {
+	s.authFailCountsMu.Lock()
+	defer s.authFailCountsMu.Unlock()
+	s.authFailCounts[sourceID]++
+	return s.authFailCounts[sourceID]
+}
+
+// resetAuthFailCount zeros the auth failure counter for a source.
+// Called on every successful sync.
+func (s *Scheduler) resetAuthFailCount(sourceID string) {
+	s.authFailCountsMu.Lock()
+	defer s.authFailCountsMu.Unlock()
+	delete(s.authFailCounts, sourceID)
+}
+
+// isAuthError returns true if the sync result looks like it failed
+// due to an authentication or authorization problem. Uses substring
+// matching against the error strings because CalDAV servers report
+// auth failures inconsistently.
+func (s *Scheduler) isAuthError(result *caldav.SyncResult) bool {
+	check := func(text string) bool {
+		lower := strings.ToLower(text)
+		return strings.Contains(lower, "401") ||
+			strings.Contains(lower, "403") ||
+			strings.Contains(lower, "unauthorized") ||
+			strings.Contains(lower, "forbidden") ||
+			strings.Contains(lower, "authentication failed") ||
+			strings.Contains(lower, "access denied") ||
+			strings.Contains(lower, "invalid credentials")
+	}
+	if check(result.Message) {
+		return true
+	}
+	for _, e := range result.Errors {
+		if check(e) {
+			return true
+		}
+	}
+	return false
+}
+
+// sendCredentialExpiryAlert fires a one-shot alert when a source
+// hits authFailureAlertThreshold consecutive auth failures. Uses
+// the existing notifier with a distinctive message so operators
+// can tell "credentials expired" apart from "server down."
+func (s *Scheduler) sendCredentialExpiryAlert(source *db.Source, consecutiveFailures int) {
+	if s.notifier == nil {
+		return
+	}
+	userEmail := ""
+	if user, err := s.db.GetUserByID(source.UserID); err == nil {
+		userEmail = user.Email
+	}
+	userPrefs := s.getUserAlertPrefs(source.UserID)
+	msg := fmt.Sprintf("Credentials may be expired for source '%s' — %d consecutive authentication failures. Re-enter credentials in the web UI.",
+		source.Name, consecutiveFailures)
+	s.notifier.SendSyncFailureAlertWithPrefs(
+		s.ctx, source.ID, source.Name, userEmail,
+		msg, "Check if the app password or OAuth token was revoked.", userPrefs,
+	)
 }
 
 // Start loads all enabled sources and starts their sync jobs.
@@ -735,6 +825,9 @@ func (s *Scheduler) executeSync(sourceID string) {
 		log.Printf("Sync completed for source %s: %d created, %d updated, %d deleted, %d duplicates removed in %v",
 			source.Name, result.Created, result.Updated, result.Deleted, result.DuplicatesRemoved, result.Duration)
 
+		// Reset auth failure counter on success
+		s.resetAuthFailCount(sourceID)
+
 		// Send recovery notification if source was previously stale
 		if s.notifier != nil && s.notifier.IsEnabled() {
 			// Look up user email for per-user notifications
@@ -749,6 +842,17 @@ func (s *Scheduler) executeSync(sourceID string) {
 		}
 	} else {
 		log.Printf("Sync failed for source %s: %s", source.Name, result.Message)
+
+		// Track consecutive auth failures. If the sync failed
+		// because of authentication (401/403), increment the
+		// counter. At the threshold, send an alert so the operator
+		// knows credentials may have expired. (#136)
+		if s.isAuthError(result) {
+			count := s.incrementAuthFailCount(sourceID)
+			if count == authFailureAlertThreshold {
+				s.sendCredentialExpiryAlert(source, count)
+			}
+		}
 	}
 
 	// Fire a failure alert when appropriate. This covers two cases:
@@ -848,7 +952,7 @@ func (s *Scheduler) cleanupRoutine() {
 
 // cleanupOldLogs deletes sync logs older than retention period.
 func (s *Scheduler) cleanupOldLogs() {
-	cutoff := time.Now().AddDate(0, 0, -logRetentionDays)
+	cutoff := time.Now().AddDate(0, 0, -s.logRetentionDays)
 	deleted, err := s.db.CleanOldSyncLogs(cutoff)
 	if err != nil {
 		log.Printf("Failed to clean old sync logs: %v", err)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -73,9 +73,23 @@ func TestSchedulerConstants(t *testing.T) {
 		}
 	})
 
-	t.Run("log retention is 30 days", func(t *testing.T) {
-		if logRetentionDays != 30 {
-			t.Errorf("expected logRetentionDays to be 30, got %d", logRetentionDays)
+	t.Run("default log retention is 30 days", func(t *testing.T) {
+		if defaultLogRetentionDays != 30 {
+			t.Errorf("expected defaultLogRetentionDays to be 30, got %d", defaultLogRetentionDays)
+		}
+	})
+
+	t.Run("scheduler uses configured retention days", func(t *testing.T) {
+		sched := New(nil, nil, nil, 60)
+		if sched.logRetentionDays != 60 {
+			t.Errorf("expected logRetentionDays 60, got %d", sched.logRetentionDays)
+		}
+	})
+
+	t.Run("scheduler defaults to 30 when no retention arg", func(t *testing.T) {
+		sched := New(nil, nil, nil)
+		if sched.logRetentionDays != 30 {
+			t.Errorf("expected logRetentionDays 30, got %d", sched.logRetentionDays)
 		}
 	})
 

--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -309,6 +309,29 @@ func (h *Handlers) APIGetVersion(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"version": version.Version})
 }
 
+// APIGetLogStats returns aggregate sync log statistics for the
+// Settings page. Shows total count, oldest log, and retention
+// period so operators can gauge log growth. (#136)
+func (h *Handlers) APIGetLogStats(c *gin.Context) {
+	session := auth.GetCurrentUser(c)
+	if session == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	count, oldest, err := h.db.GetSyncLogStats()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get log stats"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"total_logs":     count,
+		"oldest_log":     oldest.Format(time.RFC3339),
+		"retention_days": h.cfg.LogRetentionDays,
+	})
+}
+
 // APILogout logs out the user.
 func (h *Handlers) APILogout(c *gin.Context) {
 	if err := h.session.Clear(c.Writer, c.Request); err != nil {

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -75,6 +75,7 @@ func SetupRoutes(r *gin.Engine, h *Handlers, sm *auth.SessionManager) {
 		protectedAPI.DELETE("/malformed-events/:id", h.APIDeleteMalformedEvent)
 		protectedAPI.GET("/settings/alerts", h.APIGetAlertPreferences)
 		protectedAPI.PUT("/settings/alerts", h.APIUpdateAlertPreferences)
+		protectedAPI.GET("/settings/log-stats", h.APIGetLogStats)
 		protectedAPI.GET("/activity", h.APIGetActivity)
 	}
 

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CalBridgeSync</title>
-    <script type="module" crossorigin src="/assets/index-DuXLdpnc.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BLOeowkf.css">
+    <script type="module" crossorigin src="/assets/index-B-dGESRH.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BJWxMb5G.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect } from 'react';
-import { getAlertPreferences, updateAlertPreferences, testWebhook } from '../services/api';
+import { getAlertPreferences, updateAlertPreferences, testWebhook, getLogStats } from '../services/api';
 import type { AlertPreferences } from '../types';
+
+interface LogStatsData {
+  total_logs: number;
+  oldest_log: string;
+  retention_days: number;
+}
 
 export default function Settings() {
   const [preferences, setPreferences] = useState<AlertPreferences>({
@@ -9,6 +15,7 @@ export default function Settings() {
     webhook_url: '',
     cooldown_minutes: null,
   });
+  const [logStats, setLogStats] = useState<LogStatsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -17,6 +24,7 @@ export default function Settings() {
 
   useEffect(() => {
     loadPreferences();
+    getLogStats().then(setLogStats).catch(() => {});
   }, []);
 
   const loadPreferences = async () => {
@@ -210,6 +218,34 @@ export default function Settings() {
           {saving ? 'Saving...' : 'Save Preferences'}
         </button>
       </div>
+
+      {/* Log Retention Stats */}
+      {logStats && (
+        <div className="bg-zinc-900 rounded-lg border border-zinc-800 overflow-hidden mt-6">
+          <div className="p-4 border-b border-zinc-800">
+            <h3 className="text-lg font-medium text-white">Sync Log Retention</h3>
+            <p className="text-sm text-gray-400 mt-1">Logs older than {logStats.retention_days} days are automatically purged daily</p>
+          </div>
+          <div className="p-4">
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <p className="text-xs text-gray-500 uppercase">Total Logs</p>
+                <p className="text-lg font-medium text-white">{logStats.total_logs.toLocaleString()}</p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500 uppercase">Oldest Log</p>
+                <p className="text-lg font-medium text-white">
+                  {new Date(logStats.oldest_log).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500 uppercase">Retention</p>
+                <p className="text-lg font-medium text-white">{logStats.retention_days} days</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -142,6 +142,11 @@ export const testWebhook = async (url: string): Promise<void> => {
   await api.post('/settings/alerts/test-webhook', { webhook_url: url });
 };
 
+export const getLogStats = async (): Promise<{ total_logs: number; oldest_log: string; retention_days: number }> => {
+  const response = await api.get('/settings/log-stats');
+  return response.data;
+};
+
 // Activity
 export const getActivity = async (): Promise<ActivityData> => {
   const response = await api.get('/activity');


### PR DESCRIPTION
## PR 2 of 15-feature wave

### Configurable log retention (Feature 1)
- \`SYNC_LOG_RETENTION_DAYS\` env var (default 30, range 1-365)
- Settings page shows total logs, oldest log date, retention period
- New \`GET /api/settings/log-stats\` endpoint

### Credential expiry detection (Feature 2)
- Tracks consecutive auth failures per source (401/403/unauthorized substring matching)
- At threshold of 3, fires one-shot alert via existing notifier: "Credentials may be expired for source X"
- Resets on any successful sync

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./...\` all packages green
- [x] \`npm run build\` passes
- [x] Scheduler constant tests updated for new naming

Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)