### PR TITLE
feat: dry-run sync mode (#152)

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -34,6 +34,28 @@ var (
 	ErrEventSkipped = errors.New("event skipped")
 )
 
+// dryRunContextKey is a context key that, when present, causes
+// PutEvent and DeleteEvent to return nil without actually calling
+// the CalDAV server. The sync engine runs the full computation
+// (determines what WOULD change) and populates SyncResult as if
+// the operations happened, but no data is actually written. (#150)
+type dryRunContextKeyType struct{}
+
+var dryRunContextKey = dryRunContextKeyType{}
+
+// WithDryRun returns a context that causes PutEvent and DeleteEvent
+// to be no-ops. The sync engine will still compute all deltas and
+// populate SyncResult, but no CalDAV writes will happen.
+func WithDryRun(ctx context.Context) context.Context {
+	return context.WithValue(ctx, dryRunContextKey, true)
+}
+
+// IsDryRun returns true if the context has the dry-run flag set.
+func IsDryRun(ctx context.Context) bool {
+	v, _ := ctx.Value(dryRunContextKey).(bool)
+	return v
+}
+
 const (
 	defaultTimeout = 300 * time.Second // 5 minutes default for slow CalDAV servers like iCloud
 	minTLSVersion  = tls.VersionTLS12
@@ -719,6 +741,16 @@ func (c *Client) GetEvent(ctx context.Context, eventPath string) (*Event, error)
 //     write). Callers should surface these in result.Warnings or
 //     result.Errors as appropriate.
 func (c *Client) PutEvent(ctx context.Context, calendarPath string, event *Event) error {
+	// Dry-run: return nil without writing. The caller's bookkeeping
+	// (result.Created++, result.Updated++) proceeds as normal,
+	// producing an accurate preview of what WOULD happen. (#150)
+	if IsDryRun(ctx) {
+		if event.Data == "" {
+			return ErrEventSkipped
+		}
+		return nil
+	}
+
 	// Skip events with empty data. This is NOT a success — we did not
 	// write anything. Previously this returned nil, which made the
 	// caller's `result.Created++` bookkeeping lie.
@@ -772,6 +804,10 @@ func (c *Client) PutEvent(ctx context.Context, calendarPath string, event *Event
 
 // DeleteEvent deletes an event.
 func (c *Client) DeleteEvent(ctx context.Context, eventPath string) error {
+	// Dry-run: return nil without deleting. (#150)
+	if IsDryRun(ctx) {
+		return nil
+	}
 	err := c.caldavClient.RemoveAll(ctx, eventPath)
 	if err != nil {
 		return fmt.Errorf("%w: failed to delete event: %w", ErrConnectionFailed, err)

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -781,6 +781,9 @@ type SyncResult struct {
 	// Populated only for ICS source types. Used by the scheduler's
 	// adaptive polling logic to detect unchanged feeds. (#146)
 	ContentHash string `json:"content_hash,omitempty"`
+	// DryRun indicates this result was computed without actually
+	// writing to the CalDAV servers. Counts are what WOULD happen.
+	DryRun bool `json:"dry_run,omitempty"`
 }
 
 // sanitizeLogDetails removes potentially sensitive information from sync log details.
@@ -896,13 +899,18 @@ func (se *SyncEngine) SyncSource(ctx context.Context, source *db.Source) *SyncRe
 	result := &SyncResult{
 		Errors:   make([]string, 0),
 		Warnings: make([]string, 0),
+		DryRun:   IsDryRun(ctx),
 	}
 
-	// Update status to running (with retry for concurrent access)
-	if err := retryDBOperation(func() error {
-		return se.db.UpdateSourceSyncStatus(source.ID, db.SyncStatusRunning, "Sync in progress")
-	}, 5); err != nil {
-		log.Printf("Failed to update sync status after retries: %v", err)
+	// Skip status update in dry-run mode — we don't want to
+	// change the source's last_sync_status/last_sync_at. (#150)
+	if !result.DryRun {
+		// Update status to running (with retry for concurrent access)
+		if err := retryDBOperation(func() error {
+			return se.db.UpdateSourceSyncStatus(source.ID, db.SyncStatusRunning, "Sync in progress")
+		}, 5); err != nil {
+			log.Printf("Failed to update sync status after retries: %v", err)
+		}
 	}
 
 	// Branch for ICS sources (read-only feed, different sync path)
@@ -2287,6 +2295,12 @@ func (se *SyncEngine) TestICSConnection(ctx context.Context, url, username, pass
 const finishSyncPersistenceWarningPrefix = "sync persistence failure: "
 
 func (se *SyncEngine) finishSync(sourceID string, result *SyncResult) {
+	// In dry-run mode, don't write status or sync log to DB —
+	// the sync didn't actually happen. (#150)
+	if result.DryRun {
+		return
+	}
+
 	// Determine status: error > partial > success
 	var status db.SyncStatus
 	if !result.Success {

--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -870,10 +870,20 @@ func (h *Handlers) APITriggerSync(c *gin.Context) {
 	}
 
 	sourceID := c.Param("id")
-	// Use timing-safe query that combines ID and user check
-	_, err := h.db.GetSourceByIDForUser(sourceID, session.UserID)
+	source, err := h.db.GetSourceByIDForUser(sourceID, session.UserID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Source not found"})
+		return
+	}
+
+	// Dry-run mode: run the sync synchronously with a dry-run
+	// context so PutEvent/DeleteEvent are no-ops. Returns the
+	// SyncResult as JSON so the user can preview what would
+	// happen without actually changing any data. (#150)
+	if c.Query("dry_run") == "true" {
+		ctx := caldav.WithDryRun(c.Request.Context())
+		result := h.syncEngine.SyncSource(ctx, source)
+		c.JSON(http.StatusOK, result)
 		return
 	}
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -100,6 +100,20 @@ export const triggerSync = async (id: string): Promise<void> => {
   await api.post(`/sources/${id}/sync`);
 };
 
+export const dryRunSync = async (id: string): Promise<{
+  success: boolean;
+  created: number;
+  updated: number;
+  deleted: number;
+  skipped: number;
+  dry_run: boolean;
+  message: string;
+  warnings?: string[];
+}> => {
+  const response = await api.post(`/sources/${id}/sync?dry_run=true`);
+  return response.data;
+};
+
 export const getSourceStats = async (id: string): Promise<{
   synced_event_count: number;
   malformed_count: number;


### PR DESCRIPTION
## PR 9 of 15-feature wave (Feature 14)

Preview what a sync would do without writing. \`POST /api/sources/{id}/sync?dry_run=true\` runs the sync with \`PutEvent\`/\`DeleteEvent\` as no-ops via context flag. Returns SyncResult JSON with accurate counts of what WOULD change.

- Context-based: \`WithDryRun(ctx)\` + \`IsDryRun(ctx)\` check
- No DB state change: \`finishSync\` skips in dry-run, status update skipped
- Full computation: sync engine runs the full delta analysis

## Test plan
- [x] All tests green
- [x] Frontend builds

Closes #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)