### PR TITLE
fix: Google OAuth callback missing session middleware

### DIFF
--- a/internal/web/oauth_google.go
+++ b/internal/web/oauth_google.go
@@ -326,11 +326,8 @@ func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
 
 	// Read back the pending form data BEFORE exchanging the code, so
 	// we have the per-source client_id and client_secret to build the
-	// oauth2.Config that the exchange call needs. As of #79 these
-	// credentials live on each source, not in global env vars, so the
-	// pending session cookie is the only place they exist between the
-	// prepare step and this callback. GetPendingGoogleSource also
-	// clears the cookie.
+	// oauth2.Config that the exchange call needs. GetPendingGoogleSource
+	// also clears the cookie (consume-once semantics).
 	pending, err := h.session.GetPendingGoogleSource(c.Writer, c.Request)
 	if err != nil {
 		log.Printf("Google OAuth callback: no pending source in session: %v", err)
@@ -398,7 +395,8 @@ func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
 
 	session := auth.GetCurrentUser(c)
 	if session == nil {
-		c.Redirect(http.StatusFound, "/auth/login")
+		log.Printf("Google OAuth callback: no authenticated session; redirecting to /auth/login")
+		c.Redirect(http.StatusFound, "/auth/login?error=session_lost")
 		return
 	}
 

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -28,6 +28,7 @@ func SetupRoutes(r *gin.Engine, h *Handlers, sm *auth.SessionManager) {
 	authRateLimiter := RateLimiter(5, 10)
 	authGroup := r.Group("/auth")
 	authGroup.Use(authRateLimiter)
+	authGroup.Use(auth.OptionalAuth(sm)) // Hydrate session context so Google OAuth callback can read the user (#160)
 	{
 		authGroup.GET("/login", h.Login)
 		authGroup.POST("/login", h.Login)


### PR DESCRIPTION
## Summary
- Add `OptionalAuth(sm)` middleware to auth group so the Google OAuth callback can read the user session
- Add log line to the nil-session path that was previously completely silent

## Root cause
The `/auth/oauth/google/callback` route was in `authGroup` which had no session middleware. `auth.GetCurrentUser(c)` returned nil because no middleware hydrated the Gin context. The OAuth flow completed successfully but silently bounced to `/auth/login` at the source creation step.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` all packages green
- [ ] Deploy and retry Google OAuth source creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)