### PR TITLE
fix: bypass principal discovery for Google CalDAV

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -190,6 +190,14 @@ func (c *Client) TestConnection(ctx context.Context) error {
 	return nil
 }
 
+// TestConnectionGoogle tests a Google CalDAV connection by listing
+// calendars directly, since Google doesn't support the standard
+// FindCurrentUserPrincipal PROPFIND. (#160)
+func (c *Client) TestConnectionGoogle(ctx context.Context) error {
+	_, err := c.FindCalendarsGoogle(ctx)
+	return err
+}
+
 // FindCalendars discovers all calendars for the current user.
 func (c *Client) FindCalendars(ctx context.Context) ([]Calendar, error) {
 	principal, err := c.caldavClient.FindCurrentUserPrincipal(ctx)
@@ -205,6 +213,38 @@ func (c *Client) FindCalendars(ctx context.Context) ([]Calendar, error) {
 	cals, err := c.caldavClient.FindCalendars(ctx, homeSet)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to find calendars: %w", ErrConnectionFailed, err)
+	}
+
+	calendars := make([]Calendar, 0, len(cals))
+	for _, cal := range cals {
+		calendars = append(calendars, Calendar{
+			Path:        cal.Path,
+			Name:        cal.Name,
+			Description: cal.Description,
+		})
+	}
+
+	return calendars, nil
+}
+
+// FindCalendarsGoogle discovers calendars on Google CalDAV by skipping
+// principal discovery (which Google doesn't support) and going directly
+// to the calendar home set. Google's CalDAV structure is:
+//
+//	/caldav/v2/{email}/         — calendar home set
+//	/caldav/v2/{email}/events/  — primary calendar
+//
+// The baseURL is expected to be https://apidata.googleusercontent.com/caldav/v2/{email}/user
+// so we derive the home set by stripping "/user". (#160)
+func (c *Client) FindCalendarsGoogle(ctx context.Context) ([]Calendar, error) {
+	// Derive calendar home set from baseURL: strip "/user" suffix
+	homeSet := strings.TrimSuffix(c.baseURL, "/user")
+	homeSet = strings.TrimSuffix(homeSet, "/")
+	homeSet += "/"
+
+	cals, err := c.caldavClient.FindCalendars(ctx, homeSet)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to find Google calendars at %s: %w", ErrConnectionFailed, homeSet, err)
 	}
 
 	calendars := make([]Calendar, 0, len(cals))

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -1007,13 +1007,24 @@ func (se *SyncEngine) SyncSource(ctx context.Context, source *db.Source) *SyncRe
 		return result
 	}
 
-	// Test connections
-	if err := sourceClient.TestConnection(ctx); err != nil {
-		result.Message = "Source connection test failed"
-		result.Errors = append(result.Errors, err.Error())
-		result.Duration = time.Since(start)
-		se.finishSync(source.ID, result)
-		return result
+	// Test connections — Google CalDAV doesn't support the standard
+	// FindCurrentUserPrincipal PROPFIND, so we use a different test. (#160)
+	if source.SourceType == db.SourceTypeGoogle {
+		if err := sourceClient.TestConnectionGoogle(ctx); err != nil {
+			result.Message = "Source connection test failed"
+			result.Errors = append(result.Errors, err.Error())
+			result.Duration = time.Since(start)
+			se.finishSync(source.ID, result)
+			return result
+		}
+	} else {
+		if err := sourceClient.TestConnection(ctx); err != nil {
+			result.Message = "Source connection test failed"
+			result.Errors = append(result.Errors, err.Error())
+			result.Duration = time.Since(start)
+			se.finishSync(source.ID, result)
+			return result
+		}
 	}
 
 	if err := destClient.TestConnection(ctx); err != nil {
@@ -1024,8 +1035,13 @@ func (se *SyncEngine) SyncSource(ctx context.Context, source *db.Source) *SyncRe
 		return result
 	}
 
-	// Find calendars on source
-	sourceCalendars, err := sourceClient.FindCalendars(ctx)
+	// Find calendars on source — Google needs a different discovery path. (#160)
+	var sourceCalendars []Calendar
+	if source.SourceType == db.SourceTypeGoogle {
+		sourceCalendars, err = sourceClient.FindCalendarsGoogle(ctx)
+	} else {
+		sourceCalendars, err = sourceClient.FindCalendars(ctx)
+	}
 	if err != nil {
 		result.Message = "Failed to find source calendars"
 		result.Errors = append(result.Errors, err.Error())


### PR DESCRIPTION
## Summary
- Google CalDAV returns 404 on `FindCurrentUserPrincipal` PROPFIND
- Added `FindCalendarsGoogle()` that skips principal discovery and goes directly to calendar home set
- Added `TestConnectionGoogle()` for connection testing without principal lookup
- Sync engine branches on `SourceTypeGoogle` for both test and discovery

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` all green
- [ ] Deploy and verify Google source syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)