### PR TITLE
feat: automated DB backup + per-user ICS export (#150)

### DIFF
--- a/cmd/calbridgesync/main.go
+++ b/cmd/calbridgesync/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/macjediwizard/calbridgesync/internal/auth"
+	"github.com/macjediwizard/calbridgesync/internal/backup"
 	"github.com/macjediwizard/calbridgesync/internal/caldav"
 	"github.com/macjediwizard/calbridgesync/internal/config"
 	"github.com/macjediwizard/calbridgesync/internal/crypto"
@@ -133,6 +134,17 @@ func main() {
 
 	// Initialize scheduler with configurable log retention
 	sched := scheduler.New(database, syncEngine, notifier, cfg.LogRetentionDays)
+
+	// Initialize automated backup if enabled
+	if cfg.Backup.Enabled {
+		backupMgr, err := backup.New(cfg.Database.Path, cfg.Backup.Dir, cfg.Backup.RetentionCount)
+		if err != nil {
+			log.Printf("WARNING: automated backup disabled: %v", err)
+		} else {
+			sched.SetBackupManager(backupMgr)
+			log.Printf("Automated backup enabled (dir=%s, retention=%d)", cfg.Backup.Dir, cfg.Backup.RetentionCount)
+		}
+	}
 
 	// Initialize health checker
 	healthChecker := health.NewChecker(database, cfg.OIDC.Issuer, cfg.CalDAV.DefaultDestURL)

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,0 +1,205 @@
+// Package backup provides automated SQLite database backup with
+// retention-based cleanup. The Manager runs a daily backup via
+// SQLite's VACUUM INTO command (atomic, WAL-safe) and compresses
+// the result with gzip. Old backups are purged to stay within a
+// configurable retention count.
+//
+// Designed to be driven by the scheduler's daily cleanup routine
+// rather than as a standalone daemon. The Manager is stateless
+// between calls — it reads the backup directory on each
+// invocation to count existing backups for purge decisions.
+package backup
+
+import (
+	"compress/gzip"
+	"database/sql"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Manager handles automated database backups.
+type Manager struct {
+	dbPath         string
+	backupDir      string
+	retentionCount int
+}
+
+// New creates a backup manager. backupDir is created if it doesn't
+// exist. retentionCount is the maximum number of backup files to
+// keep; oldest are deleted when exceeded.
+func New(dbPath, backupDir string, retentionCount int) (*Manager, error) {
+	if dbPath == "" {
+		return nil, fmt.Errorf("database path is required")
+	}
+	if backupDir == "" {
+		return nil, fmt.Errorf("backup directory is required")
+	}
+	if retentionCount < 1 {
+		retentionCount = 7
+	}
+	if err := os.MkdirAll(backupDir, 0750); err != nil {
+		return nil, fmt.Errorf("failed to create backup directory %s: %w", backupDir, err)
+	}
+	return &Manager{
+		dbPath:         dbPath,
+		backupDir:      backupDir,
+		retentionCount: retentionCount,
+	}, nil
+}
+
+// RunBackup creates an atomic backup of the SQLite database,
+// compressed with gzip. Returns the path to the backup file.
+//
+// Uses VACUUM INTO which is safe to run while the database is
+// open and being written to (it takes a snapshot of the current
+// state including WAL contents). Requires SQLite 3.27+.
+func (m *Manager) RunBackup() (string, error) {
+	timestamp := time.Now().UTC().Format("20060102-150405Z")
+	backupName := fmt.Sprintf("calbridgesync-%s.db.gz", timestamp)
+	backupPath := filepath.Join(m.backupDir, backupName)
+
+	// VACUUM INTO creates a clean copy of the database at the
+	// specified path. It's atomic and WAL-safe.
+	tempPath := backupPath + ".tmp"
+	tempDBPath := tempPath + ".db"
+
+	db, err := sql.Open("sqlite3", m.dbPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open database for backup: %w", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(fmt.Sprintf("VACUUM INTO '%s'", tempDBPath))
+	if err != nil {
+		return "", fmt.Errorf("VACUUM INTO failed: %w", err)
+	}
+
+	// Compress with gzip
+	srcFile, err := os.Open(tempDBPath)
+	if err != nil {
+		os.Remove(tempDBPath)
+		return "", fmt.Errorf("failed to open temp backup: %w", err)
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(tempPath)
+	if err != nil {
+		os.Remove(tempDBPath)
+		return "", fmt.Errorf("failed to create gzip file: %w", err)
+	}
+
+	gzWriter := gzip.NewWriter(dstFile)
+	if _, err := io.Copy(gzWriter, srcFile); err != nil {
+		gzWriter.Close()
+		dstFile.Close()
+		os.Remove(tempDBPath)
+		os.Remove(tempPath)
+		return "", fmt.Errorf("gzip compression failed: %w", err)
+	}
+	gzWriter.Close()
+	dstFile.Close()
+	srcFile.Close()
+	os.Remove(tempDBPath)
+
+	// Atomic rename
+	if err := os.Rename(tempPath, backupPath); err != nil {
+		os.Remove(tempPath)
+		return "", fmt.Errorf("failed to finalize backup: %w", err)
+	}
+
+	info, _ := os.Stat(backupPath)
+	if info != nil {
+		log.Printf("Backup created: %s (%.1f MB)", backupPath, float64(info.Size())/(1024*1024))
+	}
+
+	return backupPath, nil
+}
+
+// PurgeOldBackups deletes the oldest backups beyond the retention
+// count. Returns the number of backups deleted.
+func (m *Manager) PurgeOldBackups() (int, error) {
+	entries, err := os.ReadDir(m.backupDir)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read backup directory: %w", err)
+	}
+
+	// Filter to only our backup files
+	var backups []os.DirEntry
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), "calbridgesync-") && strings.HasSuffix(e.Name(), ".db.gz") {
+			backups = append(backups, e)
+		}
+	}
+
+	if len(backups) <= m.retentionCount {
+		return 0, nil
+	}
+
+	// Sort by name (timestamp-based names sort chronologically)
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].Name() < backups[j].Name()
+	})
+
+	// Delete oldest beyond retention
+	toDelete := backups[:len(backups)-m.retentionCount]
+	deleted := 0
+	for _, b := range toDelete {
+		path := filepath.Join(m.backupDir, b.Name())
+		if err := os.Remove(path); err != nil {
+			log.Printf("Failed to delete old backup %s: %v", path, err)
+		} else {
+			deleted++
+		}
+	}
+
+	if deleted > 0 {
+		log.Printf("Purged %d old backup(s), keeping %d", deleted, m.retentionCount)
+	}
+
+	return deleted, nil
+}
+
+// ListBackups returns info about existing backups, newest first.
+func (m *Manager) ListBackups() ([]BackupInfo, error) {
+	entries, err := os.ReadDir(m.backupDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read backup directory: %w", err)
+	}
+
+	var backups []BackupInfo
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), "calbridgesync-") && strings.HasSuffix(e.Name(), ".db.gz") {
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			backups = append(backups, BackupInfo{
+				Name:      e.Name(),
+				Path:      filepath.Join(m.backupDir, e.Name()),
+				Size:      info.Size(),
+				CreatedAt: info.ModTime(),
+			})
+		}
+	}
+
+	// Newest first
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].CreatedAt.After(backups[j].CreatedAt)
+	})
+
+	return backups, nil
+}
+
+// BackupInfo describes a single backup file.
+type BackupInfo struct {
+	Name      string    `json:"name"`
+	Path      string    `json:"path"`
+	Size      int64     `json:"size"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,15 @@ type Config struct {
 	// scheduler's daily cleanup routine keeps. Configurable via
 	// SYNC_LOG_RETENTION_DAYS env var. Default 30.
 	LogRetentionDays int
+	// Backup settings for automated DB snapshots.
+	Backup BackupConfig
+}
+
+// BackupConfig holds automated backup settings. (#148)
+type BackupConfig struct {
+	Enabled        bool
+	Dir            string
+	RetentionCount int
 }
 
 // GoogleOAuthConfig holds instance-level Google OAuth2 settings. As of
@@ -316,6 +325,21 @@ func Load() (*Config, error) {
 		logRetention = 365
 	}
 	cfg.LogRetentionDays = logRetention
+
+	// Backup configuration
+	cfg.Backup.Enabled = strings.ToLower(getEnv("BACKUP_ENABLED", "true")) != "false"
+	cfg.Backup.Dir = getEnv("BACKUP_DIR", "./data/backups")
+	backupRetention, err := getEnvInt("BACKUP_RETENTION_COUNT", 7)
+	if err != nil {
+		return nil, fmt.Errorf("%w: BACKUP_RETENTION_COUNT: %w", ErrInvalidConfig, err)
+	}
+	if backupRetention < 1 {
+		backupRetention = 1
+	}
+	if backupRetention > 100 {
+		backupRetention = 100
+	}
+	cfg.Backup.RetentionCount = backupRetention
 
 	// Check for missing required configuration
 	missing := cfg.getMissingRequired()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -119,6 +119,13 @@ type Scheduler struct {
 	// expired. Reset on successful sync. (#136)
 	authFailCountsMu sync.Mutex
 	authFailCounts   map[string]int
+
+	// backupMgr is the automated backup manager. Nil if backups
+	// are disabled. Called from the daily cleanup routine.
+	backupMgr interface {
+		RunBackup() (string, error)
+		PurgeOldBackups() (int, error)
+	}
 }
 
 // New creates a new scheduler. logRetentionDays controls how many
@@ -982,8 +989,34 @@ func (s *Scheduler) cleanupRoutine() {
 		case <-ticker.C:
 			s.heartbeat(routineCleanup)
 			s.cleanupOldLogs()
+			s.runAutomatedBackup()
 		}
 	}
+}
+
+// runAutomatedBackup runs the daily automated database backup if
+// a backup manager is configured. Errors are logged but not fatal
+// — a failed backup doesn't affect sync operation. (#148)
+func (s *Scheduler) runAutomatedBackup() {
+	if s.backupMgr == nil {
+		return
+	}
+	if _, err := s.backupMgr.RunBackup(); err != nil {
+		log.Printf("Automated backup failed: %v", err)
+		return
+	}
+	if _, err := s.backupMgr.PurgeOldBackups(); err != nil {
+		log.Printf("Backup purge failed: %v", err)
+	}
+}
+
+// SetBackupManager configures the automated backup manager. Called
+// from main.go after creating the backup.Manager, before Start().
+func (s *Scheduler) SetBackupManager(mgr interface {
+	RunBackup() (string, error)
+	PurgeOldBackups() (int, error)
+}) {
+	s.backupMgr = mgr
 }
 
 // cleanupOldLogs deletes sync logs older than retention period.

--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -1268,6 +1269,98 @@ type APITestWebhookRequest struct {
 }
 
 // APITestWebhook sends a test message to the specified webhook URL.
+// APIExportCalendars exports all the authenticated user's synced
+// calendar events as a single .ics file download. Connects to
+// each destination CalDAV server, fetches all events, and streams
+// the combined VCALENDAR output. Per-user ICS export for backup
+// or portability. (#148)
+func (h *Handlers) APIExportCalendars(c *gin.Context) {
+	session := auth.GetCurrentUser(c)
+	if session == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	sources, err := h.db.GetSourcesByUserID(session.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load sources"})
+		return
+	}
+
+	// Set response headers for ICS download
+	c.Header("Content-Type", "text/calendar; charset=utf-8")
+	c.Header("Content-Disposition", "attachment; filename=\"calbridgesync-export.ics\"")
+	c.Writer.WriteHeader(http.StatusOK)
+
+	// Write VCALENDAR envelope
+	c.Writer.Write([]byte("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//calbridgesync//export//EN\r\nCALSCALE:GREGORIAN\r\n"))
+
+	for _, source := range sources {
+		if !source.Enabled {
+			continue
+		}
+
+		// Decrypt dest credentials
+		destPassword, err := h.encryptor.Decrypt(source.DestPassword)
+		if err != nil {
+			log.Printf("Export: failed to decrypt dest password for source %s: %v", source.Name, err)
+			continue
+		}
+
+		// Connect to destination CalDAV
+		destClient, err := caldav.NewClient(source.DestURL, source.DestUsername, destPassword)
+		if err != nil {
+			log.Printf("Export: failed to connect to dest for source %s: %v", source.Name, err)
+			continue
+		}
+
+		// Find calendars
+		calendars, err := destClient.FindCalendars(c.Request.Context())
+		if err != nil {
+			log.Printf("Export: failed to find calendars for source %s: %v", source.Name, err)
+			continue
+		}
+
+		// Fetch events from each calendar
+		for _, cal := range calendars {
+			events, err := destClient.GetEvents(c.Request.Context(), cal.Path, nil)
+			if err != nil {
+				log.Printf("Export: failed to get events from %s/%s: %v", source.Name, cal.Name, err)
+				continue
+			}
+			// Write X-WR-CALNAME for context
+			c.Writer.Write([]byte(fmt.Sprintf("X-WR-CALNAME:%s - %s\r\n", source.Name, cal.Name)))
+
+			for _, event := range events {
+				if event.Data == "" {
+					continue
+				}
+				// Extract VEVENT blocks from the event data and write
+				// them directly — each event.Data is a full VCALENDAR
+				// envelope so we need to strip it and emit just the
+				// VEVENT blocks.
+				data := event.Data
+				for {
+					start := strings.Index(data, "BEGIN:VEVENT")
+					if start == -1 {
+						break
+					}
+					end := strings.Index(data[start:], "END:VEVENT")
+					if end == -1 {
+						break
+					}
+					end += start + len("END:VEVENT")
+					c.Writer.Write([]byte(data[start:end]))
+					c.Writer.Write([]byte("\r\n"))
+					data = data[end:]
+				}
+			}
+		}
+	}
+
+	c.Writer.Write([]byte("END:VCALENDAR\r\n"))
+}
+
 func (h *Handlers) APITestWebhook(c *gin.Context) {
 	session := auth.GetCurrentUser(c)
 	if session == nil {

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -93,6 +93,7 @@ func SetupRoutes(r *gin.Engine, h *Handlers, sm *auth.SessionManager) {
 		expensiveAPI.POST("/sources/google/prepare", h.APIPrepareGoogleSource) // Tests dest + stashes pending Google source (#70)
 		expensiveAPI.POST("/calendars/discover", h.APIDiscoverCalendars)       // Discovers calendars via network
 		expensiveAPI.POST("/settings/alerts/test-webhook", h.APITestWebhook)   // Tests webhook via network
+		expensiveAPI.GET("/export/calendars", h.APIExportCalendars)            // Exports all user calendars as ICS
 	}
 
 	// Serve React app static files

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CalBridgeSync</title>
-    <script type="module" crossorigin src="/assets/index-BOCxpNeZ.js"></script>
+    <script type="module" crossorigin src="/assets/index-PxN-k_YR.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-BPDmbprl.css">
   </head>
   <body>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { getAlertPreferences, updateAlertPreferences, testWebhook, getLogStats } from '../services/api';
+import { getAlertPreferences, updateAlertPreferences, testWebhook, getLogStats, exportCalendars } from '../services/api';
 import type { AlertPreferences } from '../types';
 
 interface LogStatsData {
@@ -220,6 +220,38 @@ export default function Settings() {
       </div>
 
       {/* Log Retention Stats */}
+      {/* Data Export */}
+      <div className="bg-zinc-900 rounded-lg border border-zinc-800 overflow-hidden mt-6">
+        <div className="p-4 border-b border-zinc-800">
+          <h3 className="text-lg font-medium text-white">Data Export</h3>
+          <p className="text-sm text-gray-400 mt-1">Download your calendar data as a standard .ics file for backup or import into other apps</p>
+        </div>
+        <div className="p-4">
+          <button
+            onClick={async () => {
+              try {
+                const blob = await exportCalendars();
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `calbridgesync-export-${new Date().toISOString().slice(0, 10)}.ics`;
+                a.click();
+                URL.revokeObjectURL(url);
+              } catch {
+                setError('Failed to export calendars');
+              }
+            }}
+            className="px-4 py-2 rounded bg-zinc-800 hover:bg-zinc-700 text-white text-sm font-medium transition-colors border border-zinc-700"
+          >
+            Export My Calendars (.ics)
+          </button>
+          <p className="text-xs text-gray-500 mt-2">
+            Downloads all events from your synced destination calendars in iCalendar format.
+            Compatible with Apple Calendar, Google Calendar, Outlook, and any CalDAV app.
+          </p>
+        </div>
+      </div>
+
       {logStats && (
         <div className="bg-zinc-900 rounded-lg border border-zinc-800 overflow-hidden mt-6">
           <div className="p-4 border-b border-zinc-800">

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -154,6 +154,11 @@ export const testWebhook = async (url: string): Promise<void> => {
   await api.post('/settings/alerts/test-webhook', { webhook_url: url });
 };
 
+export const exportCalendars = async (): Promise<Blob> => {
+  const response = await api.get('/export/calendars', { responseType: 'blob' });
+  return response.data;
+};
+
 export const getLogStats = async (): Promise<{ total_logs: number; oldest_log: string; retention_days: number }> => {
   const response = await api.get('/settings/log-stats');
   return response.data;


### PR DESCRIPTION
## PR 8 of 15-feature wave (Feature 5)

### Automated DB backup
- New \`internal/backup\` package: \`VACUUM INTO\` + gzip, retention-based purge
- Env vars: \`BACKUP_ENABLED\` (default true), \`BACKUP_DIR\`, \`BACKUP_RETENTION_COUNT\` (default 7)
- Runs daily via scheduler cleanup routine

### Per-user ICS export
- \`GET /api/export/calendars\` — streams all user's destination events as .ics download
- Settings page "Export My Calendars (.ics)" button

## Test plan
- [x] All tests green
- [x] Frontend builds

Closes #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)