### PR TITLE
fix: fall back from HEAD to GET on 403 in ICS TestConnection

### DIFF
--- a/internal/caldav/ics_client.go
+++ b/internal/caldav/ics_client.go
@@ -278,8 +278,11 @@ func (c *ICSClient) TestConnection(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 
-	// Some servers don't support HEAD, fall back to GET
-	if resp.StatusCode == http.StatusMethodNotAllowed {
+	// Some servers don't support HEAD, fall back to GET. 405 is the
+	// strict-correct response, but presigned URLs (e.g. Gusto → S3,
+	// where the redirect target is signed only for GET) and some CDNs
+	// reject HEAD with 403 instead — fall back in both cases.
+	if resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusForbidden {
 		req2, err := http.NewRequestWithContext(ctx, http.MethodGet, c.feedURL, nil)
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrConnectionFailed, err)


### PR DESCRIPTION
## Summary
- ICS `TestConnection` only fell back from HEAD to GET on 405. Feeds that 302-redirect to presigned URLs signed only for GET (e.g. Gusto → S3) return 403 on HEAD, so source-add fails at the connection-test step even though the actual sync (which uses GET) works.
- Treat 403 the same as 405 for the HEAD→GET fallback in `internal/caldav/ics_client.go`.

## Test plan
- [ ] Add a Gusto ICS feed via the UI — connection test should pass.
- [ ] Existing 405-based fallback paths still work.
- [ ] Real 403s on the GET fallback still surface as connection errors (the GET itself returns the truthful status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)