### PR TITLE
fix: gate two-way deletions on observed other-side ETag

### DIFF
--- a/internal/caldav/source_deletion_test.go
+++ b/internal/caldav/source_deletion_test.go
@@ -291,3 +291,58 @@ func TestPlanTwoWaySourceDeletion_SymmetricWithDestDeletion(t *testing.T) {
 		})
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Rule 4 (source direction): prev.DestETag must be non-empty to qualify as
+// a source-deletion candidate. Symmetric to the planTwoWayDeletion gate
+// added in #171.
+// -----------------------------------------------------------------------------
+
+// TestPlanTwoWaySourceDeletion_ForwardCreateOnlyPriorIsSkipped locks
+// in the symmetric source-side gate. A synced_events row with
+// SourceETag set but empty DestETag represents "forward-create wrote
+// this UID to dest but we never observed it coming back on the next
+// cycle's PROPFIND." Without a confirmed DestETag, the source side
+// of this sync has no authority to propagate a delete back to source
+// just because dest no longer returns the UID.
+//
+// Without this gate, a flaky dest PROPFIND response that dropped
+// specific UIDs would cause us to delete them from source on the
+// next cycle — a different flavor of the #171 fight loop but in
+// the reverse direction.
+func TestPlanTwoWaySourceDeletion_ForwardCreateOnlyPriorIsSkipped(t *testing.T) {
+	source := newEventMap("a", "b", "fc1", "fc2") // all four still on source
+	dest := newEventMap("a", "b")                 // "fc1" and "fc2" missing from dest
+	prior := newPriorMap("a", "b")
+	fc := newPriorMapForwardCreateOnly("fc1", "fc2")
+	for k, v := range fc {
+		prior[k] = v
+	}
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("no guard should fire; got warning: %q", warning)
+	}
+	if len(toDelete) != 0 {
+		t.Errorf("forward-create-only priors must NOT be source-delete candidates; got %v - this is the symmetric #171 regression",
+			toDelete)
+	}
+}
+
+// TestPlanTwoWaySourceDeletion_ConfirmedDestETagStillDeletes: the
+// over-blocking sanity check for the source direction.
+func TestPlanTwoWaySourceDeletion_ConfirmedDestETagStillDeletes(t *testing.T) {
+	source := newEventMap("a", "b", "c") // all three still on source
+	dest := newEventMap("a", "b")        // "c" deleted from dest
+	prior := newPriorMap("a", "b", "c")  // all three have confirmed both ETags
+
+	toDelete, warning := planTwoWaySourceDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("no guard should fire; got: %q", warning)
+	}
+	if len(toDelete) != 1 || toDelete[0] != "c" {
+		t.Errorf("expected ['c'] (confirmed dest deletion), got %v", toDelete)
+	}
+}

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -311,11 +311,23 @@ func planTwoWayDeletion(
 	}
 	// Build candidate list: previously-synced UIDs that no longer
 	// exist on source but still exist on destination.
+	//
+	// Rule 4 (#171): require prev.SourceETag != "" on the candidate.
+	// A synced_events row with an empty SourceETag means "we wrote a
+	// tracking entry but never observed this UID on the source side"
+	// — the exact shape reverse-create leaves behind when the PUT
+	// "succeeded" but the source server didn't persist it in a way
+	// we can read back (e.g., Google CalDAV silently dropping
+	// non-conforming writes). Treating that row as evidence of
+	// source ownership then fires a spurious delete-from-dest every
+	// cycle, which is the fight loop that chewed up William's
+	// Google→SOGo sync. Without a confirmed SourceETag, this source
+	// has no authority to propagate a delete for this UID.
 	candidates := make([]string, 0)
-	for uid := range previouslySyncedMap {
+	for uid, prev := range previouslySyncedMap {
 		_, existsOnSource := sourceEventMap[uid]
 		_, existsOnDest := destEventMap[uid]
-		if !existsOnSource && existsOnDest {
+		if !existsOnSource && existsOnDest && prev.SourceETag != "" {
 			candidates = append(candidates, uid)
 		}
 	}
@@ -396,11 +408,19 @@ func planTwoWaySourceDeletion(
 	}
 	// Build candidate list: previously-synced UIDs that still exist
 	// on source but no longer exist on destination.
+	//
+	// Rule 4 (#171): require prev.DestETag != "" on the candidate —
+	// symmetric to the gate in planTwoWayDeletion. A synced_events
+	// row with an empty DestETag means "we wrote a tracking entry
+	// but never observed this UID on the destination side." Without
+	// a confirmed DestETag we cannot claim this source ever owned
+	// the dest copy, so we have no authority to propagate a delete
+	// back to source just because dest no longer returns the UID.
 	candidates := make([]string, 0)
-	for uid := range previouslySyncedMap {
+	for uid, prev := range previouslySyncedMap {
 		_, existsOnSource := sourceEventMap[uid]
 		_, existsOnDest := destEventMap[uid]
-		if existsOnSource && !existsOnDest {
+		if existsOnSource && !existsOnDest && prev.DestETag != "" {
 			candidates = append(candidates, uid)
 		}
 	}

--- a/internal/caldav/two_way_deletion_test.go
+++ b/internal/caldav/two_way_deletion_test.go
@@ -31,10 +31,61 @@ import (
 // Helpers
 // -----------------------------------------------------------------------------
 
+// newPriorMap builds a map of realistic steady-state synced_events
+// rows — both SourceETag and DestETag populated. This matches what
+// the upsert path writes after a forward-created (or forward-updated)
+// event has completed one full sync cycle. The deletion-planning
+// helpers (#171) require a non-empty "other side" ETag to classify
+// a UID as a deletion candidate, so tests that want deletion
+// behavior MUST start from a prior map with both ETags set.
+//
+// For the bug scenario where a reverse-create wrote a tracking row
+// with only DestETag (because the source PUT returned no ETag to
+// read), use newPriorMapReverseCreateOnly.
 func newPriorMap(uids ...string) map[string]*db.SyncedEvent {
 	m := make(map[string]*db.SyncedEvent, len(uids))
 	for _, uid := range uids {
-		m[uid] = &db.SyncedEvent{EventUID: uid}
+		m[uid] = &db.SyncedEvent{
+			EventUID:   uid,
+			SourceETag: "src-" + uid,
+			DestETag:   "dest-" + uid,
+		}
+	}
+	return m
+}
+
+// newPriorMapReverseCreateOnly builds rows that represent a
+// reverse-create whose source-side landing was never verified — only
+// DestETag is set, SourceETag is empty. This is the exact shape of
+// the synced_events rows that triggered the Google→SOGo fight loop
+// in #171: Google's reaper saw these as "in prior map, not on source,
+// on dest → delete" and deleted iCloud-origin events from SOGo every
+// cycle, which iCloud then recreated.
+func newPriorMapReverseCreateOnly(uids ...string) map[string]*db.SyncedEvent {
+	m := make(map[string]*db.SyncedEvent, len(uids))
+	for _, uid := range uids {
+		m[uid] = &db.SyncedEvent{
+			EventUID: uid,
+			DestETag: "dest-" + uid,
+			// SourceETag intentionally empty
+		}
+	}
+	return m
+}
+
+// newPriorMapForwardCreateOnly is the symmetric shape for the other
+// deletion direction: SourceETag set, DestETag empty. Would be the
+// output of a forward-create whose dest ETag was never observed
+// (PutEvent does not return dest ETag, and we cannot read it back
+// before cycle 2). Used by planTwoWaySourceDeletion tests.
+func newPriorMapForwardCreateOnly(uids ...string) map[string]*db.SyncedEvent {
+	m := make(map[string]*db.SyncedEvent, len(uids))
+	for _, uid := range uids {
+		m[uid] = &db.SyncedEvent{
+			EventUID:   uid,
+			SourceETag: "src-" + uid,
+			// DestETag intentionally empty
+		}
 	}
 	return m
 }
@@ -332,4 +383,88 @@ func contains(haystack, needle string) bool {
 		}
 	}
 	return false
+}
+
+// -----------------------------------------------------------------------------
+// Rule 4: prev.SourceETag must be non-empty to qualify as a delete candidate
+// (#171 — the Google→SOGo fight-loop fix)
+// -----------------------------------------------------------------------------
+
+// TestPlanTwoWayDeletion_ReverseCreateOnlyPriorIsSkipped is the
+// direct regression test for the fight loop in #171.
+//
+// Setup: two UIDs, both with only DestETag recorded (reverse-create
+// shape — we wrote a tracking row when the source PUT returned 200,
+// but never observed the source side of this UID). Both are missing
+// from source now and still present on dest. Without the gate, the
+// old code classified these as "deleted from source, propagate to
+// dest," which fired a DELETE to SOGo. iCloud's next cycle then
+// recreated them in SOGo. Repeat every ~15 minutes forever.
+//
+// With the gate, prev.SourceETag == "" disqualifies them from the
+// candidate list. Dest keeps the events. iCloud remains the
+// authoritative writer. No fight loop.
+func TestPlanTwoWayDeletion_ReverseCreateOnlyPriorIsSkipped(t *testing.T) {
+	source := newEventMap("kept-by-other-source-1", "kept-by-other-source-2")
+	// Source does NOT have the two reverse-created UIDs.
+	dest := newEventMap("kept-by-other-source-1", "kept-by-other-source-2", "icloud-uid-a", "icloud-uid-b")
+	// Prior map has realistic rows for the two source-owned UIDs and
+	// reverse-create-only rows for the two iCloud-origin UIDs.
+	prior := newPriorMap("kept-by-other-source-1", "kept-by-other-source-2")
+	rc := newPriorMapReverseCreateOnly("icloud-uid-a", "icloud-uid-b")
+	for k, v := range rc {
+		prior[k] = v
+	}
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("no guard should fire in this scenario; got warning: %q", warning)
+	}
+	if len(toDelete) != 0 {
+		t.Errorf("reverse-create-only priors must NOT be delete candidates; got %d candidates: %v - this is the #171 regression",
+			len(toDelete), toDelete)
+	}
+}
+
+// TestPlanTwoWayDeletion_ConfirmedSourceETagStillDeletes verifies
+// that the gate does not over-block — legitimate source-deletions
+// (prior rows with confirmed SourceETag) still get propagated to
+// dest as before.
+func TestPlanTwoWayDeletion_ConfirmedSourceETagStillDeletes(t *testing.T) {
+	source := newEventMap("a", "b") // "c" was deleted from source
+	dest := newEventMap("a", "b", "c")
+	prior := newPriorMap("a", "b", "c") // all three have both ETags
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("no guard should fire; got: %q", warning)
+	}
+	if len(toDelete) != 1 || toDelete[0] != "c" {
+		t.Errorf("expected ['c'] as delete candidate (confirmed source deletion), got %v", toDelete)
+	}
+}
+
+// TestPlanTwoWayDeletion_MixedPriorsDeletesOnlyConfirmed exercises
+// the fix in the realistic scenario where a single cycle sees both
+// legitimate source-deletions AND reverse-create-only tracking
+// rows. Only the former should land in the delete list.
+func TestPlanTwoWayDeletion_MixedPriorsDeletesOnlyConfirmed(t *testing.T) {
+	source := newEventMap("a") // "b" deleted from source; reverse-create UIDs never in source
+	dest := newEventMap("a", "b", "rc1", "rc2")
+	prior := newPriorMap("a", "b")
+	rc := newPriorMapReverseCreateOnly("rc1", "rc2")
+	for k, v := range rc {
+		prior[k] = v
+	}
+
+	toDelete, warning := planTwoWayDeletion(source, dest, prior, 0.5)
+
+	if warning != "" {
+		t.Errorf("no guard should fire; got: %q", warning)
+	}
+	if len(toDelete) != 1 || toDelete[0] != "b" {
+		t.Errorf("expected only ['b'] (confirmed source deletion) — 'rc1' and 'rc2' must be gated out; got %v", toDelete)
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes #171 — after #168 and #170 cleared the 403s and the false-positive CONFLICTs, a stable 6-UID delete/recreate fight loop remained between William's Google and iCloud syncs into SOGo. Every Google cycle deleted 6 iCloud-origin events from SOGo; every iCloud cycle put them back.
- Root cause: reverse-create PUTs to Google returned 200 but silently didn't persist, leaving `synced_events` rows with `dest_etag` populated and `source_etag` empty. The deletion planner then treated those ghost rows as authority to delete iCloud-origin events from SOGo.
- Fix: gate both deletion helpers on a confirmed ETag from the "other side" — proof this source actually observed the event on the side it's treating as authoritative for the delete decision. Same philosophy as `shouldUpdateDestFromSource`.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -count=1 ./...` green (all 11 packages)
- [x] 5 new tests cover both directions (bug regression + over-block sanity checks)
- [x] Existing tests pass after `newPriorMap` fixture was updated to match realistic post-cycle-1 state with both ETags set
- [ ] Live verification: after deploy, next Google cycle shows `0 created, 0 updated, 0 deleted` — oscillation eliminated, no more churn between Google and iCloud syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)