### PR TITLE
fix: retry 403 PUTs with bumped SEQUENCE so Google→SOGo sync works

### DIFF
--- a/internal/caldav/client.go
+++ b/internal/caldav/client.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -840,10 +841,130 @@ func (c *Client) PutEvent(ctx context.Context, calendarPath string, event *Event
 	log.Printf("PutEvent: putting to path %s", path)
 	_, err = c.caldavClient.PutCalendarObject(ctx, path, cal)
 	if err != nil {
+		// SOGo (and other RFC-5546-strict servers) reject a PUT when the
+		// incoming SEQUENCE is lower than what they already have stored
+		// for this UID, returning 403 with body `<D:error>sequences don't
+		// match</D:error>`. Google Calendar emits SEQUENCE:0 for nearly
+		// every event, so any event that was previously written to the
+		// destination at SEQUENCE >= 1 (by another client or an earlier
+		// calbridgesync run) will be refused every cycle forever.
+		//
+		// On 403 we try once to recover: GET the existing event at the
+		// same path, extract its SEQUENCE, rewrite our outbound payload
+		// to SEQUENCE = existing + 1, and retry the PUT. If the retry
+		// succeeds we return nil; if it doesn't, we surface the original
+		// error so real auth/ACL 403s still bubble up. (#167)
+		if strings.Contains(err.Error(), "403") {
+			if retryErr := c.retryPutWithBumpedSequence(ctx, path, cal); retryErr == nil {
+				log.Printf("PutEvent: recovered from 403 via SEQUENCE bump on %s", path)
+				return nil
+			}
+		}
 		return fmt.Errorf("%w: failed to put event: %w", ErrConnectionFailed, err)
 	}
 
 	return nil
+}
+
+// retryPutWithBumpedSequence attempts a second PUT after a 403 by reading
+// the destination's current SEQUENCE for this UID and bumping the outbound
+// payload to be strictly greater. Returns nil on successful retry, non-nil
+// if the retry cannot be attempted (cannot read existing, no SEQUENCE to
+// compare against) or the retry itself fails.
+func (c *Client) retryPutWithBumpedSequence(ctx context.Context, path string, cal *ical.Calendar) error {
+	existingData, err := c.fetchRawEvent(ctx, path)
+	if err != nil {
+		return err
+	}
+	existingSeq := extractSequenceFromICS(existingData)
+	if existingSeq < 0 {
+		return fmt.Errorf("no SEQUENCE on existing event at %s", path)
+	}
+	newSeq := existingSeq + 1
+	if our := extractSequenceFromCalendar(cal); our > newSeq {
+		newSeq = our + 1
+	}
+	rewriteSequenceInCalendar(cal, newSeq)
+	_, err = c.caldavClient.PutCalendarObject(ctx, path, cal)
+	return err
+}
+
+// fetchRawEvent does a plain HTTP GET against an event path and returns
+// the raw iCalendar body. Used by retryPutWithBumpedSequence to read the
+// current SEQUENCE without paying for a full MULTIGET.
+func (c *Client) fetchRawEvent(ctx context.Context, path string) (string, error) {
+	fullURL := c.buildURL(path)
+	req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.SetBasicAuth(c.username, c.password)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, path)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxCalDAVResponseSize))
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// extractSequenceFromICS parses the SEQUENCE value from raw iCalendar data.
+// Returns -1 if no SEQUENCE line is present. Only the first SEQUENCE found
+// in the first VEVENT is used — master + overrides would all share the
+// same SEQUENCE under RFC 5545 in practice.
+func extractSequenceFromICS(data string) int {
+	// Scan line-by-line so we don't allocate a full parse when the
+	// caller only needs a single integer. Lines are CRLF or LF; handle
+	// both.
+	for _, line := range strings.Split(strings.ReplaceAll(data, "\r\n", "\n"), "\n") {
+		if strings.HasPrefix(line, "SEQUENCE:") {
+			v := strings.TrimSpace(strings.TrimPrefix(line, "SEQUENCE:"))
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return -1
+			}
+			return n
+		}
+	}
+	return -1
+}
+
+// extractSequenceFromCalendar reads the SEQUENCE property from the first
+// VEVENT in a parsed calendar. Returns -1 if absent or unparseable.
+func extractSequenceFromCalendar(cal *ical.Calendar) int {
+	for _, evt := range cal.Events() {
+		if prop := evt.Props.Get("SEQUENCE"); prop != nil {
+			n, err := strconv.Atoi(strings.TrimSpace(prop.Value))
+			if err == nil {
+				return n
+			}
+		}
+	}
+	return -1
+}
+
+// rewriteSequenceInCalendar sets SEQUENCE=newSeq on every VEVENT in the
+// calendar, creating the property if it was absent. Used by the retry
+// path so the retried PUT carries a SEQUENCE that SOGo will accept as
+// "newer" than what it has stored.
+//
+// We build the Prop directly instead of calling Props.SetText — SetText
+// attaches a VALUE=TEXT parameter, which would emit `SEQUENCE;VALUE=TEXT:N`.
+// RFC 5545 defines SEQUENCE as an INTEGER, and SOGo's parser rejects the
+// VALUE=TEXT variant. Building the Prop bare produces the canonical
+// `SEQUENCE:N` form.
+func rewriteSequenceInCalendar(cal *ical.Calendar, newSeq int) {
+	for _, evt := range cal.Events() {
+		prop := ical.NewProp("SEQUENCE")
+		prop.Value = strconv.Itoa(newSeq)
+		evt.Props.Set(prop)
+	}
 }
 
 // DeleteEvent deletes an event.

--- a/internal/caldav/client_test.go
+++ b/internal/caldav/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1932,5 +1933,182 @@ func TestIsGoogleURL(t *testing.T) {
 		if got := IsGoogleURL(tt.url); got != tt.want {
 			t.Errorf("IsGoogleURL(%q) = %v, want %v", tt.url, got, tt.want)
 		}
+	}
+}
+
+func TestExtractSequenceFromICS(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want int
+	}{
+		{
+			name: "CRLF line endings, SEQUENCE:0",
+			data: "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:x\r\nSEQUENCE:0\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+			want: 0,
+		},
+		{
+			name: "LF line endings, SEQUENCE:5",
+			data: "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:x\nSEQUENCE:5\nEND:VEVENT\nEND:VCALENDAR\n",
+			want: 5,
+		},
+		{
+			name: "no SEQUENCE line",
+			data: "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:x\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+			want: -1,
+		},
+		{
+			name: "malformed SEQUENCE",
+			data: "BEGIN:VCALENDAR\r\nSEQUENCE:not-a-number\r\nEND:VCALENDAR\r\n",
+			want: -1,
+		},
+		{
+			name: "empty string",
+			data: "",
+			want: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractSequenceFromICS(tt.data); got != tt.want {
+				t.Errorf("extractSequenceFromICS() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRewriteSequenceInCalendar(t *testing.T) {
+	// Start with a calendar at SEQUENCE:0, rewrite to 7, verify encode
+	// emits SEQUENCE:7.
+	data := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//test//EN\r\nBEGIN:VEVENT\r\nUID:abc\r\nDTSTAMP:20260101T000000Z\r\nDTSTART:20260101T120000Z\r\nDTEND:20260101T130000Z\r\nSEQUENCE:0\r\nSUMMARY:test\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+	cal, err := parseICalendar(data)
+	if err != nil {
+		t.Fatalf("parseICalendar: %v", err)
+	}
+	rewriteSequenceInCalendar(cal, 7)
+	if got := extractSequenceFromCalendar(cal); got != 7 {
+		t.Errorf("after rewrite, extractSequenceFromCalendar() = %d, want 7", got)
+	}
+	// Also verify via re-encode that the emitted body carries SEQUENCE:7.
+	out, err := encodeCalendar(cal)
+	if err != nil {
+		t.Fatalf("encodeCalendar: %v", err)
+	}
+	if !strings.Contains(out, "SEQUENCE:7") {
+		t.Errorf("re-encoded body missing SEQUENCE:7, got:\n%s", out)
+	}
+	if strings.Contains(out, "SEQUENCE:0") {
+		t.Errorf("re-encoded body still has old SEQUENCE:0, got:\n%s", out)
+	}
+}
+
+func TestRewriteSequenceInCalendar_NoExistingSequence(t *testing.T) {
+	// VEVENT with no SEQUENCE — rewrite should add one.
+	data := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//test//EN\r\nBEGIN:VEVENT\r\nUID:abc\r\nDTSTAMP:20260101T000000Z\r\nDTSTART:20260101T120000Z\r\nDTEND:20260101T130000Z\r\nSUMMARY:test\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+	cal, err := parseICalendar(data)
+	if err != nil {
+		t.Fatalf("parseICalendar: %v", err)
+	}
+	rewriteSequenceInCalendar(cal, 3)
+	if got := extractSequenceFromCalendar(cal); got != 3 {
+		t.Errorf("after rewrite with no prior SEQUENCE, got %d, want 3", got)
+	}
+}
+
+// TestPutEventSequenceRetry exercises the SOGo "sequences don't match" 403
+// recovery path: first PUT returns 403, client GETs existing event, bumps
+// SEQUENCE, retries, retry succeeds. Covers the real-world Google→SOGo
+// scenario that motivated the fix.
+func TestPutEventSequenceRetry(t *testing.T) {
+	const existingUID = "61D367D8-CDA7-4540-AD11-5E49264A71D2"
+	existingBody := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//SOGo//EN\r\nBEGIN:VEVENT\r\nUID:" + existingUID + "\r\nSEQUENCE:3\r\nDTSTAMP:20260101T000000Z\r\nDTSTART:20260101T120000Z\r\nDTEND:20260101T130000Z\r\nSUMMARY:existing\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+
+	var putCount int
+	var lastPutBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			putCount++
+			body, _ := io.ReadAll(r.Body)
+			lastPutBody = string(body)
+			// First PUT returns 403 (sequences don't match). Retry PUT
+			// succeeds with 201. We use the body's SEQUENCE value to
+			// decide — anything <= 3 is rejected as stale.
+			if seq := extractSequenceFromICS(lastPutBody); seq <= 3 {
+				w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?><D:error xmlns:D="DAV:">sequences don't match</D:error>`))
+				return
+			}
+			w.Header().Set("ETag", `"bumped"`)
+			w.WriteHeader(http.StatusCreated)
+		case "GET":
+			w.Header().Set("Content-Type", "text/calendar")
+			_, _ = w.Write([]byte(existingBody))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL+"/cal", "user", "pass")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	// Simulate a Google-originated event (SEQUENCE:0, as Google emits).
+	// Server already has SEQUENCE:3 for this UID, so first PUT will 403.
+	googleBody := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Google Inc//Google Calendar 70.9054//EN\r\nBEGIN:VEVENT\r\nUID:" + existingUID + "\r\nSEQUENCE:0\r\nDTSTAMP:20260115T000000Z\r\nDTSTART:20260115T120000Z\r\nDTEND:20260115T130000Z\r\nSUMMARY:google version\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+	event := &Event{
+		UID:  existingUID,
+		Path: "/cal/" + existingUID + ".ics",
+		Data: googleBody,
+	}
+	if err := client.PutEvent(context.Background(), "/cal", event); err != nil {
+		t.Fatalf("PutEvent should have recovered via retry, got error: %v", err)
+	}
+	if putCount != 2 {
+		t.Errorf("expected 2 PUT attempts (first 403, retry 201), got %d", putCount)
+	}
+	// The final PUT body must carry SEQUENCE > 3 (existing).
+	retrySeq := extractSequenceFromICS(lastPutBody)
+	if retrySeq <= 3 {
+		t.Errorf("retry PUT body had SEQUENCE:%d, want > 3", retrySeq)
+	}
+}
+
+// TestPutEventSequenceRetry_NoExistingEvent covers the case where the 403
+// is real (not a SEQUENCE issue) — the GET of the existing event fails
+// with 404, so we cannot recover and the original error propagates.
+func TestPutEventSequenceRetry_NoExistingEvent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PUT":
+			w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?><D:error xmlns:D="DAV:">forbidden</D:error>`))
+		case "GET":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL+"/cal", "user", "pass")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	body := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:x\r\nSEQUENCE:0\r\nDTSTAMP:20260101T000000Z\r\nDTSTART:20260101T120000Z\r\nDTEND:20260101T130000Z\r\nSUMMARY:t\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+	err = client.PutEvent(context.Background(), "/cal", &Event{
+		UID:  "x",
+		Path: "/cal/x.ics",
+		Data: body,
+	})
+	if err == nil {
+		t.Fatal("expected error when retry GET returns 404 and PUT stays 403")
+	}
+	if !errors.Is(err, ErrConnectionFailed) {
+		t.Errorf("expected ErrConnectionFailed, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes #167 — every forward PUT from a Google source to a SOGo destination was returning 403 Forbidden `sequences don't match` because Google emits `SEQUENCE:0` while SOGo already had these UIDs at `SEQUENCE:1+` from prior writes. SOGo enforces RFC 5546 monotonicity and rejected every cycle forever.
- Root cause captured verbatim via tcpdump on the SOGo bridge (see #167).
- On 403, `PutEvent` now GETs the existing event, reads its SEQUENCE, rewrites the outbound payload to `max(ours, existing)+1`, and retries once. Legitimate ACL 403s still propagate because the retry either cannot read the existing event or still gets 403 after the bump.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -count=1 ./...` green (all 11 packages)
- [x] New `TestPutEventSequenceRetry` against `httptest.NewServer` exercises the real 403 → GET → bump → 201 retry flow
- [x] New `TestPutEventSequenceRetry_NoExistingEvent` verifies that a real (non-SEQUENCE) 403 with no readable existing object surfaces the original error rather than swallowing it
- [x] Helpers tested individually for CRLF/LF input, absent SEQUENCE, malformed SEQUENCE, and re-encoding without `VALUE=TEXT` parameter
- [ ] Live verification: after merge, trigger the Google→SOGo sync and confirm the `19 warnings` counter drops to `0` (or `3` read-only reverse-direction skips only)

## Out of scope (tracked separately)
Cross-source UID collision — both Google and iCloud sources are writing the same Apple-format UUIDs into the same SOGo calendar. Even with this fix, they will trade edits. Needs a source-precedence policy (iCloud authoritative for `*@me.com` UIDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)