### PR TITLE
feat: calendar UI tiles with color dots + event counts (#144)

### DIFF
--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -122,9 +122,10 @@ type APISource struct {
 
 // APICalendar represents a calendar discovered on a CalDAV server.
 type APICalendar struct {
-	Name  string `json:"name"`
-	Path  string `json:"path"`
-	Color string `json:"color,omitempty"`
+	Name       string `json:"name"`
+	Path       string `json:"path"`
+	Color      string `json:"color,omitempty"`
+	EventCount int    `json:"event_count"`
 }
 
 // APICalendarConfig represents per-calendar configuration including sync direction.
@@ -1130,11 +1131,18 @@ func (h *Handlers) APIDiscoverCalendars(c *gin.Context) {
 
 	apiCalendars := make([]*APICalendar, len(calendars))
 	for i, cal := range calendars {
-		apiCalendars[i] = &APICalendar{
+		apiCal := &APICalendar{
 			Name:  cal.Name,
 			Path:  cal.Path,
 			Color: cal.Color,
 		}
+		// Best-effort event count — don't fail the whole discovery
+		// if counting events for one calendar errors out. (#142)
+		events, err := client.GetEvents(ctx, cal.Path, nil)
+		if err == nil {
+			apiCal.EventCount = len(events)
+		}
+		apiCalendars[i] = apiCal
 	}
 
 	c.JSON(http.StatusOK, apiCalendars)

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CalBridgeSync</title>
-    <script type="module" crossorigin src="/assets/index-Do6OLJ66.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-ZC2dUDNT.css">
+    <script type="module" crossorigin src="/assets/index-x191FvbM.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-AN-ZjcBD.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/pages/SourceAdd.tsx
+++ b/web/src/pages/SourceAdd.tsx
@@ -406,38 +406,49 @@ export default function SourceAdd() {
                   )}
                   {calendars.length > 0 && (
                     <div className="mt-3 p-3 bg-black/50 rounded border border-zinc-700">
-                      <p className="text-xs text-gray-400 mb-2">Select calendars to sync (each can have its own sync direction):</p>
-                      <div className="space-y-2">
-                        {calendars.map((cal) => (
-                          <div key={cal.path} className="flex items-center justify-between">
-                            <label className="flex items-center space-x-2 cursor-pointer flex-1">
-                              <input
-                                type="checkbox"
-                                checked={isCalendarSelected(cal.path)}
-                                onChange={() => handleCalendarToggle(cal.path)}
-                                className="rounded border-zinc-600 bg-zinc-800 text-red-600 focus:ring-red-500"
-                              />
-                              <span className="text-sm text-white">{cal.name || cal.path}</span>
-                              {cal.color && (
-                                <span
-                                  className="w-3 h-3 rounded-full"
-                                  style={{ backgroundColor: cal.color }}
-                                />
-                              )}
-                            </label>
-                            {isCalendarSelected(cal.path) && (
-                              <select
-                                value={getCalendarSyncDirection(cal.path)}
-                                onChange={(e) => handleCalendarSyncDirection(cal.path, e.target.value as '' | 'one_way' | 'two_way')}
-                                className="ml-2 text-xs bg-zinc-800 border-zinc-600 rounded px-2 py-1"
-                              >
-                                <option value="">Source default</option>
-                                <option value="one_way">One-way</option>
-                                <option value="two_way">Two-way</option>
-                              </select>
-                            )}
-                          </div>
-                        ))}
+                      <p className="text-xs text-gray-400 mb-2">Select calendars to sync (click to toggle, each can have its own sync direction):</p>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                        {calendars.map((cal) => {
+                          const selected = isCalendarSelected(cal.path);
+                          return (
+                            <div
+                              key={cal.path}
+                              onClick={() => handleCalendarToggle(cal.path)}
+                              className={`p-3 rounded-lg border cursor-pointer transition-colors ${
+                                selected
+                                  ? 'border-red-600 bg-red-900/20'
+                                  : 'border-zinc-700 bg-zinc-800/50 hover:border-zinc-600'
+                              }`}
+                            >
+                              <div className="flex items-center space-x-2">
+                                {cal.color && (
+                                  <span
+                                    className="w-3 h-3 rounded-full flex-shrink-0"
+                                    style={{ backgroundColor: cal.color }}
+                                  />
+                                )}
+                                <span className="text-sm text-white font-medium truncate">{cal.name || cal.path}</span>
+                              </div>
+                              <div className="flex items-center justify-between mt-1">
+                                <span className="text-xs text-gray-500">
+                                  {cal.event_count !== undefined ? `${cal.event_count} events` : ''}
+                                </span>
+                                {selected && (
+                                  <select
+                                    value={getCalendarSyncDirection(cal.path)}
+                                    onChange={(e) => { e.stopPropagation(); handleCalendarSyncDirection(cal.path, e.target.value as '' | 'one_way' | 'two_way'); }}
+                                    onClick={(e) => e.stopPropagation()}
+                                    className="text-xs bg-zinc-800 border-zinc-600 rounded px-2 py-0.5"
+                                  >
+                                    <option value="">Source default</option>
+                                    <option value="one_way">One-way</option>
+                                    <option value="two_way">Two-way</option>
+                                  </select>
+                                )}
+                              </div>
+                            </div>
+                          );
+                        })}
                       </div>
                       <p className="text-xs text-gray-500 mt-2">
                         {form.selected_calendars.length} of {calendars.length} selected

--- a/web/src/pages/SourceEdit.tsx
+++ b/web/src/pages/SourceEdit.tsx
@@ -349,38 +349,49 @@ export default function SourceEdit() {
               )}
               {calendars.length > 0 && (
                 <div className="p-3 bg-black/50 rounded border border-zinc-700">
-                  <p className="text-xs text-gray-400 mb-2">Select calendars to sync (each can have its own sync direction):</p>
-                  <div className="space-y-2">
-                    {calendars.map((cal) => (
-                      <div key={cal.path} className="flex items-center justify-between">
-                        <label className="flex items-center space-x-2 cursor-pointer flex-1">
-                          <input
-                            type="checkbox"
-                            checked={isCalendarSelected(cal.path)}
-                            onChange={() => handleCalendarToggle(cal.path)}
-                            className="rounded border-zinc-600 bg-zinc-800 text-red-600 focus:ring-red-500"
-                          />
-                          <span className="text-sm text-white">{cal.name || cal.path}</span>
-                          {cal.color && (
-                            <span
-                              className="w-3 h-3 rounded-full"
-                              style={{ backgroundColor: cal.color }}
-                            />
-                          )}
-                        </label>
-                        {isCalendarSelected(cal.path) && (
-                          <select
-                            value={getCalendarSyncDirection(cal.path)}
-                            onChange={(e) => handleCalendarSyncDirection(cal.path, e.target.value as '' | 'one_way' | 'two_way')}
-                            className="ml-2 text-xs bg-zinc-800 border-zinc-600 rounded px-2 py-1"
-                          >
-                            <option value="">Source default</option>
-                            <option value="one_way">One-way</option>
-                            <option value="two_way">Two-way</option>
-                          </select>
-                        )}
-                      </div>
-                    ))}
+                  <p className="text-xs text-gray-400 mb-2">Select calendars to sync (click to toggle, each can have its own sync direction):</p>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    {calendars.map((cal) => {
+                      const selected = isCalendarSelected(cal.path);
+                      return (
+                        <div
+                          key={cal.path}
+                          onClick={() => handleCalendarToggle(cal.path)}
+                          className={`p-3 rounded-lg border cursor-pointer transition-colors ${
+                            selected
+                              ? 'border-red-600 bg-red-900/20'
+                              : 'border-zinc-700 bg-zinc-800/50 hover:border-zinc-600'
+                          }`}
+                        >
+                          <div className="flex items-center space-x-2">
+                            {cal.color && (
+                              <span
+                                className="w-3 h-3 rounded-full flex-shrink-0"
+                                style={{ backgroundColor: cal.color }}
+                              />
+                            )}
+                            <span className="text-sm text-white font-medium truncate">{cal.name || cal.path}</span>
+                          </div>
+                          <div className="flex items-center justify-between mt-1">
+                            <span className="text-xs text-gray-500">
+                              {cal.event_count !== undefined ? `${cal.event_count} events` : ''}
+                            </span>
+                            {selected && (
+                              <select
+                                value={getCalendarSyncDirection(cal.path)}
+                                onChange={(e) => { e.stopPropagation(); handleCalendarSyncDirection(cal.path, e.target.value as '' | 'one_way' | 'two_way'); }}
+                                onClick={(e) => e.stopPropagation()}
+                                className="text-xs bg-zinc-800 border-zinc-600 rounded px-2 py-0.5"
+                              >
+                                <option value="">Source default</option>
+                                <option value="one_way">One-way</option>
+                                <option value="two_way">Two-way</option>
+                              </select>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
                   </div>
                   <p className="text-xs text-gray-500 mt-2">
                     {form.selected_calendars.length} of {calendars.length} selected

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -31,6 +31,7 @@ export interface Calendar {
   name: string;
   path: string;
   color?: string;
+  event_count?: number;
 }
 
 export interface CalendarConfig {


### PR DESCRIPTION
## PR 5 of 15-feature wave (Feature 8)

Upgrade calendar selection from checkboxes to visual tiles:

- **Backend:** Discover endpoint now counts events per calendar via \`GetEvents\`
- **Frontend:** 2-column tile grid with color dots, names, event counts. Selected tiles get red border. Per-calendar sync direction dropdown inline on selected tiles.
- Both SourceAdd and SourceEdit use the same tile UI

## Test plan
- [x] \`go build ./...\` + \`go test -count=1 ./...\` all green
- [x] \`npm run build\` passes

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)