### PR TITLE
feat: conflict resolution UI (#146)

### DIFF
--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -1740,6 +1740,14 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 				}
 			} else {
 				result.Updated++
+				// Log conflict resolution for the UI (#136).
+				// In two-way mode, pushing source → dest means source
+				// won this conflict (or it's source_wins default).
+				if syncDirection == db.SyncDirectionTwoWay {
+					result.Warnings = append(result.Warnings, fmt.Sprintf(
+						"CONFLICT:{\"uid\":%q,\"winner\":\"source\",\"summary\":%q,\"strategy\":%q}",
+						sourceEvent.UID, sourceEvent.Summary, source.ConflictStrategy))
+				}
 				// Record both ETags: source from the server we just
 				// read, dest from the server we just wrote. Note the
 				// dest ETag here is the OLD one — we don't have the
@@ -1930,6 +1938,11 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 					}
 				} else {
 					result.Updated++
+					// Log conflict resolution for the UI (#136).
+					// Pushing dest → source means dest won this conflict.
+					result.Warnings = append(result.Warnings, fmt.Sprintf(
+						"CONFLICT:{\"uid\":%q,\"winner\":\"dest\",\"summary\":%q,\"strategy\":%q}",
+						destEvent.UID, destEvent.Summary, source.ConflictStrategy))
 					// Record the dest ETag we just propagated back
 					// to source so the next cycle can detect another
 					// dest-side change. We don't know the new source

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CalBridgeSync</title>
-    <script type="module" crossorigin src="/assets/index-x191FvbM.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-AN-ZjcBD.css">
+    <script type="module" crossorigin src="/assets/index-BOCxpNeZ.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BPDmbprl.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/pages/SourceLogs.tsx
+++ b/web/src/pages/SourceLogs.tsx
@@ -145,16 +145,47 @@ export default function SourceLogs() {
                       </td>
                       <td className="px-4 py-3 text-gray-300">
                         <div className="max-w-md truncate" title={log.message}>{log.message}</div>
-                        {log.details && (
-                          <details className="mt-1">
-                            <summary className="text-xs text-red-400 cursor-pointer hover:text-red-300">
-                              Details
-                            </summary>
-                            <pre className="mt-1 text-xs text-gray-400 bg-black p-2 rounded overflow-x-auto max-w-md">
-                              {log.details}
-                            </pre>
-                          </details>
-                        )}
+                        {log.details && (() => {
+                          const lines = log.details.split('\n');
+                          const conflicts = lines.filter(l => l.startsWith('CONFLICT:'));
+                          const otherDetails = lines.filter(l => !l.startsWith('CONFLICT:')).join('\n').trim();
+                          return (
+                            <>
+                              {conflicts.length > 0 && (
+                                <details className="mt-1">
+                                  <summary className="text-xs text-yellow-400 cursor-pointer hover:text-yellow-300">
+                                    {conflicts.length} conflict{conflicts.length > 1 ? 's' : ''} resolved
+                                  </summary>
+                                  <div className="mt-1 space-y-1">
+                                    {conflicts.map((c, i) => {
+                                      try {
+                                        const data = JSON.parse(c.replace('CONFLICT:', ''));
+                                        return (
+                                          <div key={i} className="text-xs bg-yellow-900/20 border border-yellow-800/50 rounded p-2">
+                                            <span className="text-yellow-300 font-medium">{data.summary || data.uid}</span>
+                                            <span className="text-gray-400 ml-2">→ {data.winner} wins ({data.strategy})</span>
+                                          </div>
+                                        );
+                                      } catch {
+                                        return <div key={i} className="text-xs text-gray-400">{c}</div>;
+                                      }
+                                    })}
+                                  </div>
+                                </details>
+                              )}
+                              {otherDetails && (
+                                <details className="mt-1">
+                                  <summary className="text-xs text-red-400 cursor-pointer hover:text-red-300">
+                                    Details
+                                  </summary>
+                                  <pre className="mt-1 text-xs text-gray-400 bg-black p-2 rounded overflow-x-auto max-w-md">
+                                    {otherDetails}
+                                  </pre>
+                                </details>
+                              )}
+                            </>
+                          );
+                        })()}
                       </td>
                       <td className="px-4 py-3 text-gray-400 whitespace-nowrap">{formatDuration(log.duration)}</td>
                     </tr>


### PR DESCRIPTION
## PR 6 of 15-feature wave (Feature 9)

Structured CONFLICT: warnings in sync results + expandable conflict details in SourceLogs page.

- **Backend:** Two injection points in sync.go — forward update (source wins) and dest_wins reverse update (dest wins). Each appends \`CONFLICT:{\"uid\":\"...\",\"winner\":\"source\",\"summary\":\"...\",\"strategy\":\"...\"}\` to result.Warnings.
- **Frontend:** SourceLogs.tsx parses CONFLICT: lines from log.details, renders yellow accordion: event summary + which side won + strategy. Non-conflict details render separately.

## Test plan
- [x] All tests green
- [x] Frontend builds

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)