### PR TITLE
feat: Slack/Discord rich webhook formatting (#140)

### DIFF
--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -411,6 +411,9 @@ func (n *Notifier) initialBackoff() time.Duration {
 // variants. The legacy functions had no callers and were just dead code.
 
 // WebhookPayload is the JSON payload sent to webhooks.
+// WebhookPayload is the generic JSON payload for webhook
+// notifications. Used when the webhook URL doesn't match a
+// known platform (Slack or Discord).
 type WebhookPayload struct {
 	AlertType  string `json:"alert_type"`
 	SourceID   string `json:"source_id"`
@@ -422,31 +425,149 @@ type WebhookPayload struct {
 	Text string `json:"text,omitempty"`
 }
 
-func (n *Notifier) sendWebhook(ctx context.Context, alert Alert) error {
-	// Build Slack-compatible message.
-	// Idempotent setup lives outside the retry: re-marshaling the same
-	// payload every attempt is wasted work.
-	emoji := ""
-	switch alert.Type {
+// webhookPlatform identifies which platform-specific formatter to
+// use for a webhook URL.
+type webhookPlatform string
+
+const (
+	platformGeneric webhookPlatform = "generic"
+	platformSlack   webhookPlatform = "slack"
+	platformDiscord webhookPlatform = "discord"
+)
+
+// detectWebhookPlatform infers the target platform from the webhook
+// URL so we can send rich-formatted payloads (Slack Block Kit,
+// Discord embeds) instead of a generic JSON blob.
+func detectWebhookPlatform(webhookURL string) webhookPlatform {
+	lower := strings.ToLower(webhookURL)
+	if strings.Contains(lower, "hooks.slack.com") {
+		return platformSlack
+	}
+	if strings.Contains(lower, "discord.com/api/webhooks") || strings.Contains(lower, "discordapp.com/api/webhooks") {
+		return platformDiscord
+	}
+	return platformGeneric
+}
+
+// alertEmoji returns the emoji string for an alert type.
+func alertEmoji(alertType AlertType) string {
+	switch alertType {
 	case AlertTypeStale:
-		emoji = ":warning:"
+		return ":warning:"
 	case AlertTypeRecovery:
-		emoji = ":white_check_mark:"
+		return ":white_check_mark:"
 	case AlertTypeError:
-		emoji = ":x:"
+		return ":x:"
+	default:
+		return ":bell:"
 	}
+}
 
-	payload := WebhookPayload{
-		AlertType:  string(alert.Type),
-		SourceID:   alert.SourceID,
-		SourceName: alert.SourceName,
-		Message:    alert.Message,
-		Details:    alert.Details,
-		Timestamp:  alert.Timestamp.Format(time.RFC3339),
-		Text:       fmt.Sprintf("%s *%s*\n%s", emoji, alert.Message, alert.Details),
+// alertColor returns a color integer for the alert type, used by
+// Discord embeds and Slack attachment sidebars.
+func alertColor(alertType AlertType) int {
+	switch alertType {
+	case AlertTypeError:
+		return 15158332 // red
+	case AlertTypeRecovery:
+		return 3066993 // green
+	case AlertTypeStale:
+		return 15105570 // orange
+	default:
+		return 3447003 // blue
 	}
+}
 
-	body, err := json.Marshal(payload)
+// formatSlackPayload builds a Slack Block Kit payload with a
+// colored sidebar, header, and structured fields.
+func formatSlackPayload(alert Alert) ([]byte, error) {
+	emoji := alertEmoji(alert.Type)
+	color := fmt.Sprintf("#%06x", alertColor(alert.Type))
+
+	payload := map[string]interface{}{
+		"text": fmt.Sprintf("%s %s", emoji, alert.Message),
+		"attachments": []map[string]interface{}{
+			{
+				"color": color,
+				"blocks": []map[string]interface{}{
+					{
+						"type": "section",
+						"fields": []map[string]interface{}{
+							{"type": "mrkdwn", "text": fmt.Sprintf("*Alert:* %s", alert.Type)},
+							{"type": "mrkdwn", "text": fmt.Sprintf("*Source:* %s", alert.SourceName)},
+						},
+					},
+					{
+						"type": "section",
+						"text": map[string]interface{}{
+							"type": "mrkdwn",
+							"text": alert.Details,
+						},
+					},
+					{
+						"type": "context",
+						"elements": []map[string]interface{}{
+							{"type": "mrkdwn", "text": fmt.Sprintf("CalBridgeSync | %s", alert.Timestamp.Format(time.RFC1123))},
+						},
+					},
+				},
+			},
+		},
+	}
+	return json.Marshal(payload)
+}
+
+// formatDiscordPayload builds a Discord embed payload with a
+// colored sidebar, title, fields, and timestamp.
+func formatDiscordPayload(alert Alert) ([]byte, error) {
+	payload := map[string]interface{}{
+		"content": fmt.Sprintf("%s %s", alertEmoji(alert.Type), alert.Message),
+		"embeds": []map[string]interface{}{
+			{
+				"title":       "CalBridgeSync Alert",
+				"description": alert.Details,
+				"color":       alertColor(alert.Type),
+				"fields": []map[string]interface{}{
+					{"name": "Type", "value": string(alert.Type), "inline": true},
+					{"name": "Source", "value": alert.SourceName, "inline": true},
+					{"name": "Source ID", "value": alert.SourceID, "inline": false},
+				},
+				"timestamp": alert.Timestamp.Format(time.RFC3339),
+				"footer": map[string]interface{}{
+					"text": "CalBridgeSync",
+				},
+			},
+		},
+	}
+	return json.Marshal(payload)
+}
+
+// buildWebhookPayload selects the appropriate formatter based on
+// the webhook URL and returns the marshaled JSON payload.
+func buildWebhookPayload(alert Alert, webhookURL string) ([]byte, error) {
+	platform := detectWebhookPlatform(webhookURL)
+	switch platform {
+	case platformSlack:
+		return formatSlackPayload(alert)
+	case platformDiscord:
+		return formatDiscordPayload(alert)
+	default:
+		emoji := alertEmoji(alert.Type)
+		payload := WebhookPayload{
+			AlertType:  string(alert.Type),
+			SourceID:   alert.SourceID,
+			SourceName: alert.SourceName,
+			Message:    alert.Message,
+			Details:    alert.Details,
+			Timestamp:  alert.Timestamp.Format(time.RFC3339),
+			Text:       fmt.Sprintf("%s *%s*\n%s", emoji, alert.Message, alert.Details),
+		}
+		return json.Marshal(payload)
+	}
+}
+
+func (n *Notifier) sendWebhook(ctx context.Context, alert Alert) error {
+	body, err := buildWebhookPayload(alert, n.cfg.WebhookURL)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
@@ -963,6 +1084,8 @@ func (n *Notifier) sendWithPrefs(ctx context.Context, alert Alert, userPrefs *Us
 }
 
 // sendWebhookToURL sends a webhook to a specific URL (for user webhooks).
+// Uses the same platform-detection + rich-formatting as sendWebhook so
+// per-user Slack/Discord webhooks get Block Kit / embed payloads too.
 func (n *Notifier) sendWebhookToURL(ctx context.Context, alert Alert, webhookURL string) error {
 	// Validate URL before sending (security check). Validation failures
 	// are permanent — no point retrying a URL that will never pass.
@@ -970,29 +1093,7 @@ func (n *Notifier) sendWebhookToURL(ctx context.Context, alert Alert, webhookURL
 		return fmt.Errorf("invalid webhook URL: %w", err)
 	}
 
-	// Build Slack-compatible message. Idempotent setup stays outside
-	// the retry.
-	emoji := ""
-	switch alert.Type {
-	case AlertTypeStale:
-		emoji = ":warning:"
-	case AlertTypeRecovery:
-		emoji = ":white_check_mark:"
-	case AlertTypeError:
-		emoji = ":x:"
-	}
-
-	payload := WebhookPayload{
-		AlertType:  string(alert.Type),
-		SourceID:   alert.SourceID,
-		SourceName: alert.SourceName,
-		Message:    alert.Message,
-		Details:    alert.Details,
-		Timestamp:  alert.Timestamp.Format(time.RFC3339),
-		Text:       fmt.Sprintf("%s *%s*\n%s", emoji, alert.Message, alert.Details),
-	}
-
-	body, err := json.Marshal(payload)
+	body, err := buildWebhookPayload(alert, webhookURL)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}

--- a/internal/notify/webhook_format_test.go
+++ b/internal/notify/webhook_format_test.go
@@ -1,0 +1,161 @@
+package notify
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectWebhookPlatform(t *testing.T) {
+	cases := []struct {
+		url  string
+		want webhookPlatform
+	}{
+		{"https://hooks.slack.com/services/T00/B00/xxx", platformSlack},
+		{"https://hooks.slack.com/workflows/xxx", platformSlack},
+		{"https://HOOKS.SLACK.COM/services/xxx", platformSlack},
+		{"https://discord.com/api/webhooks/123/abc", platformDiscord},
+		{"https://discordapp.com/api/webhooks/123/abc", platformDiscord},
+		{"https://DISCORD.COM/api/webhooks/123/abc", platformDiscord},
+		{"https://example.com/webhook", platformGeneric},
+		{"https://my-slack-clone.com/hooks", platformGeneric},
+		{"", platformGeneric},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			got := detectWebhookPlatform(tc.url)
+			if got != tc.want {
+				t.Errorf("detectWebhookPlatform(%q) = %q, want %q", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatSlackPayload(t *testing.T) {
+	alert := Alert{
+		Type:       AlertTypeError,
+		SourceID:   "src-123",
+		SourceName: "My Calendar",
+		Message:    "Sync failed",
+		Details:    "Connection timeout",
+		Timestamp:  time.Date(2026, 4, 12, 10, 30, 0, 0, time.UTC),
+	}
+
+	body, err := formatSlackPayload(alert)
+	if err != nil {
+		t.Fatalf("formatSlackPayload error: %v", err)
+	}
+
+	// Verify it's valid JSON
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Has text field (Slack fallback)
+	text, ok := parsed["text"].(string)
+	if !ok || text == "" {
+		t.Error("missing or empty text field")
+	}
+	if !strings.Contains(text, "Sync failed") {
+		t.Errorf("text should contain message, got: %s", text)
+	}
+
+	// Has attachments with color
+	attachments, ok := parsed["attachments"].([]interface{})
+	if !ok || len(attachments) == 0 {
+		t.Fatal("missing attachments")
+	}
+	att := attachments[0].(map[string]interface{})
+	color, ok := att["color"].(string)
+	if !ok || color == "" {
+		t.Error("missing color in attachment")
+	}
+}
+
+func TestFormatDiscordPayload(t *testing.T) {
+	alert := Alert{
+		Type:       AlertTypeRecovery,
+		SourceID:   "src-456",
+		SourceName: "iCloud Caldav",
+		Message:    "Source recovered",
+		Details:    "Back online",
+		Timestamp:  time.Date(2026, 4, 12, 10, 30, 0, 0, time.UTC),
+	}
+
+	body, err := formatDiscordPayload(alert)
+	if err != nil {
+		t.Fatalf("formatDiscordPayload error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Has content (Discord fallback text)
+	content, ok := parsed["content"].(string)
+	if !ok || content == "" {
+		t.Error("missing content")
+	}
+
+	// Has embeds with color + fields
+	embeds, ok := parsed["embeds"].([]interface{})
+	if !ok || len(embeds) == 0 {
+		t.Fatal("missing embeds")
+	}
+	embed := embeds[0].(map[string]interface{})
+	if embed["title"] != "CalBridgeSync Alert" {
+		t.Errorf("unexpected title: %v", embed["title"])
+	}
+	if embed["color"] == nil {
+		t.Error("missing color in embed")
+	}
+	fields, ok := embed["fields"].([]interface{})
+	if !ok || len(fields) < 2 {
+		t.Error("expected at least 2 fields in embed")
+	}
+}
+
+func TestBuildWebhookPayload_RoutesToCorrectFormatter(t *testing.T) {
+	alert := Alert{
+		Type:       AlertTypeStale,
+		SourceID:   "src-789",
+		SourceName: "Test Source",
+		Message:    "Source stale",
+		Details:    "No sync in 2 hours",
+		Timestamp:  time.Now(),
+	}
+
+	t.Run("slack URL gets attachments", func(t *testing.T) {
+		body, err := buildWebhookPayload(alert, "https://hooks.slack.com/services/T00/B00/xxx")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(body), "attachments") {
+			t.Error("Slack payload should contain 'attachments'")
+		}
+	})
+
+	t.Run("discord URL gets embeds", func(t *testing.T) {
+		body, err := buildWebhookPayload(alert, "https://discord.com/api/webhooks/123/abc")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(body), "embeds") {
+			t.Error("Discord payload should contain 'embeds'")
+		}
+	})
+
+	t.Run("generic URL gets WebhookPayload", func(t *testing.T) {
+		body, err := buildWebhookPayload(alert, "https://example.com/webhook")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(body), "alert_type") {
+			t.Error("Generic payload should contain 'alert_type'")
+		}
+	})
+}


### PR DESCRIPTION
## PR 3 of 15-feature wave

Auto-detect webhook URL platform and send rich-formatted payloads:

- **Slack:** Block Kit with colored sidebar + structured fields
- **Discord:** Embed with color + fields + timestamp + footer
- **Generic:** Existing JSON blob (backward compatible)

Both global webhook (\`sendWebhook\`) and per-user webhook (\`sendWebhookToURL\`) use the same formatter, so Slack/Discord rich formatting works for operator-level AND user-level webhook URLs.

## Tests
- [x] \`go test -count=1 ./...\` all green
- [x] 9 URL detection cases, 3 formatter structure tests, 3 routing tests

Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)