### PR TITLE
feat: per-source "Ignore alarms" toggle + strip malformed VALARMs

### DIFF
--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -49,6 +49,9 @@ type PendingGoogleSource struct {
 	// The callback decrypts it just long enough to call cfg.Exchange,
 	// then re-encrypts it for storage on the Source row. (#79)
 	GoogleClientSecretEnc string `json:"google_client_secret_enc"`
+	// StripAlarms is the per-source "Ignore alarms" flag; carried
+	// through OAuth so the callback writes it onto the created source.
+	StripAlarms bool `json:"strip_alarms"`
 }
 
 var (

--- a/internal/caldav/alarms.go
+++ b/internal/caldav/alarms.go
@@ -1,0 +1,83 @@
+package caldav
+
+import "strings"
+
+// sanitizeAlarms walks the iCalendar text and removes VALARM blocks per the
+// requested policy. Two cases:
+//
+//   - stripAll = true: remove every VALARM block. The user has set the
+//     "Ignore alarms" flag on the source — typically for subscribed feeds
+//     (Gusto payroll reminders, billing deadlines, sports schedules) where
+//     the alarms are noise on the destination calendar.
+//   - stripAll = false: remove only malformed VALARM blocks (those missing
+//     the required TRIGGER property). RFC 5545 §3.6.6 mandates TRIGGER on
+//     every VALARM. Some publish feeds (notably Gusto) emit alarms without
+//     it, and RFC-strict CalDAV servers (notably SOGo) reject the entire
+//     calendar object with 501 Not Implemented when they see one. Stripping
+//     just the broken alarm preserves the surrounding VEVENT instead of
+//     dropping the whole event.
+//
+// Operates on the raw iCalendar text rather than the parsed go-ical tree
+// because string-level filtering preserves the source server's exact
+// formatting (line folding, property ordering, parameter quoting) for
+// everything outside the VALARM blocks we drop. Re-encoding through
+// go-ical can subtly reformat surrounding properties in ways some servers
+// care about.
+func sanitizeAlarms(data string, stripAll bool) string {
+	if data == "" || !strings.Contains(data, "BEGIN:VALARM") {
+		return data
+	}
+
+	// Mirror the input's line ending so the output matches byte-for-byte
+	// outside the VALARM blocks. iCalendar mandates CRLF, but inputs from
+	// some sources arrive LF-only.
+	lineEnd := "\n"
+	if strings.Contains(data, "\r\n") {
+		lineEnd = "\r\n"
+	}
+	lines := strings.Split(data, lineEnd)
+
+	out := make([]string, 0, len(lines))
+	var alarmBuf []string
+	inAlarm := false
+	hasTrigger := false
+
+	for _, line := range lines {
+		if !inAlarm {
+			if strings.HasPrefix(line, "BEGIN:VALARM") {
+				inAlarm = true
+				hasTrigger = false
+				alarmBuf = alarmBuf[:0]
+				alarmBuf = append(alarmBuf, line)
+				continue
+			}
+			out = append(out, line)
+			continue
+		}
+
+		alarmBuf = append(alarmBuf, line)
+		// Property names are uppercase per RFC 5545. Accept TRIGGER: (no
+		// parameters) and TRIGGER; (with parameters like RELATED=START).
+		if strings.HasPrefix(line, "TRIGGER:") || strings.HasPrefix(line, "TRIGGER;") {
+			hasTrigger = true
+		}
+		if strings.HasPrefix(line, "END:VALARM") {
+			inAlarm = false
+			drop := stripAll || !hasTrigger
+			if !drop {
+				out = append(out, alarmBuf...)
+			}
+			alarmBuf = alarmBuf[:0]
+		}
+	}
+
+	// Defensive: an unterminated VALARM at EOF means the input was truncated.
+	// Preserve the partial buffer rather than silently dropping data — the
+	// destination will reject it for a different reason and surface that to
+	// the user, which is more honest than disappearing the event.
+	if inAlarm {
+		out = append(out, alarmBuf...)
+	}
+
+	return strings.Join(out, lineEnd)
+}

--- a/internal/caldav/alarms_test.go
+++ b/internal/caldav/alarms_test.go
@@ -1,0 +1,128 @@
+package caldav
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeAlarms_NoAlarmsPassthrough(t *testing.T) {
+	in := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:abc\r\nSUMMARY:Test\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+	if got := sanitizeAlarms(in, false); got != in {
+		t.Errorf("expected passthrough; got diff:\nin=%q\nout=%q", in, got)
+	}
+	if got := sanitizeAlarms(in, true); got != in {
+		t.Errorf("expected passthrough with stripAll=true too; got diff")
+	}
+}
+
+func TestSanitizeAlarms_StripsMalformedAlarmKeepsValid(t *testing.T) {
+	// VEVENT with one well-formed VALARM (has TRIGGER) and one malformed
+	// VALARM (no TRIGGER, the Gusto-style bug).
+	in := strings.Join([]string{
+		"BEGIN:VCALENDAR",
+		"VERSION:2.0",
+		"BEGIN:VEVENT",
+		"UID:abc",
+		"SUMMARY:Test",
+		"BEGIN:VALARM",
+		"ACTION:DISPLAY",
+		"DESCRIPTION:Bad alarm without TRIGGER",
+		"END:VALARM",
+		"BEGIN:VALARM",
+		"ACTION:DISPLAY",
+		"TRIGGER:-PT15M",
+		"DESCRIPTION:Good alarm with TRIGGER",
+		"END:VALARM",
+		"END:VEVENT",
+		"END:VCALENDAR",
+		"",
+	}, "\r\n")
+
+	got := sanitizeAlarms(in, false)
+	if strings.Contains(got, "Bad alarm without TRIGGER") {
+		t.Errorf("malformed alarm was not stripped:\n%s", got)
+	}
+	if !strings.Contains(got, "Good alarm with TRIGGER") {
+		t.Errorf("well-formed alarm was incorrectly stripped:\n%s", got)
+	}
+	if !strings.Contains(got, "UID:abc") || !strings.Contains(got, "SUMMARY:Test") {
+		t.Errorf("VEVENT body was corrupted:\n%s", got)
+	}
+}
+
+func TestSanitizeAlarms_StripAllRemovesEverything(t *testing.T) {
+	in := strings.Join([]string{
+		"BEGIN:VCALENDAR",
+		"BEGIN:VEVENT",
+		"UID:abc",
+		"BEGIN:VALARM",
+		"ACTION:DISPLAY",
+		"TRIGGER:-PT15M",
+		"DESCRIPTION:Even valid alarm should be stripped",
+		"END:VALARM",
+		"END:VEVENT",
+		"END:VCALENDAR",
+		"",
+	}, "\r\n")
+
+	got := sanitizeAlarms(in, true)
+	if strings.Contains(got, "VALARM") || strings.Contains(got, "Even valid alarm") {
+		t.Errorf("stripAll=true should remove every VALARM:\n%s", got)
+	}
+	if !strings.Contains(got, "UID:abc") {
+		t.Errorf("VEVENT body was corrupted:\n%s", got)
+	}
+}
+
+func TestSanitizeAlarms_TriggerWithParameters(t *testing.T) {
+	// TRIGGER;RELATED=END:-PT5M is valid per RFC 5545 and must NOT be
+	// treated as malformed even when stripAll=false.
+	in := strings.Join([]string{
+		"BEGIN:VEVENT",
+		"BEGIN:VALARM",
+		"ACTION:DISPLAY",
+		"TRIGGER;RELATED=END:-PT5M",
+		"END:VALARM",
+		"END:VEVENT",
+		"",
+	}, "\r\n")
+
+	got := sanitizeAlarms(in, false)
+	if !strings.Contains(got, "TRIGGER;RELATED=END:-PT5M") {
+		t.Errorf("alarm with parameterized TRIGGER was incorrectly stripped:\n%s", got)
+	}
+}
+
+func TestSanitizeAlarms_LFOnlyLineEndings(t *testing.T) {
+	// Some sources hand us LF-only iCalendar text. We must preserve the
+	// input's line ending (not silently convert to CRLF) so the output
+	// matches byte-for-byte outside the dropped alarms.
+	in := strings.Join([]string{
+		"BEGIN:VEVENT",
+		"UID:lf-test",
+		"BEGIN:VALARM",
+		"ACTION:DISPLAY",
+		"DESCRIPTION:malformed",
+		"END:VALARM",
+		"END:VEVENT",
+		"",
+	}, "\n")
+
+	got := sanitizeAlarms(in, false)
+	if strings.Contains(got, "\r\n") {
+		t.Errorf("LF-only input should produce LF-only output; got CRLF in:\n%q", got)
+	}
+	if strings.Contains(got, "VALARM") {
+		t.Errorf("malformed alarm not stripped:\n%s", got)
+	}
+}
+
+func TestSanitizeAlarms_EmptyAndAlarmless(t *testing.T) {
+	if got := sanitizeAlarms("", false); got != "" {
+		t.Errorf("empty input should yield empty output, got %q", got)
+	}
+	noAlarm := "BEGIN:VEVENT\r\nUID:x\r\nEND:VEVENT\r\n"
+	if got := sanitizeAlarms(noAlarm, true); got != noAlarm {
+		t.Errorf("input without VALARM should be returned unchanged")
+	}
+}

--- a/internal/caldav/sync.go
+++ b/internal/caldav/sync.go
@@ -1538,6 +1538,17 @@ func (se *SyncEngine) syncEventsToDestination(ctx context.Context, source *db.So
 		Warnings: make([]string, 0),
 	}
 
+	// Sanitize VALARM blocks before comparison/PUT. Always strip malformed
+	// alarms (missing the RFC-required TRIGGER) so RFC-strict destinations
+	// like SOGo don't 501 the whole calendar object. When the user has
+	// flipped "Ignore alarms" for this source, strip every VALARM.
+	for i := range sourceEvents {
+		if sourceEvents[i].Data == "" {
+			continue
+		}
+		sourceEvents[i].Data = sanitizeAlarms(sourceEvents[i].Data, source.StripAlarms)
+	}
+
 	// Helper to update activity tracker with current progress
 	updateProgress := func() {
 		se.tracker.UpdateProgress(source.ID, result.Created, result.Updated, result.Deleted, result.Skipped, result.EventsProcessed)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -284,6 +284,16 @@ func (db *DB) migrate() error {
 			FOREIGN KEY (source_id) REFERENCES sources(id) ON DELETE CASCADE
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_destinations_source_id ON destinations(source_id)`,
+
+		// Strip-alarms toggle. When true, the sync engine removes every
+		// VALARM block from this source's events before writing them to
+		// the destination. Useful for subscribed publish feeds (Gusto
+		// payroll reminders, billing deadlines, etc.) where the alarms
+		// would surface as notifications on the destination calendar.
+		// Malformed VALARMs (no TRIGGER per RFC 5545 §3.6.6) are always
+		// stripped regardless of this flag — they cause RFC-strict
+		// servers like SOGo to 501 the whole calendar object.
+		`ALTER TABLE sources ADD COLUMN strip_alarms INTEGER NOT NULL DEFAULT 0`,
 	}
 
 	for _, migration := range migrations {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -213,6 +213,12 @@ type Source struct {
 	// polling interval in seconds (0 = use source.SyncInterval default).
 	LastContentHash  string `json:"-"`
 	AdaptiveInterval int    `json:"adaptive_interval,omitempty"`
+	// StripAlarms removes every VALARM block from this source's events
+	// before writing them to the destination. Useful for subscribed
+	// publish feeds where the source-side alarms shouldn't fire on the
+	// destination calendar. Malformed VALARMs (missing TRIGGER) are
+	// always stripped regardless of this flag.
+	StripAlarms bool `json:"strip_alarms"`
 }
 
 // SyncState represents the synchronization state for a calendar.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -125,8 +125,8 @@ func (db *DB) CreateSource(source *Source) error {
 		id, user_id, name, source_type, source_url, source_username, source_password,
 		dest_url, dest_username, dest_password, sync_interval, sync_days_past, sync_direction, conflict_strategy,
 		selected_calendars, enabled, last_sync_status, oauth_refresh_token,
-		google_client_id, google_client_secret, created_at, updated_at
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		google_client_id, google_client_secret, strip_alarms, created_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	_, err := db.conn.Exec(query,
 		source.ID, source.UserID, source.Name, source.SourceType,
@@ -135,7 +135,7 @@ func (db *DB) CreateSource(source *Source) error {
 		source.SyncInterval, source.SyncDaysPast, source.SyncDirection, source.ConflictStrategy,
 		selectedCalendarsJSON, source.Enabled,
 		source.LastSyncStatus, oauthRefreshToken,
-		googleClientID, googleClientSecret,
+		googleClientID, googleClientSecret, source.StripAlarms,
 		source.CreatedAt, source.UpdatedAt,
 	)
 	if err != nil {
@@ -153,7 +153,7 @@ func (db *DB) CreateSource(source *Source) error {
 const sourceSelectColumns = `id, user_id, name, source_type, source_url, source_username, source_password,
 	dest_url, dest_username, dest_password, sync_interval, sync_days_past, sync_direction, conflict_strategy,
 	selected_calendars, enabled, last_sync_at, last_sync_status, last_sync_message, created_at, updated_at,
-	oauth_refresh_token, google_client_id, google_client_secret`
+	oauth_refresh_token, google_client_id, google_client_secret, strip_alarms`
 
 // GetSourceByID returns a source by its ID.
 func (db *DB) GetSourceByID(id string) (*Source, error) {
@@ -276,6 +276,7 @@ func (db *DB) UpdateSource(source *Source) error {
 		oauth_refresh_token = COALESCE(?, oauth_refresh_token),
 		google_client_id = COALESCE(?, google_client_id),
 		google_client_secret = COALESCE(?, google_client_secret),
+		strip_alarms = ?,
 		updated_at = ?
 		WHERE id = ?`
 
@@ -284,6 +285,7 @@ func (db *DB) UpdateSource(source *Source) error {
 		source.DestURL, source.DestUsername, source.DestPassword, source.SyncInterval, source.SyncDaysPast,
 		source.SyncDirection, source.ConflictStrategy, selectedCalendarsJSON, source.Enabled,
 		oauthRefreshToken, googleClientID, googleClientSecret,
+		source.StripAlarms,
 		source.UpdatedAt, source.ID,
 	)
 	if err != nil {
@@ -762,7 +764,7 @@ func scanSource(row *sql.Row) (*Source, error) {
 		&selectedCalendarsJSON, &source.Enabled,
 		&lastSyncAt, &source.LastSyncStatus, &lastSyncMessage,
 		&source.CreatedAt, &source.UpdatedAt,
-		&oauthRefreshToken, &googleClientID, &googleClientSecret,
+		&oauthRefreshToken, &googleClientID, &googleClientSecret, &source.StripAlarms,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -816,7 +818,7 @@ func scanSourceFromRows(rows *sql.Rows) (*Source, error) {
 		&selectedCalendarsJSON, &source.Enabled,
 		&lastSyncAt, &source.LastSyncStatus, &lastSyncMessage,
 		&source.CreatedAt, &source.UpdatedAt,
-		&oauthRefreshToken, &googleClientID, &googleClientSecret,
+		&oauthRefreshToken, &googleClientID, &googleClientSecret, &source.StripAlarms,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan source: %w", err)

--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -113,6 +113,7 @@ type APISource struct {
 	ConflictStrategy  string              `json:"conflict_strategy"`
 	SelectedCalendars []APICalendarConfig `json:"selected_calendars"`
 	Enabled           bool                `json:"enabled"`
+	StripAlarms       bool                `json:"strip_alarms"`
 	SyncStatus        string              `json:"sync_status"`
 	LastSyncAt        *string             `json:"last_sync_at"`
 	NextSyncAt        *string             `json:"next_sync_at"`
@@ -226,6 +227,7 @@ func sourceToAPI(s *db.Source) *APISource {
 		ConflictStrategy:  string(s.ConflictStrategy),
 		SelectedCalendars: apiCalendars,
 		Enabled:           s.Enabled,
+		StripAlarms:       s.StripAlarms,
 		SyncStatus:        string(s.LastSyncStatus),
 		CreatedAt:         s.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:         s.UpdatedAt.Format(time.RFC3339),
@@ -698,6 +700,7 @@ type APICreateSourceRequest struct {
 	SyncDirection     string              `json:"sync_direction"`
 	ConflictStrategy  string              `json:"conflict_strategy"`
 	SelectedCalendars []APICalendarConfig `json:"selected_calendars"`
+	StripAlarms       bool                `json:"strip_alarms"`
 }
 
 // APICreateSource creates a new source.
@@ -822,6 +825,7 @@ func (h *Handlers) APICreateSource(c *gin.Context) {
 		ConflictStrategy:  db.ConflictStrategy(req.ConflictStrategy),
 		SelectedCalendars: dbCalendars,
 		Enabled:           true,
+		StripAlarms:       req.StripAlarms,
 	}
 
 	if err := h.db.CreateSource(source); err != nil {
@@ -849,6 +853,7 @@ type APIUpdateSourceRequest struct {
 	SyncDirection     string              `json:"sync_direction"`
 	ConflictStrategy  string              `json:"conflict_strategy"`
 	SelectedCalendars []APICalendarConfig `json:"selected_calendars"`
+	StripAlarms       bool                `json:"strip_alarms"`
 }
 
 // APIUpdateSource updates an existing source.
@@ -908,6 +913,7 @@ func (h *Handlers) APIUpdateSource(c *gin.Context) {
 	source.SyncDirection = db.SyncDirection(req.SyncDirection)
 	source.ConflictStrategy = db.ConflictStrategy(req.ConflictStrategy)
 	source.SelectedCalendars = dbCalendars
+	source.StripAlarms = req.StripAlarms
 	if req.SyncInterval > 0 {
 		source.SyncInterval = req.SyncInterval
 	}

--- a/internal/web/oauth_google.go
+++ b/internal/web/oauth_google.go
@@ -101,6 +101,7 @@ type APIPrepareGoogleSourceRequest struct {
 	DestPassword       string `json:"dest_password"`
 	GoogleClientID     string `json:"google_client_id"`
 	GoogleClientSecret string `json:"google_client_secret"`
+	StripAlarms        bool   `json:"strip_alarms"`
 }
 
 // APIPrepareGoogleSourceResponse tells the SPA where to send the user
@@ -236,6 +237,7 @@ func (h *Handlers) APIPrepareGoogleSource(c *gin.Context) {
 		DestPasswordEnc:       encDestPwd,
 		GoogleClientID:        req.GoogleClientID,
 		GoogleClientSecretEnc: encGoogleClientSecret,
+		StripAlarms:           req.StripAlarms,
 	}
 	if err := h.session.SetPendingGoogleSource(c.Writer, c.Request, pending); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save pending source"})
@@ -462,6 +464,7 @@ func (h *Handlers) GoogleOAuthCallback(c *gin.Context) {
 		SyncDirection:      syncDirection,
 		ConflictStrategy:   conflictStrategy,
 		Enabled:            true,
+		StripAlarms:        pending.StripAlarms,
 	}
 
 	if err := h.db.CreateSource(source); err != nil {

--- a/web/src/pages/SourceAdd.tsx
+++ b/web/src/pages/SourceAdd.tsx
@@ -43,6 +43,7 @@ export default function SourceAdd() {
     sync_direction: 'one_way',
     conflict_strategy: 'source_wins',
     selected_calendars: [],
+    strip_alarms: false,
     google_client_id: '',
     google_client_secret: '',
   });
@@ -119,11 +120,18 @@ export default function SourceAdd() {
   const isGoogleOAuth = form.source_type === 'google';
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value } = e.target;
+    const { name, value, type } = e.target;
+    const isCheckbox = type === 'checkbox';
+    const checked = isCheckbox ? (e.target as HTMLInputElement).checked : undefined;
     setForm((prev) => {
+      const nextValue: string | number | boolean = isCheckbox
+        ? Boolean(checked)
+        : (name === 'sync_interval' || name === 'sync_days_past')
+          ? parseInt(value)
+          : value;
       const updated = {
         ...prev,
-        [name]: (name === 'sync_interval' || name === 'sync_days_past') ? parseInt(value) : value,
+        [name]: nextValue,
       };
       // Force one-way + source_wins for ICS
       if (name === 'source_type' && value === 'ics') {
@@ -161,6 +169,7 @@ export default function SourceAdd() {
           dest_url: form.dest_url,
           dest_username: form.dest_username,
           dest_password: form.dest_password,
+          strip_alarms: form.strip_alarms,
           google_client_id: form.google_client_id,
           google_client_secret: form.google_client_secret,
         });
@@ -283,6 +292,24 @@ export default function SourceAdd() {
                       <option value="latest_wins">Newest wins</option>
                     </select>
                   </div>
+                </div>
+                <div className="flex items-start gap-2 pt-1">
+                  <input
+                    type="checkbox"
+                    name="strip_alarms"
+                    id="strip_alarms"
+                    checked={form.strip_alarms}
+                    onChange={handleChange}
+                    className="mt-0.5"
+                  />
+                  <label htmlFor="strip_alarms" className="text-sm text-gray-300 select-none cursor-pointer">
+                    Ignore alarms
+                    <span className="block text-xs text-gray-500">
+                      Strip VALARM blocks from this source's events before writing to the destination.
+                      Useful for subscribed feeds (payroll, billing, sports) where the source's alarms
+                      shouldn't fire on your calendar.
+                    </span>
+                  </label>
                 </div>
               </div>
 

--- a/web/src/pages/SourceEdit.tsx
+++ b/web/src/pages/SourceEdit.tsx
@@ -28,6 +28,7 @@ export default function SourceEdit() {
     sync_direction: 'one_way' as 'one_way' | 'two_way',
     conflict_strategy: 'source_wins',
     selected_calendars: [] as CalendarConfig[],
+    strip_alarms: false,
   });
 
   useEffect(() => {
@@ -54,6 +55,7 @@ export default function SourceEdit() {
         sync_direction: data.sync_direction || 'one_way',
         conflict_strategy: data.conflict_strategy,
         selected_calendars: data.selected_calendars || [],
+        strip_alarms: data.strip_alarms || false,
       });
     } catch (err) {
       setError('Failed to load source');
@@ -130,11 +132,18 @@ export default function SourceEdit() {
   const isICS = form.source_type === 'ics';
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value } = e.target;
+    const { name, value, type } = e.target;
+    const isCheckbox = type === 'checkbox';
+    const checked = isCheckbox ? (e.target as HTMLInputElement).checked : undefined;
     setForm((prev) => {
+      const nextValue: string | number | boolean = isCheckbox
+        ? Boolean(checked)
+        : (name === 'sync_interval' || name === 'sync_days_past')
+          ? parseInt(value)
+          : value;
       const updated = {
         ...prev,
-        [name]: (name === 'sync_interval' || name === 'sync_days_past') ? parseInt(value) : value,
+        [name]: nextValue,
       };
       if (name === 'source_type' && value === 'ics') {
         updated.sync_direction = 'one_way';
@@ -299,6 +308,24 @@ export default function SourceEdit() {
                   <option value="latest_wins">Newest wins</option>
                 </select>
               </div>
+            </div>
+            <div className="flex items-start gap-2 pt-1">
+              <input
+                type="checkbox"
+                name="strip_alarms"
+                id="strip_alarms"
+                checked={form.strip_alarms}
+                onChange={handleChange}
+                className="mt-0.5"
+              />
+              <label htmlFor="strip_alarms" className="text-sm text-gray-300 select-none cursor-pointer">
+                Ignore alarms
+                <span className="block text-xs text-gray-500">
+                  Strip VALARM blocks from this source's events before writing to the destination.
+                  Useful for subscribed feeds (payroll, billing, sports) where the source's alarms
+                  shouldn't fire on your calendar.
+                </span>
+              </label>
             </div>
           </div>
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -66,6 +66,7 @@ export interface PrepareGoogleSourceRequest {
   dest_url: string;
   dest_username: string;
   dest_password: string;
+  strip_alarms: boolean;
   // Per-source Google OAuth credentials (#79). The user provides
   // their own Google Cloud project client_id + client_secret instead
   // of relying on a global env-var configured value.

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -19,6 +19,7 @@ export interface Source {
   conflict_strategy: string;
   selected_calendars: CalendarConfig[];
   enabled: boolean;
+  strip_alarms: boolean;
   sync_status: string;
   last_sync_at: string | null;
   next_sync_at: string | null;
@@ -76,6 +77,7 @@ export interface SourceFormData {
   sync_direction: 'one_way' | 'two_way';
   conflict_strategy: string;
   selected_calendars: CalendarConfig[];
+  strip_alarms: boolean;
   // Per-source Google OAuth credentials (#79). Only populated when
   // source_type === 'google'. Empty for all other source types.
   google_client_id?: string;


### PR DESCRIPTION
## Summary

Adds a per-source **Ignore alarms** checkbox in the SourceAdd / SourceEdit forms. When enabled, every VALARM block on this source's events is stripped before the event is written to the destination. Useful for subscribed publish feeds (Gusto payroll reminders, billing deadlines, sports schedules, etc.) where the source's alarms would surface as notifications on the destination calendar.

Also fixes the underlying bug that prompted this: CalBridgeSync now **unconditionally** strips malformed VALARMs — those missing the RFC 5545 §3.6.6-required \`TRIGGER\` property — from every source. Gusto's payroll feed emits 52 such VALARMs, and SOGo (which is RFC-strict) correctly rejects each enclosing VEVENT with \`501 Not Implemented\`, blocking ~half of every Gusto sync. Stripping just the broken alarm preserves the surrounding event instead of losing it.

The sanitizer operates on the raw iCalendar text (not the parsed go-ical tree) so non-VALARM properties retain their exact source-server formatting — line folding, property ordering, parameter quoting — for everything outside the dropped alarms.

## Test plan
- [x] Unit tests in \`internal/caldav/alarms_test.go\` cover: passthrough, strip-malformed-keep-valid, strip-all, parameterized TRIGGER, LF-only line endings, empty input.
- [x] \`go build\`, \`go vet\`, full test suite, and \`npm run build\` all pass clean.
- [ ] After deploy: edit the existing Gusto source, leave \"Ignore alarms\" unchecked, run sync — the 52 \`501 Not Implemented\` warnings should be gone (those events now sync, malformed alarms silently dropped).
- [ ] Tick \"Ignore alarms\" on Gusto, save, run sync — all VALARMs stripped (no notifications on destination).
- [ ] Existing sources keep working untouched (DB migration adds column with default 0).

## Files
**Backend (Go)**
- \`internal/caldav/alarms.go\` (new) — sanitizer
- \`internal/caldav/alarms_test.go\` (new) — 6 unit tests
- \`internal/caldav/sync.go\` — invoke sanitizer at top of \`syncEventsToDestination\`
- \`internal/db/db.go\` — \`ALTER TABLE sources ADD COLUMN strip_alarms\`
- \`internal/db/models.go\` — \`Source.StripAlarms bool\`
- \`internal/db/queries.go\` — INSERT / UPDATE / SELECT / scan
- \`internal/web/api_handlers.go\` — \`APISource\`, create/update request bodies
- \`internal/web/oauth_google.go\` + \`internal/auth/session.go\` — plumb through OAuth flow

**Frontend (TypeScript / React)**
- \`web/src/types/index.ts\` — \`Source\`, \`SourceFormData\`
- \`web/src/services/api.ts\` — \`PrepareGoogleSourceRequest\`
- \`web/src/pages/SourceAdd.tsx\` + \`SourceEdit.tsx\` — form state, checkbox UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)