### PR TITLE
feat: wire multi-destination sync engine + DestinationManager UI

### DIFF
--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -1080,6 +1080,54 @@ func (se *SyncEngine) SyncSource(ctx context.Context, source *db.Source) *SyncRe
 	}
 
 	result.CalendarsSynced = len(sourceCalendars)
+
+	// Multi-destination sync (#156): after syncing to the primary
+	// destination, check for additional destinations and sync to
+	// each one. The primary destination (dest_url on the source
+	// row) always syncs first — additional destinations are
+	// additive. A failure on one additional destination doesn't
+	// prevent others from being tried.
+	additionalDests, err := se.db.GetDestinationsBySourceID(source.ID)
+	if err != nil {
+		log.Printf("Failed to load additional destinations for source %s: %v", source.Name, err)
+	}
+	for _, dest := range additionalDests {
+		if !dest.Enabled {
+			continue
+		}
+		log.Printf("Syncing to additional destination: %s (%s)", dest.Name, dest.DestURL)
+		extraDestPassword, decErr := se.encryptor.Decrypt(dest.DestPassword)
+		if decErr != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to decrypt credentials for additional dest %q: %v", dest.Name, decErr))
+			continue
+		}
+		extraDestClient, connErr := NewClient(dest.DestURL, dest.DestUsername, extraDestPassword)
+		if connErr != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to connect to additional dest %q: %v", dest.Name, connErr))
+			continue
+		}
+		if testErr := extraDestClient.TestConnection(ctx); testErr != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Connection test failed for additional dest %q: %v", dest.Name, testErr))
+			continue
+		}
+		for i, cal := range sourceCalendars {
+			calResult := se.syncCalendar(ctx, source, sourceClient, extraDestClient, cal, i+1)
+			result.Created += calResult.Created
+			result.Updated += calResult.Updated
+			result.Deleted += calResult.Deleted
+			result.Skipped += calResult.Skipped
+			result.EventsProcessed += calResult.EventsProcessed
+			result.Warnings = append(result.Warnings, calResult.Warnings...)
+			// Errors from additional dests are downgraded to warnings
+			// so a failure on one extra dest doesn't mark the whole
+			// sync as failed.
+			for _, e := range calResult.Errors {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("[additional dest %q] %s", dest.Name, e))
+			}
+		}
+		log.Printf("Completed sync to additional destination: %s", dest.Name)
+	}
+
 	// Success if no critical errors (warnings are OK)
 	result.Success = len(result.Errors) == 0
 	if result.Success && len(result.Warnings) == 0 {
@@ -2261,6 +2309,45 @@ func (se *SyncEngine) syncICSSource(ctx context.Context, source *db.Source) *Syn
 	result.Errors = append(result.Errors, syncResult.Errors...)
 	result.Warnings = append(result.Warnings, syncResult.Warnings...)
 	result.CalendarsSynced = 1
+
+	// Multi-destination sync (#156): after syncing to the primary
+	// destination, replicate the same ICS events to any additional
+	// destinations. Failures on one extra dest don't block others.
+	additionalDests, err := se.db.GetDestinationsBySourceID(source.ID)
+	if err != nil {
+		log.Printf("Failed to load additional destinations for ICS source %s: %v", source.Name, err)
+	}
+	for _, dest := range additionalDests {
+		if !dest.Enabled {
+			continue
+		}
+		log.Printf("Syncing ICS feed to additional destination: %s (%s)", dest.Name, dest.DestURL)
+		extraDestPassword, decErr := se.encryptor.Decrypt(dest.DestPassword)
+		if decErr != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to decrypt credentials for additional dest %q: %v", dest.Name, decErr))
+			continue
+		}
+		extraDestClient, connErr := NewClient(dest.DestURL, dest.DestUsername, extraDestPassword)
+		if connErr != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to connect to additional dest %q: %v", dest.Name, connErr))
+			continue
+		}
+		if testErr := extraDestClient.TestConnection(ctx); testErr != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Connection test failed for additional dest %q: %v", dest.Name, testErr))
+			continue
+		}
+		extraResult := se.syncEventsToDestination(ctx, source, nil, extraDestClient, sourceEvents, calendar, 1, db.SyncDirectionOneWay)
+		result.Created += extraResult.Created
+		result.Updated += extraResult.Updated
+		result.Deleted += extraResult.Deleted
+		result.Skipped += extraResult.Skipped
+		result.EventsProcessed += extraResult.EventsProcessed
+		result.Warnings = append(result.Warnings, extraResult.Warnings...)
+		for _, e := range extraResult.Errors {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("[additional dest %q] %s", dest.Name, e))
+		}
+		log.Printf("Completed ICS sync to additional destination: %s", dest.Name)
+	}
 
 	result.Success = len(result.Errors) == 0
 	if result.Success && len(result.Warnings) == 0 {

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CalBridgeSync</title>
-    <script type="module" crossorigin src="/assets/index-BbWNJ77m.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BYsACTer.css">
+    <script type="module" crossorigin src="/assets/index-DZ_2havE.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CL3VRuZO.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/components/DestinationManager.tsx
+++ b/web/src/components/DestinationManager.tsx
@@ -1,0 +1,170 @@
+import { useState, useEffect } from 'react';
+import { getDestinations, createDestination, deleteDestination } from '../services/api';
+import type { Destination } from '../types';
+
+interface Props {
+  sourceId: string;
+}
+
+export default function DestinationManager({ sourceId }: Props) {
+  const [destinations, setDestinations] = useState<Destination[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({ name: '', dest_url: '', dest_username: '', dest_password: '' });
+
+  useEffect(() => {
+    loadDestinations();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sourceId]);
+
+  const loadDestinations = async () => {
+    try {
+      const data = await getDestinations(sourceId);
+      setDestinations(data);
+    } catch {
+      setError('Failed to load destinations');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.dest_url || !form.dest_username || !form.dest_password) {
+      setError('All fields are required');
+      return;
+    }
+    setAdding(true);
+    setError(null);
+    try {
+      await createDestination(sourceId, form);
+      setForm({ name: '', dest_url: '', dest_username: '', dest_password: '' });
+      setShowForm(false);
+      await loadDestinations();
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosErr = err as { response?: { data?: { error?: string } } };
+        setError(axiosErr.response?.data?.error || 'Failed to add destination');
+      } else {
+        setError('Failed to add destination');
+      }
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleDelete = async (destId: string, name: string) => {
+    if (!confirm(`Delete destination "${name || destId}"?`)) return;
+    try {
+      await deleteDestination(sourceId, destId);
+      await loadDestinations();
+    } catch {
+      setError('Failed to delete destination');
+    }
+  };
+
+  if (loading) return <p className="text-gray-500 text-sm">Loading destinations...</p>;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-300 uppercase tracking-wide">
+          Additional Destinations
+        </h3>
+        <button
+          type="button"
+          onClick={() => setShowForm(!showForm)}
+          className="px-3 py-1 rounded bg-zinc-700 hover:bg-zinc-600 text-white text-xs font-medium transition-colors"
+        >
+          {showForm ? 'Cancel' : '+ Add'}
+        </button>
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      {destinations.length === 0 && !showForm && (
+        <p className="text-xs text-gray-500">No additional destinations. Events sync only to the primary destination above.</p>
+      )}
+
+      {destinations.map((dest) => (
+        <div key={dest.id} className="flex items-center justify-between p-3 bg-black/50 rounded border border-zinc-700">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm text-white font-medium truncate">{dest.name || dest.dest_url}</p>
+            <p className="text-xs text-gray-500 truncate">{dest.dest_url}</p>
+            <p className="text-xs text-gray-500">{dest.dest_username}</p>
+          </div>
+          <div className="flex items-center space-x-2 ml-3">
+            <span className={`text-xs px-1.5 py-0.5 rounded ${dest.enabled ? 'bg-green-900/50 text-green-400' : 'bg-zinc-800 text-gray-500'}`}>
+              {dest.enabled ? 'Active' : 'Disabled'}
+            </span>
+            <button
+              type="button"
+              onClick={() => handleDelete(dest.id, dest.name)}
+              className="text-red-400 hover:text-red-300 text-xs"
+            >
+              Remove
+            </button>
+          </div>
+        </div>
+      ))}
+
+      {showForm && (
+        <form onSubmit={handleAdd} className="p-4 bg-black/50 rounded border border-zinc-700 space-y-3">
+          <div>
+            <label className="block text-xs font-medium text-gray-400 mb-1">Name (optional)</label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm(prev => ({ ...prev, name: e.target.value }))}
+              placeholder="e.g. Backup SOGo"
+              className="w-full"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-400 mb-1">CalDAV URL</label>
+            <input
+              type="url"
+              value={form.dest_url}
+              onChange={(e) => setForm(prev => ({ ...prev, dest_url: e.target.value }))}
+              required
+              className="w-full"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-400 mb-1">Username</label>
+              <input
+                type="text"
+                value={form.dest_username}
+                onChange={(e) => setForm(prev => ({ ...prev, dest_username: e.target.value }))}
+                required
+                className="w-full"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-400 mb-1">Password</label>
+              <input
+                type="password"
+                value={form.dest_password}
+                onChange={(e) => setForm(prev => ({ ...prev, dest_password: e.target.value }))}
+                required
+                className="w-full"
+              />
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={adding}
+              className="px-4 py-1.5 rounded bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors disabled:opacity-50"
+            >
+              {adding ? 'Adding...' : 'Add Destination'}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/SourceEdit.tsx
+++ b/web/src/pages/SourceEdit.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { getSource, updateSource, deleteSource, discoverCalendars } from '../services/api';
+import DestinationManager from '../components/DestinationManager';
 import type { Source, Calendar, CalendarConfig } from '../types';
 
 export default function SourceEdit() {
@@ -432,6 +433,13 @@ export default function SourceEdit() {
               </div>
             </div>
           </div>
+
+          {/* Additional Destinations (#156) */}
+          {id && (
+            <div className="border-t border-zinc-800 pt-6">
+              <DestinationManager sourceId={id} />
+            </div>
+          )}
 
           {/* Status Info */}
           {source && (

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { Source, SyncLog, DashboardStats, SourceFormData, AuthStatus, SyncHistory, MalformedEvent, Calendar, AlertPreferences, ActivityData } from '../types';
+import type { Source, SyncLog, DashboardStats, SourceFormData, AuthStatus, SyncHistory, MalformedEvent, Calendar, AlertPreferences, ActivityData, Destination } from '../types';
 
 const api = axios.create({
   baseURL: '/api',
@@ -187,6 +187,21 @@ export const getLogStats = async (): Promise<{ total_logs: number; oldest_log: s
 export const getActivity = async (): Promise<ActivityData> => {
   const response = await api.get('/activity');
   return response.data;
+};
+
+// Destinations (multi-destination sync #156)
+export const getDestinations = async (sourceId: string): Promise<Destination[]> => {
+  const response = await api.get(`/sources/${sourceId}/destinations`);
+  return response.data;
+};
+
+export const createDestination = async (sourceId: string, data: { name: string; dest_url: string; dest_username: string; dest_password: string }): Promise<Destination> => {
+  const response = await api.post(`/sources/${sourceId}/destinations`, data);
+  return response.data;
+};
+
+export const deleteDestination = async (sourceId: string, destId: string): Promise<void> => {
+  await api.delete(`/sources/${sourceId}/destinations/${destId}`);
 };
 
 export default api;

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -155,3 +155,14 @@ export interface ActivityData {
   active: SyncActivity[];
   recent: SyncActivity[];
 }
+
+export interface Destination {
+  id: string;
+  source_id: string;
+  name: string;
+  dest_url: string;
+  dest_username: string;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- Sync engine iterates over additional destinations after primary dest sync (both CalDAV and ICS paths)
- Errors from extra dests downgraded to warnings — one failure doesn't mark the whole sync as failed
- New `DestinationManager` component in SourceEdit with list/add/remove UI

Closes #158

## Test plan
- [x] `go build ./...` passes
- [x] `go test -count=1 ./...` all packages green
- [x] `npm run build` compiles clean
- [ ] Deploy and verify DestinationManager renders on SourceEdit page
- [ ] Add an additional destination and verify it appears in sync logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)