### PR TITLE
fix: use Google-specific discovery for Google CalDAV destinations

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -667,6 +667,14 @@ func parseEventPaths(body []byte, basePath string) []string {
 	return paths
 }
 
+// IsGoogleURL reports whether a CalDAV base URL points at Google's
+// CalDAV endpoint. Google uses a non-standard discovery flow and a
+// different write path (/events/ instead of /user), so callers must
+// branch on this.
+func IsGoogleURL(baseURL string) bool {
+	return strings.Contains(baseURL, "googleusercontent.com/caldav/")
+}
+
 // GetCalendarPath returns the path portion of the client's base URL.
 // This is useful when the client is configured for a specific calendar.
 func (c *Client) GetCalendarPath() string {

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -1916,3 +1916,21 @@ func TestClientWithTestServer(t *testing.T) {
 		}
 	})
 }
+
+func TestIsGoogleURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://apidata.googleusercontent.com/caldav/v2/user@gmail.com/user", true},
+		{"https://apidata.googleusercontent.com/caldav/v2/user@gmail.com/events/", true},
+		{"https://caldav.icloud.com/12345/calendars/home/", false},
+		{"https://sogo.example.com/SOGo/dav/user/Calendar/personal/", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsGoogleURL(tt.url); got != tt.want {
+			t.Errorf("IsGoogleURL(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -1027,12 +1027,24 @@ func (se *SyncEngine) SyncSource(ctx context.Context, source *db.Source) *SyncRe
 		}
 	}
 
-	if err := destClient.TestConnection(ctx); err != nil {
-		result.Message = "Destination connection test failed"
-		result.Errors = append(result.Errors, err.Error())
-		result.Duration = time.Since(start)
-		se.finishSync(source.ID, result)
-		return result
+	// Destination connection test — Google destinations need the same
+	// non-standard path as Google sources. (#165)
+	if IsGoogleURL(source.DestURL) {
+		if err := destClient.TestConnectionGoogle(ctx); err != nil {
+			result.Message = "Destination connection test failed"
+			result.Errors = append(result.Errors, err.Error())
+			result.Duration = time.Since(start)
+			se.finishSync(source.ID, result)
+			return result
+		}
+	} else {
+		if err := destClient.TestConnection(ctx); err != nil {
+			result.Message = "Destination connection test failed"
+			result.Errors = append(result.Errors, err.Error())
+			result.Duration = time.Since(start)
+			se.finishSync(source.ID, result)
+			return result
+		}
 	}
 
 	// Find calendars on source — Google needs a different discovery path. (#160)
@@ -1182,8 +1194,16 @@ func (se *SyncEngine) syncCalendar(ctx context.Context, source *db.Source, sourc
 
 	// Discover destination calendar path using the same logic as fullSync
 	// to ensure both code paths target the same calendar.
+	// Google destinations need FindCalendarsGoogle — standard discovery
+	// fails and the URL-path fallback yields /user which is read-only. (#165)
 	destCalendarPath := ""
-	destCalendars, discoverErr := destClient.FindCalendars(ctx)
+	var destCalendars []Calendar
+	var discoverErr error
+	if IsGoogleURL(source.DestURL) {
+		destCalendars, discoverErr = destClient.FindCalendarsGoogle(ctx)
+	} else {
+		destCalendars, discoverErr = destClient.FindCalendars(ctx)
+	}
 	if discoverErr != nil {
 		log.Printf("Failed to discover destination calendars, falling back to URL path: %v", discoverErr)
 		destCalendarPath = destClient.GetCalendarPath()
@@ -1475,11 +1495,19 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 		se.tracker.UpdateCalendar(source.ID, fmt.Sprintf("%s (%s)", calendar.Name, status), calendarIndex)
 	}
 
-	// Discover destination calendar path - try calendar discovery first, then fall back to URL path
+	// Discover destination calendar path - try calendar discovery first, then fall back to URL path.
+	// Google destinations need FindCalendarsGoogle — standard discovery
+	// fails and the URL-path fallback yields /user which is read-only. (#165)
 	destCalendarPath := ""
-	destCalendars, err := destClient.FindCalendars(ctx)
-	if err != nil {
-		log.Printf("Failed to discover destination calendars, falling back to URL path: %v", err)
+	var destCalendars []Calendar
+	var destDiscoverErr error
+	if IsGoogleURL(source.DestURL) {
+		destCalendars, destDiscoverErr = destClient.FindCalendarsGoogle(ctx)
+	} else {
+		destCalendars, destDiscoverErr = destClient.FindCalendars(ctx)
+	}
+	if destDiscoverErr != nil {
+		log.Printf("Failed to discover destination calendars, falling back to URL path: %v", destDiscoverErr)
 		destCalendarPath = destClient.GetCalendarPath()
 	} else if len(destCalendars) == 0 {
 		log.Printf("No calendars found on destination, using URL path as fallback")


### PR DESCRIPTION
## Summary
- Fixes #165 — syncs **to** Google CalDAV destinations were failing with 403 Forbidden on every PUT because destination discovery used the standard CalDAV flow (which Google doesn't support), then fell back to the read-only `/user` URL instead of the writable `/events/` path.
- Adds `IsGoogleURL` helper and branches on it in the destination connection test and both destination discovery paths (fullSync + WebDAV-Sync).
- Source-side was fixed in #162/#163/#164; this is the matching destination-side fix.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -count=1 ./...` green (all 11 packages)
- [x] New `TestIsGoogleURL` covers Google / iCloud / SOGo / empty URL inputs
- [ ] Live verification: run a sync with a Google destination, confirm events are created without 403s

🤖 Generated with [Claude Code](https://claude.com/claude-code)