### PR TITLE
feat: CalDAV proxy bridge for Fantastical + SOGo

### DIFF
--- a/Dockerfile.caldav-proxy
+++ b/Dockerfile.caldav-proxy
@@ -1,0 +1,29 @@
+FROM golang:1.24-alpine AS builder
+
+RUN apk add --no-cache git ca-certificates
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-w -s" \
+    -o /app/caldav-proxy \
+    ./cmd/caldav-proxy
+
+FROM alpine:3.19
+RUN apk add --no-cache ca-certificates
+RUN addgroup -g 1001 caldavproxy && \
+    adduser -u 1001 -G caldavproxy -s /bin/sh -D caldavproxy
+
+WORKDIR /app
+COPY --from=builder /app/caldav-proxy /app/caldav-proxy
+
+USER caldavproxy
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/healthz || exit 1
+
+CMD ["/app/caldav-proxy"]

--- a/cmd/caldav-proxy/main.go
+++ b/cmd/caldav-proxy/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/macjediwizard/calbridgesync/internal/caldavproxy"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	listen := envOr("CALDAV_PROXY_LISTEN", ":8080")
+	backendStr := envOr("CALDAV_PROXY_BACKEND", "https://mail.macjediwizard.com")
+	skipVerify := envOr("CALDAV_PROXY_TLS_SKIP_VERIFY", "false") == "true"
+
+	backendURL, err := url.Parse(backendStr)
+	if err != nil {
+		log.Fatalf("Invalid backend URL %q: %v", backendStr, err)
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = backendURL.Scheme
+			req.URL.Host = backendURL.Host
+			req.Host = backendURL.Host
+		},
+		Transport: transport,
+		ModifyResponse: func(resp *http.Response) error {
+			if resp.Request.Method != "PROPFIND" || resp.StatusCode != http.StatusMultiStatus {
+				return nil
+			}
+
+			body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+			resp.Body.Close()
+			if err != nil {
+				return err
+			}
+
+			cleaned := caldavproxy.RewriteMultistatus(body)
+
+			resp.Body = io.NopCloser(bytes.NewReader(cleaned))
+			resp.ContentLength = int64(len(cleaned))
+			resp.Header.Set("Content-Length", strconv.Itoa(len(cleaned)))
+			resp.Header.Del("Transfer-Encoding")
+
+			return nil
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	mux.Handle("/", proxy)
+
+	server := &http.Server{
+		Addr:         listen,
+		Handler:      mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	go func() {
+		log.Printf("CalDAV proxy starting on %s → %s", listen, backendStr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server error: %v", err)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+
+	log.Println("Shutting down...")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	server.Shutdown(ctx)
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/internal/caldavproxy/rewrite.go
+++ b/internal/caldavproxy/rewrite.go
@@ -1,0 +1,46 @@
+package caldavproxy
+
+import (
+	"regexp"
+)
+
+// groupDAVRe matches any self-closing or open+close element from the
+// http://groupdav.org/ namespace inside a <resourcetype> block.
+// Examples it catches:
+//   - <vevent-collection xmlns="http://groupdav.org/"/>
+//   - <vtodo-collection xmlns="http://groupdav.org/"/>
+var groupDAVRe = regexp.MustCompile(`<[^>]*xmlns="http://groupdav\.org/"[^>]*/?>(?:</[^>]+>)?`)
+
+// scheduleOutboxRe matches the schedule-outbox element from the CalDAV
+// namespace inside a <resourcetype> block.
+// Examples:
+//   - <schedule-outbox xmlns="urn:ietf:params:xml:ns:caldav"/>
+//   - <n1:schedule-outbox xmlns:n1="urn:ietf:params:xml:ns:caldav"/>
+var scheduleOutboxRe = regexp.MustCompile(`<[^>]*schedule-outbox[^>]*urn:ietf:params:xml:ns:caldav[^>]*/?>(?:</[^>]+>)?`)
+
+// Also match the reverse attribute order (xmlns before element name)
+var scheduleOutboxRe2 = regexp.MustCompile(`<[^>]*urn:ietf:params:xml:ns:caldav[^>]*schedule-outbox[^>]*/?>(?:</[^>]+>)?`)
+
+// RewriteMultistatus cleans a WebDAV 207 Multi-Status XML response so that
+// CalDAV clients like Fantastical can discover calendars from SOGo.
+//
+// SOGo includes non-standard elements in <resourcetype> that cause Fantastical
+// to silently skip calendars:
+//   - GroupDAV elements (http://groupdav.org/ namespace)
+//   - schedule-outbox inside calendar collections
+//
+// This function uses regex-based surgery on the raw XML to remove those
+// elements while preserving all other content byte-for-byte.
+// If the input doesn't contain the problematic patterns, it's returned unchanged.
+func RewriteMultistatus(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+
+	result := body
+	result = groupDAVRe.ReplaceAll(result, nil)
+	result = scheduleOutboxRe.ReplaceAll(result, nil)
+	result = scheduleOutboxRe2.ReplaceAll(result, nil)
+
+	return result
+}

--- a/internal/caldavproxy/rewrite_test.go
+++ b/internal/caldavproxy/rewrite_test.go
@@ -1,0 +1,92 @@
+package caldavproxy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewriteMultistatus_SOGoCalendarResponse(t *testing.T) {
+	// Real SOGo response with problematic resourcetype elements
+	input := `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:a="urn:ietf:params:xml:ns:caldav"><D:response><D:href>/SOGo/dav/user@example.com/Calendar/personal/</D:href><D:propstat><D:status>HTTP/1.1 200 OK</D:status><D:prop><D:resourcetype><D:collection/><calendar xmlns="urn:ietf:params:xml:ns:caldav"/><vevent-collection xmlns="http://groupdav.org/"/><vtodo-collection xmlns="http://groupdav.org/"/><schedule-outbox xmlns="urn:ietf:params:xml:ns:caldav"/></D:resourcetype></D:prop></D:propstat></D:response></D:multistatus>`
+
+	result := string(RewriteMultistatus([]byte(input)))
+
+	// Should NOT contain GroupDAV elements
+	if strings.Contains(result, "groupdav.org") {
+		t.Error("result still contains groupdav.org elements")
+	}
+
+	// Should NOT contain schedule-outbox
+	if strings.Contains(result, "schedule-outbox") {
+		t.Error("result still contains schedule-outbox")
+	}
+
+	// Should still contain collection
+	if !strings.Contains(result, "collection") {
+		t.Error("result is missing collection element")
+	}
+
+	// Should still contain calendar
+	if !strings.Contains(result, "calendar") {
+		t.Error("result is missing calendar element")
+	}
+
+	// Should still be valid XML with multistatus
+	if !strings.Contains(result, "multistatus") {
+		t.Error("result is missing multistatus root")
+	}
+}
+
+func TestRewriteMultistatus_PassthroughNonCalendar(t *testing.T) {
+	// A plain collection with no calendar elements should pass through
+	input := `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:"><D:response><D:href>/SOGo/dav/user@example.com/Calendar/</D:href><D:propstat><D:status>HTTP/1.1 200 OK</D:status><D:prop><D:resourcetype><D:collection/></D:resourcetype><D:displayname>Calendar</D:displayname></D:prop></D:propstat></D:response></D:multistatus>`
+
+	result := string(RewriteMultistatus([]byte(input)))
+
+	if !strings.Contains(result, "collection") {
+		t.Error("result is missing collection element")
+	}
+	if !strings.Contains(result, "Calendar") {
+		t.Error("result is missing displayname")
+	}
+}
+
+func TestRewriteMultistatus_MalformedXML(t *testing.T) {
+	// Malformed XML should be returned unchanged
+	input := `this is not xml at all`
+	result := string(RewriteMultistatus([]byte(input)))
+	if result != input {
+		t.Errorf("malformed input was modified: got %q", result)
+	}
+}
+
+func TestRewriteMultistatus_EmptyBody(t *testing.T) {
+	result := RewriteMultistatus([]byte{})
+	if len(result) != 0 {
+		t.Errorf("empty input produced non-empty output: %q", result)
+	}
+}
+
+func TestRewriteMultistatus_PreservesOtherProperties(t *testing.T) {
+	input := `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:CS="http://calendarserver.org/ns/" xmlns:C="http://apple.com/ns/ical/"><D:response><D:href>/SOGo/dav/user@example.com/Calendar/personal/</D:href><D:propstat><D:status>HTTP/1.1 200 OK</D:status><D:prop><D:resourcetype><D:collection/><calendar xmlns="urn:ietf:params:xml:ns:caldav"/><vevent-collection xmlns="http://groupdav.org/"/></D:resourcetype><D:displayname>My Calendar</D:displayname><CS:getctag>12345</CS:getctag><C:calendar-color>#FF0000</C:calendar-color></D:prop></D:propstat></D:response></D:multistatus>`
+
+	result := string(RewriteMultistatus([]byte(input)))
+
+	// Properties outside resourcetype should be preserved
+	if !strings.Contains(result, "My Calendar") {
+		t.Error("displayname was lost")
+	}
+	if !strings.Contains(result, "12345") {
+		t.Error("getctag was lost")
+	}
+	if !strings.Contains(result, "#FF0000") {
+		t.Error("calendar-color was lost")
+	}
+	// GroupDAV should be gone
+	if strings.Contains(result, "groupdav") {
+		t.Error("groupdav elements were not removed")
+	}
+}


### PR DESCRIPTION
## Summary
- Lightweight reverse proxy that fixes SOGo's CalDAV PROPFIND responses for Fantastical compatibility
- Strips GroupDAV namespace elements and schedule-outbox from resourcetype
- Passes all other CalDAV traffic through unchanged
- Separate Dockerfile for standalone deployment

## Deployment
Build: `docker build -f Dockerfile.caldav-proxy -t caldav-proxy .`
Run: `docker run -p 8443:8080 -e CALDAV_PROXY_BACKEND=https://mail.macjediwizard.com caldav-proxy`
Point Fantastical at `https://your-proxy-host:8443/SOGo/dav/`

## Test plan
- [x] `go test ./internal/caldavproxy/...` passes
- [x] `go test ./...` all packages green
- [x] Verified proxy strips GroupDAV + schedule-outbox from real SOGo responses
- [ ] Deploy and test Fantastical discovery through proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)