### PR TITLE
feat: dashboard per-source stats + health scoring (#142)

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -273,3 +273,20 @@ type MalformedEvent struct {
 	ErrorMessage string    `json:"error_message"`
 	DiscoveredAt time.Time `json:"discovered_at"`
 }
+
+// SourceStats holds per-source statistics for the dashboard. (#136)
+type SourceStats struct {
+	SyncedEventCount int           `json:"synced_event_count"`
+	MalformedCount   int           `json:"malformed_count"`
+	RecentSyncs      []MiniSyncLog `json:"recent_syncs"`
+	SuccessRate      float64       `json:"success_rate"`
+	HealthScore      float64       `json:"health_score"`
+	HealthLabel      string        `json:"health_label"`
+}
+
+// MiniSyncLog is a compact sync log entry for sparklines. (#136)
+type MiniSyncLog struct {
+	Status     SyncStatus `json:"status"`
+	DurationMs int        `json:"duration_ms"`
+	CreatedAt  time.Time  `json:"created_at"`
+}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -490,6 +490,86 @@ func (db *DB) CleanOldSyncLogs(olderThan time.Time) (int64, error) {
 	return affected, nil
 }
 
+// GetSourceStats returns per-source statistics including event count,
+// malformed count, recent sync history, success rate, and health
+// score for the dashboard. (#136)
+func (db *DB) GetSourceStats(sourceID string) (*SourceStats, error) {
+	stats := &SourceStats{}
+
+	// Synced event count
+	row := db.conn.QueryRow(`SELECT COUNT(*) FROM synced_events WHERE source_id = ?`, sourceID)
+	if err := row.Scan(&stats.SyncedEventCount); err != nil {
+		return nil, fmt.Errorf("failed to count synced events: %w", err)
+	}
+
+	// Malformed event count
+	row = db.conn.QueryRow(`SELECT COUNT(*) FROM malformed_events WHERE source_id = ?`, sourceID)
+	if err := row.Scan(&stats.MalformedCount); err != nil {
+		return nil, fmt.Errorf("failed to count malformed events: %w", err)
+	}
+
+	// Last 20 sync logs for sparkline + success rate
+	rows, err := db.conn.Query(
+		`SELECT status, duration_ms, created_at FROM sync_logs WHERE source_id = ? ORDER BY created_at DESC LIMIT 20`,
+		sourceID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query recent sync logs: %w", err)
+	}
+	defer rows.Close()
+
+	var successCount int
+	for rows.Next() {
+		var mini MiniSyncLog
+		var durationMs int
+		if err := rows.Scan(&mini.Status, &durationMs, &mini.CreatedAt); err != nil {
+			continue
+		}
+		mini.DurationMs = durationMs
+		stats.RecentSyncs = append(stats.RecentSyncs, mini)
+		if mini.Status == SyncStatusSuccess {
+			successCount++
+		}
+	}
+
+	total := len(stats.RecentSyncs)
+	if total > 0 {
+		stats.SuccessRate = float64(successCount) / float64(total) * 100
+	}
+
+	// Health score: weighted
+	// Success rate (0.5) + malformed (0.2) + warning frequency (0.3)
+	successScore := stats.SuccessRate / 100.0
+	malformedScore := 1.0
+	if stats.MalformedCount > 5 {
+		malformedScore = 0.3
+	} else if stats.MalformedCount > 0 {
+		malformedScore = 0.7
+	}
+	// Warning frequency: count partial/error in recent syncs
+	warningCount := 0
+	for _, s := range stats.RecentSyncs {
+		if s.Status == SyncStatusPartial || s.Status == SyncStatusError {
+			warningCount++
+		}
+	}
+	warningScore := 1.0
+	if total > 0 {
+		warningScore = 1.0 - float64(warningCount)/float64(total)
+	}
+
+	stats.HealthScore = successScore*0.5 + malformedScore*0.2 + warningScore*0.3
+	if stats.HealthScore >= 0.8 {
+		stats.HealthLabel = "healthy"
+	} else if stats.HealthScore >= 0.5 {
+		stats.HealthLabel = "degraded"
+	} else {
+		stats.HealthLabel = "unhealthy"
+	}
+
+	return stats, nil
+}
+
 // GetSyncLogStats returns aggregate stats about the sync_logs table:
 // total count and oldest log timestamp. Used by the Settings page to
 // show log retention status. (#136)

--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -881,6 +881,28 @@ func (h *Handlers) APITriggerSync(c *gin.Context) {
 }
 
 // APIGetSourceLogs returns logs for a source.
+// APIGetSourceStats returns per-source statistics including event
+// count, malformed count, recent sync history, success rate, and
+// health score for the dashboard. (#136)
+func (h *Handlers) APIGetSourceStats(c *gin.Context) {
+	session := auth.GetCurrentUser(c)
+	if session == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	sourceID := c.Param("id")
+	if _, err := h.db.GetSourceByIDForUser(sourceID, session.UserID); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Source not found"})
+		return
+	}
+	stats, err := h.db.GetSourceStats(sourceID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get source stats"})
+		return
+	}
+	c.JSON(http.StatusOK, stats)
+}
+
 func (h *Handlers) APIGetSourceLogs(c *gin.Context) {
 	session := auth.GetCurrentUser(c)
 	if session == nil {

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -70,6 +70,7 @@ func SetupRoutes(r *gin.Engine, h *Handlers, sm *auth.SessionManager) {
 		protectedAPI.POST("/sources/:id/toggle", h.APIToggleSource)
 		protectedAPI.POST("/sources/:id/sync", h.APITriggerSync)
 		protectedAPI.GET("/sources/:id/logs", h.APIGetSourceLogs)
+		protectedAPI.GET("/sources/:id/stats", h.APIGetSourceStats)
 		protectedAPI.GET("/malformed-events", h.APIGetMalformedEvents)
 		protectedAPI.DELETE("/malformed-events", h.APIDeleteAllMalformedEvents)
 		protectedAPI.DELETE("/malformed-events/:id", h.APIDeleteMalformedEvent)

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CalBridgeSync</title>
-    <script type="module" crossorigin src="/assets/index-B-dGESRH.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BJWxMb5G.css">
+    <script type="module" crossorigin src="/assets/index-Do6OLJ66.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-ZC2dUDNT.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
-import { getDashboardStats, getSources, triggerSync, getSyncHistory, getMalformedEvents, deleteMalformedEvent, deleteAllMalformedEvents } from '../services/api';
+import { getDashboardStats, getSources, triggerSync, getSyncHistory, getMalformedEvents, deleteMalformedEvent, deleteAllMalformedEvents, getSourceStats } from '../services/api';
 import type { DashboardStats, Source, SyncHistory, MalformedEvent } from '../types';
 import {
   AreaChart,
@@ -28,6 +28,7 @@ export default function Dashboard() {
   const [sources, setSources] = useState<Source[]>([]);
   const [syncHistory, setSyncHistory] = useState<SyncHistory | null>(null);
   const [malformedEvents, setMalformedEvents] = useState<MalformedEvent[]>([]);
+  const [sourceStatsMap, setSourceStatsMap] = useState<Record<string, { health_label: string; synced_event_count: number }>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [syncingId, setSyncingId] = useState<string | null>(null);
@@ -55,6 +56,18 @@ export default function Dashboard() {
       setSources(sourcesData);
       setSyncHistory(historyData);
       setMalformedEvents(malformedData);
+
+      // Fetch per-source stats for health dots + event counts
+      const statsResults = await Promise.allSettled(
+        sourcesData.map(s => getSourceStats(s.id).then(st => ({ id: s.id, ...st })))
+      );
+      const newMap: Record<string, { health_label: string; synced_event_count: number }> = {};
+      for (const r of statsResults) {
+        if (r.status === 'fulfilled') {
+          newMap[r.value.id] = { health_label: r.value.health_label, synced_event_count: r.value.synced_event_count };
+        }
+      }
+      setSourceStatsMap(newMap);
     } catch (err) {
       setError('Failed to load dashboard data');
       console.error(err);
@@ -410,8 +423,24 @@ export default function Dashboard() {
                       <td className="px-4 py-3">
                         <div className="flex items-center space-x-2">
                           {isSourceSyncing && <Spinner className="h-4 w-4 text-blue-400" />}
+                          {!isSourceSyncing && sourceStatsMap[source.id] && (
+                            <span
+                              className={`inline-block w-2.5 h-2.5 rounded-full flex-shrink-0 ${
+                                sourceStatsMap[source.id].health_label === 'healthy' ? 'bg-green-400' :
+                                sourceStatsMap[source.id].health_label === 'degraded' ? 'bg-yellow-400' : 'bg-red-400'
+                              }`}
+                              title={`Health: ${sourceStatsMap[source.id].health_label}`}
+                            />
+                          )}
                           <div>
-                            <div className="font-medium text-white">{source.name}</div>
+                            <div className="font-medium text-white">
+                              {source.name}
+                              {sourceStatsMap[source.id] && (
+                                <span className="ml-2 text-xs text-gray-500 font-normal">
+                                  {sourceStatsMap[source.id].synced_event_count} events
+                                </span>
+                              )}
+                            </div>
                             <div className="text-xs text-gray-500 truncate max-w-xs">{source.source_url}</div>
                           </div>
                         </div>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -100,6 +100,18 @@ export const triggerSync = async (id: string): Promise<void> => {
   await api.post(`/sources/${id}/sync`);
 };
 
+export const getSourceStats = async (id: string): Promise<{
+  synced_event_count: number;
+  malformed_count: number;
+  success_rate: number;
+  health_score: number;
+  health_label: string;
+  recent_syncs: { status: string; duration_ms: number; created_at: string }[];
+}> => {
+  const response = await api.get(`/sources/${id}/stats`);
+  return response.data;
+};
+
 // Logs
 export const getSourceLogs = async (sourceId: string, page: number = 1): Promise<{ logs: SyncLog[]; total_pages: number; page: number }> => {
   const response = await api.get(`/sources/${sourceId}/logs`, { params: { page } });


### PR DESCRIPTION
## PR 4 of 15-feature wave

### Per-source stats (Feature 6)
- New \`GET /api/sources/{id}/stats\` — event count, malformed count, last 20 syncs, success rate
- Dashboard shows event count badge next to each source name

### Health scoring (Feature 12)
- Weighted composite: success rate (0.5) + malformed count (0.2) + warning frequency (0.3)
- Green/yellow/red dot before each source name on the dashboard

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test -count=1 ./...\` all green
- [x] \`npm run build\` passes

Closes #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)