### PR TITLE
fix: gate CONFLICT log on real both-sides-moved divergence

### DIFF
--- a/internal/caldav/etag_loop_test.go
+++ b/internal/caldav/etag_loop_test.go
@@ -246,3 +246,107 @@ func TestEtagHelpers_BothSidesUnchangedTable(t *testing.T) {
 		})
 	}
 }
+
+// -----------------------------------------------------------------------------
+// isRealConflictSourceWins / isRealConflictDestWins — #169 refinement
+// -----------------------------------------------------------------------------
+//
+// Prior to #169 the CONFLICT:source_wins log line fired on EVERY
+// successful source→dest update in two-way mode. For the Google→SOGo
+// sync that was landing via PR #168, that produced one CONFLICT
+// warning per event per cycle — 14 on the first post-fix cycle —
+// which drowned the UI warnings list in false-positive "conflicts"
+// that were in fact just routine source-to-dest propagation.
+//
+// These tests lock in the refined definition: a CONFLICT is logged
+// ONLY when both sides moved independently since the last sync,
+// detected by comparing the "other side's" current ETag against the
+// one recorded on the previous cycle.
+
+// TestIsRealConflictSourceWins_NilPrevReturnsFalse: no prior sync
+// record means we cannot tell whether dest moved independently.
+// Default to "not a conflict" to keep the warnings list clean.
+// First-time syncs never log CONFLICT.
+func TestIsRealConflictSourceWins_NilPrevReturnsFalse(t *testing.T) {
+	if isRealConflictSourceWins(nil, "any-dest-etag") {
+		t.Error("nil prev must not be treated as a real conflict")
+	}
+}
+
+// TestIsRealConflictSourceWins_EmptyStoredDestETagReturnsFalse: prev
+// exists but we never recorded a DestETag (e.g., first cycle after
+// create, or legacy record migration). Cannot compare — not a
+// conflict until next cycle has a reference point.
+func TestIsRealConflictSourceWins_EmptyStoredDestETagReturnsFalse(t *testing.T) {
+	prev := &db.SyncedEvent{SourceETag: "src-v1", DestETag: ""}
+	if isRealConflictSourceWins(prev, "dest-v1") {
+		t.Error("empty stored DestETag must not be treated as a real conflict")
+	}
+}
+
+// TestIsRealConflictSourceWins_DestUnchangedReturnsFalse: the steady-
+// state no-conflict case. Dest ETag matches what we recorded last
+// cycle, meaning dest did NOT move independently. Source moved
+// (we're only called from the forward-update branch), so this is a
+// routine propagation, not a conflict. This is the 99% case the
+// #169 refinement is targeting.
+func TestIsRealConflictSourceWins_DestUnchangedReturnsFalse(t *testing.T) {
+	prev := &db.SyncedEvent{SourceETag: "src-v1", DestETag: "dest-v1"}
+	if isRealConflictSourceWins(prev, "dest-v1") {
+		t.Error("unchanged dest ETag must not be treated as a conflict — it's a routine update")
+	}
+}
+
+// TestIsRealConflictSourceWins_DestMovedReturnsTrue: the real-
+// conflict case. Between our last sync and this one, dest's ETag
+// changed — someone edited it independently (SOGo web UI, iPhone,
+// email invite). We're now overwriting that edit per source_wins.
+// This is the scenario the CONFLICT log line is designed to surface.
+func TestIsRealConflictSourceWins_DestMovedReturnsTrue(t *testing.T) {
+	prev := &db.SyncedEvent{SourceETag: "src-v1", DestETag: "dest-v1"}
+	if !isRealConflictSourceWins(prev, "dest-v2-independently-edited") {
+		t.Error("changed dest ETag with a recorded prior value must be treated as a real conflict")
+	}
+}
+
+// TestIsRealConflictDestWins_NilPrevReturnsFalse: symmetric to the
+// source_wins nil-prev case. Reverse path is only reached when
+// shouldUpdateSourceFromDest returned true, which itself returns
+// false for nil prev, so in practice this branch won't be called
+// with nil — but the helper is defensive and returns false anyway.
+func TestIsRealConflictDestWins_NilPrevReturnsFalse(t *testing.T) {
+	if isRealConflictDestWins(nil, "any-source-etag") {
+		t.Error("nil prev must not be treated as a real conflict")
+	}
+}
+
+// TestIsRealConflictDestWins_EmptyStoredSourceETagReturnsFalse: prev
+// exists but we never recorded a SourceETag. Cannot compare — not a
+// conflict.
+func TestIsRealConflictDestWins_EmptyStoredSourceETagReturnsFalse(t *testing.T) {
+	prev := &db.SyncedEvent{SourceETag: "", DestETag: "dest-v1"}
+	if isRealConflictDestWins(prev, "src-v1") {
+		t.Error("empty stored SourceETag must not be treated as a real conflict")
+	}
+}
+
+// TestIsRealConflictDestWins_SourceUnchangedReturnsFalse: steady-
+// state reverse update. Dest moved (loop guard proved it), source
+// did not. Routine dest→source propagation, not a conflict.
+func TestIsRealConflictDestWins_SourceUnchangedReturnsFalse(t *testing.T) {
+	prev := &db.SyncedEvent{SourceETag: "src-v1", DestETag: "dest-v1"}
+	if isRealConflictDestWins(prev, "src-v1") {
+		t.Error("unchanged source ETag must not be treated as a conflict")
+	}
+}
+
+// TestIsRealConflictDestWins_SourceMovedReturnsTrue: real reverse-
+// direction conflict. Dest moved (loop guard), source ALSO moved
+// since last sync. Dest_wins policy overwrites source's independent
+// edit — surface as a conflict.
+func TestIsRealConflictDestWins_SourceMovedReturnsTrue(t *testing.T) {
+	prev := &db.SyncedEvent{SourceETag: "src-v1", DestETag: "dest-v1"}
+	if !isRealConflictDestWins(prev, "src-v2-independently-edited") {
+		t.Error("changed source ETag with a recorded prior value must be treated as a real conflict")
+	}
+}

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -221,6 +221,39 @@ func shouldUpdateSourceFromDest(destETag string, prev *db.SyncedEvent) bool {
 	return prev.DestETag != destETag
 }
 
+// isRealConflictSourceWins reports whether a successful source→dest
+// update should be surfaced to the UI as a conflict. A routine
+// propagation where only source moved is NOT a conflict — it's just
+// an update. A real conflict requires dest to also have moved
+// independently since our last recorded sync, detected by the
+// destination's current ETag differing from the one we stored on
+// the previous cycle.
+//
+// Returns false if prev is nil or prev.DestETag is empty — we cannot
+// tell whether dest moved if we don't have a reference point, so we
+// default to "not a conflict" to keep the warnings list clean. The
+// next cycle will have a recorded dest ETag to compare against.
+// (#136, refined in #169)
+func isRealConflictSourceWins(prev *db.SyncedEvent, currentDestETag string) bool {
+	if prev == nil || prev.DestETag == "" {
+		return false
+	}
+	return currentDestETag != prev.DestETag
+}
+
+// isRealConflictDestWins is the reverse-path mirror: a real conflict
+// requires source to also have moved since our last recorded sync.
+// Reaching the dest→source update branch already proves dest moved
+// (shouldUpdateSourceFromDest is the loop guard), so the only extra
+// check needed here is "did source also move independently".
+// (#136, refined in #169)
+func isRealConflictDestWins(prev *db.SyncedEvent, currentSourceETag string) bool {
+	if prev == nil || prev.SourceETag == "" {
+		return false
+	}
+	return currentSourceETag != prev.SourceETag
+}
+
 // planTwoWayDeletion determines which destination events should be
 // deleted because they were removed from source during a two-way sync.
 // It is the dest-deletion mirror of planOrphanDeletion (one-way) and
@@ -1844,10 +1877,27 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 				}
 			} else {
 				result.Updated++
-				// Log conflict resolution for the UI (#136).
-				// In two-way mode, pushing source → dest means source
-				// won this conflict (or it's source_wins default).
-				if syncDirection == db.SyncDirectionTwoWay {
+				// Log conflict resolution for the UI (#136, refined in #169).
+				//
+				// A routine source→dest update is NOT a conflict — it's
+				// just source moving forward while dest stayed put. A
+				// real conflict requires BOTH sides to have moved
+				// independently since our last recorded sync. We detect
+				// that by checking whether the current dest ETag differs
+				// from the one we stored at the previous cycle. If it
+				// does, dest was edited independently (by the SOGo web
+				// UI, an iPhone, an email invite, etc.) between cycles,
+				// and this PUT is overwriting that independent edit per
+				// the source_wins strategy — a real conflict worth
+				// surfacing to the user.
+				//
+				// Prior to #169 this log fired on every successful
+				// source→dest update in two-way mode, producing one
+				// CONFLICT line per event per cycle and drowning the
+				// warnings list in false-positive "conflicts" that were
+				// in fact just routine propagation.
+				if syncDirection == db.SyncDirectionTwoWay &&
+					isRealConflictSourceWins(previouslySyncedMap[sourceEvent.UID], destEvent.ETag) {
 					result.Warnings = append(result.Warnings, fmt.Sprintf(
 						"CONFLICT:{\"uid\":%q,\"winner\":\"source\",\"summary\":%q,\"strategy\":%q}",
 						sourceEvent.UID, sourceEvent.Summary, source.ConflictStrategy))
@@ -2042,11 +2092,20 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 					}
 				} else {
 					result.Updated++
-					// Log conflict resolution for the UI (#136).
-					// Pushing dest → source means dest won this conflict.
-					result.Warnings = append(result.Warnings, fmt.Sprintf(
-						"CONFLICT:{\"uid\":%q,\"winner\":\"dest\",\"summary\":%q,\"strategy\":%q}",
-						destEvent.UID, destEvent.Summary, source.ConflictStrategy))
+					// Log conflict resolution for the UI (#136, refined in #169).
+					// Symmetric to the forward path: only log a real
+					// conflict when BOTH sides moved since our last
+					// sync. Reaching this branch already proves dest
+					// moved (shouldUpdateSourceFromDest returned true
+					// at the loop guard above). Additionally require
+					// that source also moved since its previously
+					// tracked ETag — otherwise this is a routine
+					// dest→source update, not a conflict.
+					if isRealConflictDestWins(previouslySyncedMap[destEvent.UID], sourceEvent.ETag) {
+						result.Warnings = append(result.Warnings, fmt.Sprintf(
+							"CONFLICT:{\"uid\":%q,\"winner\":\"dest\",\"summary\":%q,\"strategy\":%q}",
+							destEvent.UID, destEvent.Summary, source.ConflictStrategy))
+					}
 					// Record the dest ETag we just propagated back
 					// to source so the next cycle can detect another
 					// dest-side change. We don't know the new source


### PR DESCRIPTION
## Summary
- Closes #169. After #168 landed and cleared the 403s on William's Google→SOGo sync, the sync still rendered `partial` with 14 CONFLICT:source_wins warnings. Those were informational notices, not failures — the PUTs all succeeded.
- Root cause: the CONFLICT log fired on *every* successful source→dest UPDATE in two-way mode, treating routine source-moved-forward propagation as a conflict.
- Fix: extract `isRealConflictSourceWins` / `isRealConflictDestWins` helpers that gate the CONFLICT log on the "other side" having actually moved since the last recorded sync. First-time syncs and routine updates no longer emit CONFLICT.

## Expected impact
- Next Google→SOGo cycle: warnings drop from 14 to 0 in steady state (all UIDs now have recorded DestETags matching current dest)
- CONFLICT only fires when both sides genuinely edited the same event between sync cycles — the case the log was designed for

## Test plan
- [x] `go build ./...` clean
- [x] `go test -count=1 ./...` green (all 11 packages)
- [x] 8 new pure-function tests covering nil-prev, empty-ETag, unchanged-other-side, and real-conflict cases for both source_wins and dest_wins
- [ ] Live verification: trigger Google→SOGo sync after deploy, confirm the 14 CONFLICT warnings drop to 0 in steady state

🤖 Generated with [Claude Code](https://claude.com/claude-code)